### PR TITLE
fix(applications): mark-not-job deletes Contact/Interview children before parent (#11)

### DIFF
--- a/backend/jobtracker/api/applications.py
+++ b/backend/jobtracker/api/applications.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import text
+from sqlalchemy import delete, text
 from sqlmodel import func, select
 
 from jobtracker.classifier import get_classifier
@@ -19,8 +19,10 @@ from jobtracker.database import get_session
 from jobtracker.database.models import (
     Application,
     ApplicationStatus,
+    Contact,
     Email,
     EmailCategory,
+    Interview,
 )
 from jobtracker.services.application_insights import (
     get_follow_up_reminders,
@@ -413,6 +415,15 @@ async def mark_application_not_job_posting(application_id: int):
                     application_id,
                     exc,
                 )
+
+        # Contacts and interviews require a non-null application_id, so remove
+        # them explicitly before deleting the parent application record.
+        await session.exec(
+            delete(Contact).where(Contact.application_id == application_id)
+        )
+        await session.exec(
+            delete(Interview).where(Interview.application_id == application_id)
+        )
 
         await session.delete(app)
         await session.commit()

--- a/backend/tests/test_api_phase5.py
+++ b/backend/tests/test_api_phase5.py
@@ -19,9 +19,14 @@ from jobtracker.database import get_session, init_db
 from jobtracker.database.models import (
     Application,
     ApplicationStatus,
+    Contact,
+    ContactRole,
     Email,
     EmailCategory,
     EmailSource,
+    Interview,
+    InterviewStatus,
+    InterviewType,
 )
 from jobtracker.main import app
 from jobtracker.tracking import get_application_linker
@@ -666,6 +671,87 @@ class TestApplicationDetailAndActions:
             assert email.application_id is None
             assert email.classified_as == EmailCategory.OTHER
             assert email.user_corrected is True
+
+    @pytest.mark.asyncio
+    async def test_mark_not_job_deletes_required_children_before_app_delete(
+        self,
+        test_client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        await _reset_analytics_tables()
+        now = datetime.utcnow()
+        from jobtracker.api import applications as applications_api
+
+        mock_classifier = SimpleNamespace(add_correction=AsyncMock())
+        monkeypatch.setattr(applications_api, "get_classifier", lambda: mock_classifier)
+
+        async with get_session() as session:
+            app_row = Application(
+                company="Signal Corp",
+                position="Platform Engineer",
+                status=ApplicationStatus.INTERVIEWING,
+                applied_date=date.today(),
+            )
+            session.add(app_row)
+            await session.commit()
+            await session.refresh(app_row)
+
+            email_row = Email(
+                application_id=app_row.id,
+                source_account=EmailSource.GMAIL,
+                message_id=f"<mark-not-job-child-{now.timestamp()}@test.com>",
+                received_at=now,
+                subject="Interview scheduling",
+                sender_email="recruiter@signalcorp.com",
+                classified_as=EmailCategory.INTERVIEW,
+                classification_confidence=0.89,
+            )
+            contact_row = Contact(
+                application_id=app_row.id,
+                name="Alex Recruiter",
+                email="alex@signalcorp.com",
+                role=ContactRole.RECRUITER,
+            )
+            interview_row = Interview(
+                application_id=app_row.id,
+                type=InterviewType.VIDEO,
+                scheduled_at=now + timedelta(days=2),
+                status=InterviewStatus.SCHEDULED,
+            )
+            session.add(email_row)
+            session.add(contact_row)
+            session.add(interview_row)
+            await session.commit()
+            await session.refresh(email_row)
+            email_id = email_row.id
+            app_id = app_row.id
+
+        response = await test_client.post(f"/applications/{app_id}/mark-not-job")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["emails_reclassified"] == 1
+
+        async with get_session() as session:
+            app_check = await session.exec(select(Application).where(Application.id == app_id))
+            assert app_check.first() is None
+
+            contact_check = await session.exec(
+                select(Contact).where(Contact.application_id == app_id)
+            )
+            assert contact_check.first() is None
+
+            interview_check = await session.exec(
+                select(Interview).where(Interview.application_id == app_id)
+            )
+            assert interview_check.first() is None
+
+            email_check = await session.exec(select(Email).where(Email.id == email_id))
+            row = email_check.first()
+            assert row is not None
+            email = row[0] if hasattr(row, "__getitem__") else row
+            assert email.application_id is None
+            assert email.classified_as == EmailCategory.OTHER
 
 
 class TestAnalyticsTrendsDeScoped:

--- a/docs/API_SPEC.md
+++ b/docs/API_SPEC.md
@@ -250,7 +250,11 @@ Transition status with payload:
 
 ### `POST /applications/{application_id}/mark-not-job`
 
-Reclassifies linked emails to `other`, unlinks them, deletes the application.
+Reclassifies linked emails to `other`, unlinks them (sets `application_id=NULL`),
+and deletes the application. Any `Contact` and `Interview` rows linked to the
+application are also deleted, because their `application_id` FK is `NOT NULL`
+(see issue #11). The linked emails themselves are retained with
+`classified_as=OTHER` and `user_corrected=True`.
 
 ### `GET /applications/link/preview/{email_id}`
 


### PR DESCRIPTION
Closes #11.

## Summary
- Marking an application "not a job" failed on any app with linked `Contact` or `Interview` rows because both child tables declare `application_id` as a NOT NULL FK on `applications.id`. The endpoint now explicitly deletes those child rows before `session.delete(app)` — matching the existing Email-unlink pattern.
- Adds a regression test covering Application + Email + Contact + Interview all present.
- Documents the child-row semantics in `docs/API_SPEC.md`.

## Per-file commit history (per CLAUDE.md rule)
1. `fix(applications): delete Contacts/Interviews before parent app delete` — `backend/jobtracker/api/applications.py`
2. `test(api-phase5): cover mark-not-job with Contact and Interview children` — `backend/tests/test_api_phase5.py`
3. `docs(api-spec): clarify mark-not-job deletes Contact/Interview children` — `docs/API_SPEC.md`

## Validation

**Automated — full backend suite (matches CI):**
```
$ .venv311/bin/pytest tests -q
============================= 151 passed in 17.55s =============================
```

Targeted:
```
$ .venv311/bin/pytest tests/test_api_phase5.py::TestApplicationDetailAndActions -q
tests/test_api_phase5.py ...                                             [100%]
============================== 3 passed in 0.69s ===============================
```

**Curl probe (local):** reproduce against a seeded row to follow up after merge — the endpoint is single-user local today, so the fixture-backed pytest is the authoritative repro. Will add a web-based curl/Playwright probe once the web UI lands (Track C C11).

**DB probe semantics:** the new test asserts, in-process:
```sql
SELECT COUNT(*) FROM applications WHERE id=<app_id>;  -- 0
SELECT COUNT(*) FROM contacts     WHERE application_id=<app_id>;  -- 0
SELECT COUNT(*) FROM interviews   WHERE application_id=<app_id>;  -- 0
SELECT application_id, classified_as FROM emails WHERE id=<email_id>;  -- (NULL, 'other')
```

## Test plan
- [x] Full backend pytest green locally (151 passed).
- [x] New `test_mark_not_job_deletes_required_children_before_app_delete` covers the regression.
- [ ] Backend CI green on this branch (wait on GH Actions).
- [ ] User-approved merge to `main` (no auto-merge — per project rule).

## Risks / notes
- Tactical Python-level delete (not DB-level `ON DELETE CASCADE`) to avoid a migration. Matches the existing Email-unlink pattern. Cascade can be introduced later as part of the Postgres migration (Track C C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)