### PR TITLE
feat(cloud): C1 — deployment toggle + cloud shim (main_cloud.py, api/index.py, vercel.json) (#14)

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,39 @@
+"""
+Vercel Python runtime entrypoint.
+
+Vercel's ``@vercel/python`` runtime detects an ASGI callable at
+``api/index.py`` and serves it directly. We force cloud mode at import
+time so the cloud variant of the FastAPI app (``main_cloud``) is built
+— NOT the desktop one in ``main.py``, which expects SQLite + Keychain
++ WebSockets.
+
+Every incoming request to the Vercel deployment is rewritten by
+``/vercel.json`` to ``api/index.py`` so FastAPI's internal router
+handles the path resolution.
+
+This file is intentionally tiny; all logic lives under
+``backend/jobtracker/``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Ensure the backend package is importable when Vercel builds from repo
+# root. Vercel's build step runs `pip install -r requirements.txt`
+# against the root requirements.txt, which does NOT include the local
+# `backend/` package — so we make the `backend/` path importable here.
+_backend_path = Path(__file__).resolve().parent.parent / "backend"
+if str(_backend_path) not in sys.path:
+    sys.path.insert(0, str(_backend_path))
+
+# Force cloud deployment mode before importing the FastAPI app. This
+# overrides any stray `JOBTRACKER_DEPLOYMENT=desktop` in the env so the
+# cloud app is always built under the serverless entrypoint.
+os.environ["JOBTRACKER_DEPLOYMENT"] = "cloud"
+
+from jobtracker.main_cloud import app  # noqa: E402
+
+__all__ = ["app"]

--- a/backend/jobtracker/config.py
+++ b/backend/jobtracker/config.py
@@ -24,10 +24,10 @@ Usage:
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import Field, computed_field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Field, computed_field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -210,7 +210,7 @@ class Settings(BaseSettings):
     # -------------------------------------------------------------------------
     # Cloud (Vercel + Supabase). Only consumed when deployment == "cloud".
     # -------------------------------------------------------------------------
-    cors_allowed_hosts: list[str] = Field(
+    cors_allowed_hosts: Annotated[list[str], NoDecode] = Field(
         default_factory=list,
         description=(
             "Extra hostnames permitted by CORS in cloud mode. Comma-separated "
@@ -238,6 +238,22 @@ class Settings(BaseSettings):
             "used by `POST /cron/sync` (C7) to reject unauthenticated cron calls."
         ),
     )
+
+    @field_validator("cors_allowed_hosts", mode="before")
+    @classmethod
+    def _split_cors_hosts(cls, value: Any) -> Any:
+        """Accept a comma-separated env var string for cors_allowed_hosts.
+
+        Vercel and most shells can only pass strings, so
+        `JOBTRACKER_CORS_ALLOWED_HOSTS='jobtracker.app,app.jobtracker.dev'`
+        should Just Work. A list/tuple is still accepted for programmatic use.
+        """
+
+        if value is None or value == "":
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return value
 
     def ensure_directories(self) -> None:
         """Create required directories if they don't exist."""

--- a/backend/jobtracker/config.py
+++ b/backend/jobtracker/config.py
@@ -57,6 +57,14 @@ class Settings(BaseSettings):
     # - test: in-memory SQLite DB for pytest (never touches real data)
     environment: Literal["development", "production", "test"] = "development"
 
+    # Deployment target. "desktop" keeps every existing assumption (SQLite,
+    # Keychain, WebSocket router, localhost CORS). "cloud" selects the
+    # Vercel-safe code paths (Postgres via DATABASE_URL, encrypted-column
+    # credentials, polling, env-driven CORS). Downstream issues wire the
+    # cloud paths in one at a time; this flag only gates which app builder
+    # is imported.
+    deployment: Literal["desktop", "cloud"] = "desktop"
+
     # -------------------------------------------------------------------------
     # API Server
     # -------------------------------------------------------------------------
@@ -198,6 +206,38 @@ class Settings(BaseSettings):
     # Keychain
     # -------------------------------------------------------------------------
     keychain_service: str = "jobtracker"
+
+    # -------------------------------------------------------------------------
+    # Cloud (Vercel + Supabase). Only consumed when deployment == "cloud".
+    # -------------------------------------------------------------------------
+    cors_allowed_hosts: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Extra hostnames permitted by CORS in cloud mode. Comma-separated "
+            "in the env var, for example "
+            "JOBTRACKER_CORS_ALLOWED_HOSTS='jobtracker.app,app.jobtracker.dev'. "
+            "Vercel preview URLs (*.vercel.app) are always allowed."
+        ),
+    )
+    supabase_jwt_secret: str | None = Field(
+        default=None,
+        description="Supabase JWT signing secret; required for cloud auth middleware (C3).",
+    )
+    secret_encryption_key: str | None = Field(
+        default=None,
+        description=(
+            "Fernet key (urlsafe base64, 32 bytes) used to encrypt user credentials "
+            "stored in the cloud `user_credentials` table (C4). Generate with "
+            "`python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"`."
+        ),
+    )
+    vercel_cron_secret: str | None = Field(
+        default=None,
+        description=(
+            "Shared secret Vercel Cron attaches via `x-vercel-cron-secret` header; "
+            "used by `POST /cron/sync` (C7) to reject unauthenticated cron calls."
+        ),
+    )
 
     def ensure_directories(self) -> None:
         """Create required directories if they don't exist."""

--- a/backend/jobtracker/main_cloud.py
+++ b/backend/jobtracker/main_cloud.py
@@ -1,0 +1,126 @@
+"""
+Cloud FastAPI Application Entry Point
+=====================================
+
+Builds the FastAPI `app` served by Vercel Python serverless functions.
+
+This module is the cloud twin of ``jobtracker.main``. It MUST NOT import
+desktop-only modules (``jobtracker.credentials``, ``jobtracker.database``,
+any router that transitively imports them) at module top, because those
+pull in ``keyring``, ``aiosqlite``, or SQLite-specific startup code that
+does not exist on Vercel.
+
+Issue #14 (C1) ships only the shim: a working ``/health`` endpoint, an
+env-driven CORS middleware, and an app object importable under
+``JOBTRACKER_DEPLOYMENT=cloud``. Later issues (C2 Postgres, C3 Auth,
+C4 credentials, C5 Gmail web OAuth, C6 cloud classifier, C7 cron)
+progressively mount cloud-safe routers onto this app.
+
+Usage (Vercel):
+    The repo-root ``api/index.py`` does ``from jobtracker.main_cloud import app``
+    and the Vercel Python runtime serves ``app`` via its built-in ASGI adapter.
+
+Usage (local smoke):
+    JOBTRACKER_DEPLOYMENT=cloud uvicorn jobtracker.main_cloud:app --port 8001
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from fastapi import FastAPI, status
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from jobtracker.config import settings
+from jobtracker.logging import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+
+def _build_cors_origin_regex() -> str:
+    """Build the CORS ``allow_origin_regex`` from config.
+
+    Always allows ``localhost``/``127.0.0.1`` (for local ``vercel dev``) and
+    any ``*.vercel.app`` preview URL. Additional hosts come from
+    ``settings.cors_allowed_hosts``.
+    """
+
+    parts: list[str] = [
+        r"localhost(:\d+)?",
+        r"127\.0\.0\.1(:\d+)?",
+        r"[a-zA-Z0-9-]+\.vercel\.app",
+    ]
+    parts.extend(re.escape(host) for host in settings.cors_allowed_hosts if host)
+    return rf"^https?://({'|'.join(parts)})$"
+
+
+app = FastAPI(
+    title=f"{settings.app_name} (cloud)",
+    description="Cloud (Vercel + Supabase) deployment of the JobTracker backend.",
+    version=settings.app_version,
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],
+    allow_origin_regex=_build_cors_origin_regex(),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class HealthResponse(BaseModel):
+    """Cloud health response. Intentionally minimal until C2/C3/C4 land."""
+
+    status: str
+    version: str
+    deployment: str
+    environment: str
+
+
+@app.get(
+    "/health",
+    response_model=HealthResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Health Check (cloud)",
+    tags=["System"],
+)
+async def health_check() -> HealthResponse:
+    """Return a minimal health response.
+
+    No database hit, no credential probe. Later issues will extend this to
+    report Postgres connectivity (C2), Supabase auth (C3), and classifier
+    availability (C6) once those subsystems are wired into the cloud app.
+    """
+
+    return HealthResponse(
+        status="ok",
+        version=settings.app_version,
+        deployment=settings.deployment,
+        environment=settings.environment,
+    )
+
+
+@app.get(
+    "/",
+    summary="Cloud API Root",
+    tags=["System"],
+)
+async def root() -> dict[str, Any]:
+    """Root endpoint with API information for the cloud deployment."""
+
+    return {
+        "name": settings.app_name,
+        "version": settings.app_version,
+        "deployment": "cloud",
+        "docs": "/docs",
+        "health": "/health",
+    }

--- a/backend/tests/test_main_cloud.py
+++ b/backend/tests/test_main_cloud.py
@@ -1,0 +1,113 @@
+"""Smoke tests for the cloud FastAPI app builder (issue #14, C1).
+
+These tests only exercise the cloud shim and MUST NOT touch SQLite, the
+classifier, or any credential store. Later issues add integration tests
+for Postgres (C2), auth (C3), credentials (C4), and the cron endpoint
+(C7).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def cloud_settings(monkeypatch: pytest.MonkeyPatch):
+    """Reload ``jobtracker.config`` with cloud deployment configured.
+
+    The settings object is cached via ``lru_cache``; reload the module
+    so ``deployment`` picks up the patched env var, then restore the
+    desktop default on teardown to keep the remainder of the test
+    session's settings singleton stable.
+    """
+
+    monkeypatch.setenv("JOBTRACKER_DEPLOYMENT", "cloud")
+    monkeypatch.setenv("JOBTRACKER_CORS_ALLOWED_HOSTS", "jobtracker.app")
+
+    import jobtracker.config as config_module
+
+    importlib.reload(config_module)
+
+    yield config_module.settings
+
+    monkeypatch.undo()
+    importlib.reload(config_module)
+
+
+@pytest.fixture
+def cloud_app(cloud_settings):
+    """Import the cloud FastAPI app after cloud settings are in effect."""
+
+    import jobtracker.main_cloud as main_cloud_module
+
+    importlib.reload(main_cloud_module)
+    return main_cloud_module.app
+
+
+@pytest.mark.asyncio
+async def test_cloud_app_boots_and_health_returns_ok(cloud_app):
+    transport = ASGITransport(app=cloud_app)
+    async with AsyncClient(transport=transport, base_url="http://cloud-test") as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["deployment"] == "cloud"
+    assert payload["version"]  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_cloud_app_root_returns_deployment_info(cloud_app):
+    transport = ASGITransport(app=cloud_app)
+    async with AsyncClient(transport=transport, base_url="http://cloud-test") as client:
+        response = await client.get("/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deployment"] == "cloud"
+    assert payload["docs"] == "/docs"
+    assert payload["health"] == "/health"
+
+
+def test_cloud_app_does_not_import_keyring_or_aiosqlite(tmp_path):
+    """Validate main_cloud's import graph stays free of desktop-only deps.
+
+    Uses a subprocess to guarantee a fresh ``sys.modules`` — the in-process
+    ``sys.modules`` will already contain ``keyring`` and ``aiosqlite`` from
+    any earlier desktop test that imported ``jobtracker.main``.
+    """
+
+    import subprocess
+    import sys
+
+    script = (
+        "import os, sys, json\n"
+        "os.environ['JOBTRACKER_DEPLOYMENT'] = 'cloud'\n"
+        "from jobtracker.main_cloud import app  # noqa: F401\n"
+        "unwanted = [m for m in ('keyring', 'aiosqlite', 'torch', 'setfit') if m in sys.modules]\n"
+        "print(json.dumps(unwanted))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    unwanted = __import__("json").loads(result.stdout.strip().splitlines()[-1])
+    assert unwanted == [], (
+        f"main_cloud pulled in desktop-only / heavy modules: {unwanted}. "
+        "Credentials (C4), Postgres driver (C2), and classifier (C6) must "
+        "stay out of the cloud import graph until those issues land."
+    )
+
+
+def test_cloud_app_does_not_register_websocket_route(cloud_app):
+    paths = {getattr(route, "path", None) for route in cloud_app.routes}
+    assert "/ws/sync-status" not in paths, (
+        "Vercel Python runtime does not support WebSockets; /ws/sync-status "
+        "is intentionally absent from the cloud app (C7 replaces it with polling)."
+    )

--- a/docs/WEB_ARCHITECTURE.md
+++ b/docs/WEB_ARCHITECTURE.md
@@ -1,0 +1,72 @@
+# Web Architecture
+
+> **Status:** Stub created by issue #14 (C1 cloud shim). Filled in
+> incrementally by C2–C18. Until this banner is removed, most sections
+> describe *intended* state, not shipped state.
+
+## Deployment modes
+
+JobTracker runs in one of two modes, selected by
+`JOBTRACKER_DEPLOYMENT`:
+
+| Mode | Host | UI | DB | Auth | Secrets | Classifier |
+|---|---|---|---|---|---|---|
+| `desktop` (default) | local process, bundled .app | SwiftUI (`apps/macos/`) | SQLite (`~/Library/Application Support/JobTracker/`) | single-user, trust-local | macOS Keychain via `keyring` | rules + embeddings + SetFit |
+| `cloud` | Vercel serverless | Next.js on Vercel (`apps/web/`) | Supabase Postgres | Supabase Auth (JWT) | Fernet-encrypted Postgres rows | rules only (v1) |
+
+Both modes share the same `backend/jobtracker/` package. The divergence
+is kept in:
+- `backend/jobtracker/main.py` (desktop app builder) vs.
+  `backend/jobtracker/main_cloud.py` (cloud app builder).
+- `backend/jobtracker/credentials.py` (to be split in C4).
+- `backend/jobtracker/database/connection.py` (to be dialect-gated in C2).
+- `backend/jobtracker/classifier/hybrid.py` (lazy SetFit import in C6).
+
+## Cloud entrypoints
+
+- `api/index.py` — Vercel Python runtime entry. Prepends `backend/` to
+  `sys.path`, forces `JOBTRACKER_DEPLOYMENT=cloud`, re-exports
+  `jobtracker.main_cloud.app`.
+- `vercel.json` — routes every path to `api/index.py`, pins Python 3.11,
+  declares the placeholder cron for `/cron/sync` (implemented in C7).
+- `requirements.txt` (repo root) — Vercel-safe dependency set, no torch
+  or keyring; `backend/requirements.txt` keeps the full desktop set.
+
+## Intended request flow (cloud, once C3–C7 land)
+
+```
+browser
+  ↓  supabase-js exchanges email+password for JWT
+Next.js (apps/web/ on Vercel)
+  ↓  Authorization: Bearer <JWT>
+FastAPI (backend/jobtracker/main_cloud.py via api/index.py)
+  ↓  Depends(current_user) validates Supabase JWT → UUID
+Supabase Postgres (asyncpg, transaction-mode pooler)
+  - All queries scoped by user_id; RLS policies defense-in-depth.
+  - user_credentials rows decrypted with Fernet for Gmail/iCloud access.
+```
+
+## Out of scope (v1 migration)
+
+- WebSocket on cloud (Vercel Python doesn't support it; polling only).
+- SetFit inference on cloud (stays macOS-only; revisit via external
+  service).
+- macOS app removal — the desktop mode remains first-class.
+
+## Issue map
+
+| Area | Issue |
+|---|---|
+| Deployment toggle + shim | #14 (C1) |
+| Postgres + Alembic | C2 |
+| Supabase Auth + user_id + RLS | C3 |
+| Encrypted credentials | C4 |
+| Gmail web OAuth | C5 |
+| Rules-only cloud classifier | C6 |
+| WebSocket → polling + cron | C7 |
+| test_cloud pytest marker | C8 |
+| Next.js scaffold | C9 |
+| Typed API client | C10 |
+| Web screens | C11–C16 |
+| CI pipelines | C17 |
+| Docs finalization | C18 |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,53 @@
+# JobTracker Cloud (Vercel) Dependencies
+# =======================================
+# Consumed by Vercel's Python runtime at build time.
+#
+# This file is DELIBERATELY DIFFERENT from backend/requirements.txt.
+# Vercel's Python Function size budget is 50 MB zipped (Hobby) / 250 MB
+# zipped (Pro). Shipping torch (~800 MB) + sentence-transformers + setfit
+# exceeds it by a wide margin — so the cloud deployment excludes the
+# entire heavy-ML stack.
+#
+# DO NOT add (they break the deploy or blow the size budget):
+#   - torch, sentence-transformers, setfit, transformers, scikit-learn
+#   - keyring (macOS Keychain only; replaced by Fernet encryption in C4)
+#   - aiosqlite, websockets (not supported / not needed on Vercel)
+#
+# Heavy-ML moves to a separate inference service in a follow-up; cloud
+# rules-only classifier lands in C6.
+
+# -----------------------------------------------------------------------------
+# Web Framework
+# -----------------------------------------------------------------------------
+fastapi>=0.109.0
+pydantic>=2.5.0
+pydantic-settings>=2.1.0
+email-validator>=2.0.0
+
+# -----------------------------------------------------------------------------
+# Database (Postgres via Supabase)
+# -----------------------------------------------------------------------------
+sqlmodel>=0.0.14
+sqlalchemy[asyncio]>=2.0.25
+asyncpg>=0.29.0
+
+# -----------------------------------------------------------------------------
+# Auth (Supabase JWT verification, wired in C3)
+# -----------------------------------------------------------------------------
+pyjwt[crypto]>=2.8.0
+cryptography>=42.0.0
+
+# -----------------------------------------------------------------------------
+# Email Integration (cloud Gmail OAuth wired in C5, IMAP stays)
+# -----------------------------------------------------------------------------
+google-api-python-client>=2.100.0
+google-auth-httplib2>=0.1.1
+google-auth-oauthlib>=1.1.0
+aioimaplib>=2.0.0
+
+# -----------------------------------------------------------------------------
+# Email Parsing
+# -----------------------------------------------------------------------------
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
+python-dateutil>=2.8.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.11",
+      "maxDuration": 60
+    }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api/index.py" }
+  ],
+  "crons": [
+    { "path": "/cron/sync", "schedule": "0 */6 * * *" }
+  ],
+  "env": {
+    "JOBTRACKER_DEPLOYMENT": "cloud"
+  }
+}


### PR DESCRIPTION
Closes #14. Implements the cloud shim layer of epic #13.

## Summary
- Adds `JOBTRACKER_DEPLOYMENT=cloud` toggle + cloud-only config fields (`cors_allowed_hosts`, `supabase_jwt_secret`, `secret_encryption_key`, `vercel_cron_secret`).
- New `backend/jobtracker/main_cloud.py` — Vercel-safe FastAPI app builder: `/health`, `/`, env-driven CORS, **no DB init**, **no WebSocket**, **no desktop-only router imports**.
- New `api/index.py` — repo-root Vercel Python runtime entrypoint; prepends `backend/` to `sys.path` and re-exports `main_cloud.app`.
- New `vercel.json` — pins Python 3.11, routes all traffic to `api/index.py`, declares placeholder cron for `/cron/sync` (C7 implements the handler).
- New root `requirements.txt` — Vercel-safe deps only; **no torch, no sentence-transformers, no setfit, no keyring, no aiosqlite, no websockets**.
- New `docs/WEB_ARCHITECTURE.md` stub — desktop vs cloud matrix + issue map.
- New `backend/tests/test_main_cloud.py` — 4 smoke tests: boots cloud app, `/health` + `/` assertions, subprocess-isolated check that keyring/aiosqlite/torch/setfit are NOT imported by `main_cloud`, WebSocket route absence guard.

## Per-file commit history (one commit per file, per CLAUDE.md rule)
1. `feat(config): add deployment toggle and cloud-only settings fields` — `backend/jobtracker/config.py`
2. `feat(main-cloud): add Vercel-safe FastAPI app builder (shim)` — `backend/jobtracker/main_cloud.py`
3. `feat(vercel): add api/index.py Vercel serverless entrypoint` — `api/index.py`
4. `feat(vercel): add vercel.json routing, runtime pin, and placeholder cron` — `vercel.json`
5. `build(vercel): add Vercel-safe root requirements.txt` — `requirements.txt`
6. `docs(web-arch): add WEB_ARCHITECTURE.md stub with deployment-mode map` — `docs/WEB_ARCHITECTURE.md`
7. `fix(config): parse comma-separated cors_allowed_hosts env var` — follow-up on #1 after discovering pydantic-settings defaults to JSON parsing
8. `test(main-cloud): smoke-test cloud app boot, health, and import hygiene` — `backend/tests/test_main_cloud.py`

## Validation

**Full backend suite (matches CI):**
\`\`\`
$ .venv311/bin/pytest tests -q
tests/test_main_cloud.py ....                                            [ 80%]
============================= 154 passed in 8.42s ==============================
\`\`\`

**Cloud app import probe:**
\`\`\`
$ JOBTRACKER_DEPLOYMENT=cloud python -c "from jobtracker.main_cloud import app; print([r.path for r in app.routes])"
['/openapi.json', '/docs', '/docs/oauth2-redirect', '/redoc', '/health', '/']
\`\`\`

**Comma-separated CORS env probe:**
\`\`\`
$ JOBTRACKER_CORS_ALLOWED_HOSTS="jobtracker.app,app.jobtracker.dev" python -c "from jobtracker.config import Settings; print(Settings().cors_allowed_hosts)"
['jobtracker.app', 'app.jobtracker.dev']
\`\`\`

**Import-hygiene guard (subprocess):** The test subprocess-imports `main_cloud` and asserts `keyring`, `aiosqlite`, `torch`, `setfit` are absent from `sys.modules`. Required because in-process sys.modules is already polluted by desktop tests running `from jobtracker.main import app`.

## Test plan
- [x] Full backend pytest green locally (154 passed).
- [x] Desktop path (`main.py`) unchanged — every existing test still passes.
- [x] Cloud app boots under `JOBTRACKER_DEPLOYMENT=cloud` with no desktop-only imports.
- [ ] Backend CI green on this branch (waiting on GH Actions).
- [ ] Bundle-size verification once C6 lands (classifier lazy-import and final check of Vercel bundle < 50 MB zipped).
- [ ] `vercel dev` locally — deferred to C17 when CI wires it in.

## Risks / notes
- `vercel.json` cron is a placeholder (`0 */6 * * *`). C7 will tighten to `*/15 * * * *` and implement `POST /cron/sync`.
- No routers are mounted on the cloud app yet; each one gets added by the issue that makes its dependencies cloud-safe (C2 Postgres, C3 Auth, C4 credentials, C5 Gmail, C6 classifier, C7 cron).
- `api/index.py` uses `sys.path.insert(0, backend/)`. Standard Vercel pattern for src-layout Python; alternative is a root `pyproject.toml` with `pip install -e backend/`, deferred unless the sys.path shim causes trouble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)