### PR TITLE
feat(cloud): C6 — rules-only classifier on cloud, lazy-import torch/SetFit (#17)

### DIFF
--- a/backend/jobtracker/classifier/__init__.py
+++ b/backend/jobtracker/classifier/__init__.py
@@ -34,19 +34,67 @@ Usage:
     result = await classifier.classify(subject, body, sender_email)
     print(f"Category: {result.category.value}")
     print(f"Confidence: {result.confidence}")
+
+Cloud import hygiene
+--------------------
+``embeddings`` and ``setfit_model`` are NOT imported at package load time.
+They are exposed lazily via ``__getattr__`` so that
+``from jobtracker.classifier import get_classifier`` on the Vercel cloud
+deployment does not pull ``numpy``, ``sentence-transformers``, ``torch``,
+or ``setfit`` into ``sys.modules``. Issue #17 (C6) enforces this via a
+subprocess-isolated test in ``backend/tests/test_main_cloud.py``.
 """
 
-from .embeddings import EmbeddingsClassifier, get_embeddings_classifier
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .hybrid import (
     ClassificationResult,
     HybridClassifier,
     get_hybrid_classifier,
 )
 from .rules import RulesClassifier, get_rules_classifier
-from .setfit_model import SetFitClassifier, get_setfit_classifier
 
-# Convenience alias
+# Convenience alias — matches the previous public API.
 get_classifier = get_hybrid_classifier
+
+if TYPE_CHECKING:  # pragma: no cover - types only, never imported at runtime
+    from .embeddings import EmbeddingsClassifier, get_embeddings_classifier
+    from .setfit_model import SetFitClassifier, get_setfit_classifier
+
+
+# Heavy submodule attributes are resolved on first attribute access so
+# desktop callers keep their ergonomic ``from jobtracker.classifier import
+# SetFitClassifier`` path while cloud callers (which never touch these
+# names) pay zero import cost.
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "EmbeddingsClassifier": ("jobtracker.classifier.embeddings", "EmbeddingsClassifier"),
+    "get_embeddings_classifier": (
+        "jobtracker.classifier.embeddings",
+        "get_embeddings_classifier",
+    ),
+    "SetFitClassifier": ("jobtracker.classifier.setfit_model", "SetFitClassifier"),
+    "get_setfit_classifier": (
+        "jobtracker.classifier.setfit_model",
+        "get_setfit_classifier",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy module attribute hook for heavy re-exports."""
+
+    if name in _LAZY_EXPORTS:
+        import importlib
+
+        module_path, attr = _LAZY_EXPORTS[name]
+        module = importlib.import_module(module_path)
+        value = getattr(module, attr)
+        globals()[name] = value  # cache for future access
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Main classifier
@@ -57,10 +105,10 @@ __all__ = [
     # Layer 1: Rules
     "RulesClassifier",
     "get_rules_classifier",
-    # Layer 2: Embeddings
+    # Layer 2: Embeddings (lazy)
     "EmbeddingsClassifier",
     "get_embeddings_classifier",
-    # Layer 3: SetFit
+    # Layer 3: SetFit (lazy)
     "SetFitClassifier",
     "get_setfit_classifier",
 ]

--- a/backend/jobtracker/classifier/hybrid.py
+++ b/backend/jobtracker/classifier/hybrid.py
@@ -22,14 +22,16 @@ Confidence thresholds:
 import logging
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from jobtracker.config import settings
 from jobtracker.database.models import EmailCategory
 
-from .embeddings import get_embeddings_classifier
 from .rules import get_rules_classifier
-from .setfit_model import get_setfit_classifier
+
+if TYPE_CHECKING:  # pragma: no cover - types only, never imported at runtime
+    from .embeddings import EmbeddingsClassifier
+    from .setfit_model import SetFitClassifier
 
 logger = logging.getLogger(__name__)
 
@@ -142,15 +144,68 @@ class HybridClassifier:
 
     def __init__(self):
         self._rules = get_rules_classifier()
-        self._embeddings = get_embeddings_classifier()
-        self._setfit = get_setfit_classifier()
-        self._lite_mode = settings.lite_mode
+        # Embeddings (Layer 2) and SetFit (Layer 3) are loaded lazily via
+        # the ``_embeddings`` / ``_setfit`` properties so the cloud import
+        # graph never pays the torch / sentence-transformers / setfit cost.
+        # See ``_load_embeddings`` and ``_load_setfit`` below.
+        self._embeddings_instance: Optional["EmbeddingsClassifier"] = None
+        self._setfit_instance: Optional["SetFitClassifier"] = None
+        # Cloud deployment implies lite-mode (no SetFit, no embeddings)
+        # regardless of the explicit ``lite_mode`` setting.
+        self._lite_mode = settings.lite_mode or settings.deployment == "cloud"
+        self._cloud_rules_only = settings.deployment == "cloud"
         self._non_application_patterns = [
             re.compile(pattern, re.IGNORECASE) for pattern in NON_APPLICATION_PATTERNS
         ]
         self._lifecycle_patterns = [
             re.compile(pattern, re.IGNORECASE) for pattern in LIFECYCLE_PATTERNS
         ]
+
+    # ------------------------------------------------------------------
+    # Lazy Layer Loaders
+    # ------------------------------------------------------------------
+    # Accessing ``self._embeddings`` or ``self._setfit`` triggers the
+    # first-time import of the heavy submodule. On cloud deployments the
+    # short-circuit in ``classify()`` returns before either property is
+    # read, which is what keeps torch / sentence-transformers / setfit
+    # out of ``sys.modules``.
+
+    def _load_embeddings(self) -> "EmbeddingsClassifier":
+        if self._embeddings_instance is None:
+            # Local import — must stay inside the method body so that the
+            # cloud import graph never imports ``embeddings`` (which pulls
+            # ``numpy`` plus transitive sentence-transformers use sites).
+            from .embeddings import get_embeddings_classifier
+
+            self._embeddings_instance = get_embeddings_classifier()
+        return self._embeddings_instance
+
+    def _load_setfit(self) -> "SetFitClassifier":
+        if self._setfit_instance is None:
+            # Local import — must stay inside the method body so that the
+            # cloud import graph never imports ``setfit_model``.
+            from .setfit_model import get_setfit_classifier
+
+            self._setfit_instance = get_setfit_classifier()
+        return self._setfit_instance
+
+    @property
+    def _embeddings(self) -> "EmbeddingsClassifier":
+        return self._load_embeddings()
+
+    @_embeddings.setter
+    def _embeddings(self, value: "EmbeddingsClassifier") -> None:
+        # Allow tests / callers to swap in a fake embeddings instance.
+        self._embeddings_instance = value
+
+    @property
+    def _setfit(self) -> "SetFitClassifier":
+        return self._load_setfit()
+
+    @_setfit.setter
+    def _setfit(self, value: "SetFitClassifier") -> None:
+        # Allow tests / callers to swap in a fake setfit instance.
+        self._setfit_instance = value
 
     async def classify(
         self,
@@ -200,6 +255,50 @@ class HybridClassifier:
                 confidence=rules_result.confidence,
                 method="rules",
                 needs_review=False,
+                details={
+                    "matched_patterns": rules_result.matched_patterns[:5],
+                    "scores": rules_result.scores,
+                },
+            )
+
+        # =====================================================================
+        # Cloud Short-Circuit: Rules-Only Deployment
+        # =====================================================================
+        # On Vercel the classifier runs in a 50 MB / 60 s serverless slot,
+        # so torch / sentence-transformers / setfit are neither bundled
+        # nor importable. We must return after the rules layer — even if
+        # rules were unsure — without touching ``self._embeddings`` or
+        # ``self._setfit`` (whose property access would lazy-import the
+        # heavy submodules). User-corrected labels still persist to
+        # ``TrainingData`` and sync back to macOS where full SetFit
+        # remains canonical.
+        if self._cloud_rules_only:
+            # ``rules.py`` returns ``OTHER`` + 0.5 confidence when no
+            # category scored above zero. Distinguish that "miss" case by
+            # inspecting the raw category scores so cloud responses can
+            # surface ``confidence=0.0`` for genuine rule misses.
+            max_score = (
+                max(rules_result.scores.values()) if rules_result.scores else 0
+            )
+            rules_miss = (
+                rules_result.category == EmailCategory.OTHER and max_score <= 0
+            )
+            if rules_miss:
+                return ClassificationResult(
+                    category=EmailCategory.OTHER,
+                    confidence=0.0,
+                    method="rules",
+                    needs_review=False,
+                    details={
+                        "matched_patterns": rules_result.matched_patterns[:5],
+                        "scores": rules_result.scores,
+                    },
+                )
+            return ClassificationResult(
+                category=rules_result.category,
+                confidence=rules_result.confidence,
+                method="rules",
+                needs_review=rules_result.confidence < CONFIDENCE_AUTO,
                 details={
                     "matched_patterns": rules_result.matched_patterns[:5],
                     "scores": rules_result.scores,
@@ -500,6 +599,28 @@ class HybridClassifier:
 
     async def get_status(self) -> dict:
         """Get status of all classification layers."""
+        if self._cloud_rules_only:
+            # Deliberately avoid touching ``self._embeddings`` /
+            # ``self._setfit`` so the cloud import graph stays light.
+            return {
+                "rules": {
+                    "available": True,
+                    "description": "Pattern matching with weighted scoring",
+                },
+                "embeddings": {
+                    "available": False,
+                    "example_count": 0,
+                    "has_examples": False,
+                    "description": "Disabled on cloud (rules-only deployment)",
+                },
+                "setfit": {
+                    "available": False,
+                    "is_training": False,
+                    "disabled_by_lite_mode": True,
+                    "description": "Disabled on cloud (rules-only deployment)",
+                },
+            }
+
         embedding_count = await self._embeddings.get_example_count()
         return {
             "rules": {

--- a/backend/tests/test_main_cloud.py
+++ b/backend/tests/test_main_cloud.py
@@ -111,3 +111,85 @@ def test_cloud_app_does_not_register_websocket_route(cloud_app):
         "Vercel Python runtime does not support WebSockets; /ws/sync-status "
         "is intentionally absent from the cloud app (C7 replaces it with polling)."
     )
+
+
+def test_cloud_classifier_is_rules_only_and_skips_heavy_ml_imports():
+    """Issue #17 (C6) — rules-only cloud classifier + import hygiene.
+
+    Two invariants are validated in a single subprocess so the test
+    stays at 1 new case (155 expected total) and so both assertions
+    run against a pristine ``sys.modules``:
+
+    1. Importing the classifier and calling ``classify()`` under
+       ``JOBTRACKER_DEPLOYMENT=cloud`` must not drag ``torch``,
+       ``sentence_transformers``, ``setfit``, or ``transformers`` into
+       ``sys.modules``. Together those wheels exceed Vercel's 250 MB
+       unzipped function budget, and even on Pro their cold-start cost
+       blows the 60 s wall clock. A subprocess provides a clean
+       ``sys.modules`` so prior desktop tests in the same pytest session
+       cannot pollute the assertion.
+    2. The cloud classifier must return ``{category, confidence,
+       method: "rules"}`` for rules hits and
+       ``{other, 0.0, rules}`` for rules misses — *never* escalate to
+       embeddings or SetFit.
+    """
+
+    import json
+    import subprocess
+    import sys
+
+    script = (
+        "import os, sys, json, asyncio\n"
+        "os.environ['JOBTRACKER_DEPLOYMENT'] = 'cloud'\n"
+        "from jobtracker.classifier import get_classifier\n"
+        "classifier = get_classifier()\n"
+        "assert classifier._cloud_rules_only is True, 'cloud flag not wired'\n"
+        "assert classifier._lite_mode is True, 'cloud must imply lite_mode'\n"
+        "hit = asyncio.run(classifier.classify(\n"
+        "    'Re: Your application',\n"
+        "    'Thank you for applying to our engineering role.',\n"
+        "    'noreply@greenhouse.io',\n"
+        "))\n"
+        "miss = asyncio.run(classifier.classify('Hello', 'Just saying hi', None))\n"
+        "heavy = [m for m in ('torch', 'sentence_transformers', 'setfit', 'transformers') if m in sys.modules]\n"
+        "submods = [m for m in (\n"
+        "    'jobtracker.classifier.embeddings',\n"
+        "    'jobtracker.classifier.setfit_model',\n"
+        ") if m in sys.modules]\n"
+        "print(json.dumps({\n"
+        "    'heavy': heavy,\n"
+        "    'submods': submods,\n"
+        "    'hit': {'category': hit.category.value, 'method': hit.method, 'confidence': hit.confidence},\n"
+        "    'miss': {'category': miss.category.value, 'method': miss.method, 'confidence': miss.confidence},\n"
+        "}))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+
+    assert payload["heavy"] == [], (
+        "cloud classifier pulled heavy ML deps into sys.modules: "
+        f"{payload['heavy']}. hybrid.py must keep torch / sentence-transformers "
+        "/ setfit behind in-method lazy imports."
+    )
+    assert payload["submods"] == [], (
+        "cloud classifier imported the embeddings or setfit_model submodule: "
+        f"{payload['submods']}. The cloud short-circuit in hybrid.classify() "
+        "must return before ``self._embeddings`` or ``self._setfit`` is read."
+    )
+
+    # Rules hit: keep rules' category + confidence, tag method="rules".
+    assert payload["hit"]["method"] == "rules"
+    assert payload["hit"]["category"] != "other"
+    assert payload["hit"]["confidence"] > 0.0
+
+    # Rules miss: collapse to ``{other, 0.0, rules}`` — no further layers.
+    assert payload["miss"] == {
+        "category": "other",
+        "method": "rules",
+        "confidence": 0.0,
+    }

--- a/docs/WEB_ARCHITECTURE.md
+++ b/docs/WEB_ARCHITECTURE.md
@@ -20,7 +20,37 @@ is kept in:
   `backend/jobtracker/main_cloud.py` (cloud app builder).
 - `backend/jobtracker/credentials.py` (to be split in C4).
 - `backend/jobtracker/database/connection.py` (to be dialect-gated in C2).
-- `backend/jobtracker/classifier/hybrid.py` (lazy SetFit import in C6).
+- `backend/jobtracker/classifier/hybrid.py` — C6 now short-circuits to
+  rules-only when `settings.deployment == "cloud"` and lazy-imports
+  `embeddings` / `setfit_model` inside method bodies so neither
+  `torch`, `sentence-transformers`, nor `setfit` enters the cloud
+  import graph. The `jobtracker.classifier` package itself uses PEP
+  562 `__getattr__` so heavy re-exports resolve only on demand.
+
+## Classifier (cloud)
+
+- **Layers available.** Rules only. Embeddings (Layer 2) and SetFit
+  (Layer 3) are disabled; `settings.deployment == "cloud"` implies
+  `lite_mode = True` regardless of the explicit `JOBTRACKER_LITE_MODE`
+  value.
+- **Response shape.** `HybridClassifier.classify()` returns
+  `{category, confidence, method: "rules", …}`. Rules hits keep the
+  rules layer's category + confidence; rules misses (no category scored
+  above zero) collapse to `{category: "other", confidence: 0.0,
+  method: "rules"}` — the cloud path never escalates to semantic
+  layers.
+- **Why rules-only.** The combined torch + sentence-transformers +
+  setfit wheel set exceeds Vercel's 250 MB unzipped function budget,
+  and even on Pro the cold-start cost blows the 60 s wall clock.
+- **Corrections.** User-corrected labels still persist to
+  `TrainingData` and sync back to macOS, where the full 3-layer
+  hybrid remains canonical.
+- **Guard test.** `backend/tests/test_main_cloud.py::
+  test_cloud_classifier_is_rules_only_and_skips_heavy_ml_imports`
+  subprocess-invokes `get_classifier()` under
+  `JOBTRACKER_DEPLOYMENT=cloud` and asserts neither `torch`,
+  `sentence_transformers`, `setfit`, nor `transformers` entered
+  `sys.modules`.
 
 ## Cloud entrypoints
 
@@ -62,7 +92,7 @@ Supabase Postgres (asyncpg, transaction-mode pooler)
 | Supabase Auth + user_id + RLS | C3 |
 | Encrypted credentials | C4 |
 | Gmail web OAuth | C5 |
-| Rules-only cloud classifier | C6 |
+| Rules-only cloud classifier | #17 (C6) |
 | WebSocket → polling + cron | C7 |
 | test_cloud pytest marker | C8 |
 | Next.js scaffold | C9 |


### PR DESCRIPTION
Closes #17. Implements the rules-only cloud classifier layer of epic #13 (depends on PR #15 / C1).

## Summary
- `HybridClassifier` now lazy-imports `jobtracker.classifier.embeddings` and `jobtracker.classifier.setfit_model` inside method bodies (via `_load_embeddings()` / `_load_setfit()`), behind properties that still support the `classifier._embeddings = fake` setter used by the evaluator's `deterministic` profile and desktop tests.
- `HybridClassifier.classify()` short-circuits immediately after the Layer-1 rules call whenever `settings.deployment == "cloud"`:
  - Rules hit → `{category, confidence, method: "rules"}`.
  - Rules miss (max score ≤ 0) → `{category: "other", confidence: 0.0, method: "rules"}`.
  - Never reads `self._embeddings` / `self._setfit`, so `.embeddings` and `.setfit_model` submodules (and their transitive `torch` / `sentence-transformers` / `setfit` imports) never enter the cloud `sys.modules`.
- `settings.deployment == "cloud"` now implicitly sets `self._lite_mode = True` inside the classifier regardless of `JOBTRACKER_LITE_MODE`.
- `jobtracker.classifier.__init__` now uses PEP 562 `__getattr__` so `EmbeddingsClassifier`, `SetFitClassifier`, and their `get_*` factories resolve only on demand — `from jobtracker.classifier import get_classifier` is zero-cost for cloud.
- `get_status()` is cloud-aware: returns a fixed "disabled on cloud" snapshot without touching the semantic layers.
- `docs/WEB_ARCHITECTURE.md` gains a dedicated "Classifier (cloud)" section documenting the response contract, capacity rationale, corrections path, and the guard test.
- `backend/tests/test_main_cloud.py` gains one new subprocess-isolated test (`test_cloud_classifier_is_rules_only_and_skips_heavy_ml_imports`) that invokes `get_classifier().classify(...)` twice under `JOBTRACKER_DEPLOYMENT=cloud` and asserts `torch`, `sentence_transformers`, `setfit`, `transformers`, and the `.embeddings` / `.setfit_model` submodules are all absent from `sys.modules`, plus validates both the hit and miss response shapes. The 4 existing smoke tests from PR #15 are untouched.

## Per-file commit history (one commit per file, per CLAUDE.md rule)
1. `refactor(classifier): lazy-import embeddings/setfit and short-circuit on cloud` — `backend/jobtracker/classifier/hybrid.py`
2. `refactor(classifier): lazy-expose embeddings/setfit via PEP 562 __getattr__` — `backend/jobtracker/classifier/__init__.py`
3. `test(main-cloud): guard rules-only cloud classifier import hygiene` — `backend/tests/test_main_cloud.py`
4. `docs(web-arch): document rules-only cloud classifier contract` — `docs/WEB_ARCHITECTURE.md`

## Validation

**Full backend suite (matches CI):**
```
$ .venv311/bin/pytest tests -q
tests/test_main_cloud.py .....                                           [ 80%]
============================= 155 passed in 7.58s ==============================
```
(154 baseline from `integration/web-migration` + 1 new subprocess guard test.)

**Rules v3 gate (desktop, CI-parity):**
```
$ JOBTRACKER_ENVIRONMENT=test .venv311/bin/python -m jobtracker.scripts.evaluate_classifier \
    --mode rules --dataset data/evaluation/classifier_eval_v3.jsonl \
    --baseline data/evaluation/baseline_rules_v3.json --min-macro-f1 0.95
accuracy: 0.9792 | macro_f1: 0.9791 | weighted_f1: 0.9791 | misclassified: 2
PASS: non-regression checks passed
```

**Hybrid v3 deterministic gate (desktop, CI-parity):**
```
$ JOBTRACKER_ENVIRONMENT=test .venv311/bin/python -m jobtracker.scripts.evaluate_classifier \
    --mode hybrid --dataset data/evaluation/classifier_eval_v3.jsonl \
    --baseline data/evaluation/baseline_hybrid_v3.json \
    --hybrid-profile deterministic --min-macro-f1 0.95
accuracy: 0.9792 | macro_f1: 0.9791 | weighted_f1: 0.9791 | misclassified: 2
PASS: non-regression checks passed
```
Baselines unchanged — rules v3 and hybrid v3 deterministic macro-F1 stay at 0.9791.

**Cloud classify() smoke (in-process, desktop shell):**
```
$ JOBTRACKER_DEPLOYMENT=cloud python -c "
import asyncio, sys
from jobtracker.classifier import get_classifier
c = get_classifier()
r = asyncio.run(c.classify('Re: Your application', 'Thank you for applying', 'noreply@greenhouse.io'))
print('method=', r.method, 'category=', r.category.value, 'confidence=', r.confidence)
print('heavy=', [m for m in ('torch', 'sentence_transformers', 'setfit', 'transformers') if m in sys.modules])
"
method= rules category= applied confidence= 0.75
heavy= []
```

## Test plan
- [x] Full backend pytest green locally (155 passed, including the new subprocess guard).
- [x] Desktop SetFit + evaluator tests still pass — Layer 2/3 paths exercised as before.
- [x] Rules v3 gate green at the pinned 0.95 macro-F1 floor.
- [x] Hybrid v3 deterministic gate green at the pinned 0.95 macro-F1 floor.
- [x] Subprocess hygiene assertion confirms `torch`, `sentence_transformers`, `setfit`, `transformers` stay out of `sys.modules` after a cloud classify() call.
- [x] `_configure_hybrid_profile(classifier, "deterministic")` still mutates `classifier._embeddings._known_embeddings` / `._loaded` — property setter keeps the test contract.
- [ ] Backend CI green on this branch (waiting on GH Actions).
- [ ] Vercel bundle-size verification once C17 wires the pipeline (expected < 50 MB zipped with torch/setfit excluded).

## Risks / notes
- `HybridClassifier._embeddings` and `._setfit` are now properties backed by `_embeddings_instance` / `_setfit_instance`. Any code that did `del classifier._embeddings` or expected AttributeError for unset state will behave differently; grep confirmed no such callers exist in-tree.
- The cloud short-circuit relies on `rules.py` producing non-zero scores when any category matches. If a future rules refactor returns OTHER/0.5 without zero scores, the miss detection collapses to "hit" branch. Guarded by the new subprocess test's miss case ("Hello" / "Just saying hi").
- `get_status()` returns a fixed disabled snapshot on cloud. When C6-bis (remote SetFit inference) lands, that method will need to report "remote" availability instead of "disabled".
- Out of scope (this PR, per issue #17): remote SetFit via Modal / HF Inference, cloud training loop (60 s wall clock infeasible), changes to the CI rules v3 / hybrid v3 baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)