### PR TITLE
ci(web): C17 — frontend-ci + e2e-ci + backend cloud-smoke (#28)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -83,3 +83,68 @@ jobs:
             --hybrid-profile deterministic \
             --min-macro-f1 0.95 \
             --tolerance 0.001
+
+  cloud-smoke:
+    # Smoke-test the cloud FastAPI entrypoint (`api/index.py` /
+    # `jobtracker.main_cloud`) under the exact env used on Vercel:
+    # `JOBTRACKER_DEPLOYMENT=cloud`. Asserts that (a) the app imports
+    # without pulling keyring / aiosqlite / torch / setfit, and (b) the
+    # pytest suite in `tests/test_main_cloud.py` passes. Runs after the
+    # main `test` job so CI fails fast on the broader pytest failures
+    # before spending cycles here.
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install dependencies
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install -r requirements-dev.txt
+
+      - name: Import cloud app under cloud deployment
+        env:
+          JOBTRACKER_DEPLOYMENT: cloud
+          JOBTRACKER_CORS_ALLOWED_HOSTS: jobtracker.app
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: |
+          python -c "
+          import asyncio
+          from httpx import ASGITransport, AsyncClient
+          from jobtracker.main_cloud import app
+
+          async def probe():
+              transport = ASGITransport(app=app)
+              async with AsyncClient(transport=transport, base_url='http://cloud-smoke') as client:
+                  response = await client.get('/health')
+              assert response.status_code == 200, response.status_code
+              payload = response.json()
+              assert payload['status'] == 'ok', payload
+              assert payload['deployment'] == 'cloud', payload
+              print('cloud /health OK:', payload)
+
+          asyncio.run(probe())
+          "
+
+      - name: Run cloud pytest suite
+        env:
+          JOBTRACKER_ENVIRONMENT: test
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: pytest tests/test_main_cloud.py -q

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,164 @@
+name: E2E CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "backend/**"
+      - "api/**"
+      - ".github/workflows/e2e-ci.yml"
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "apps/web/**"
+      - "backend/**"
+      - "api/**"
+      - ".github/workflows/e2e-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    # Placeholder env so both `next build` and `next dev`'s initial route
+    # compilation succeed without a real Supabase project. The test only
+    # renders `/login` and asserts the form is present — it never
+    # actually auths against Supabase.
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+      BACKEND_API_URL: http://localhost:8000
+      PLAYWRIGHT_BASE_URL: http://localhost:3000
+      JOBTRACKER_ENVIRONMENT: test
+      PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend dependencies
+        working-directory: backend
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install -r requirements-dev.txt
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: apps/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Boot backend (uvicorn)
+        working-directory: backend
+        run: |
+          nohup python -m uvicorn jobtracker.main:app \
+            --host 127.0.0.1 --port 8000 \
+            > ../backend.log 2>&1 &
+          echo "BACKEND_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for backend /health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+              echo "backend up after $i attempts"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "backend failed to boot; tailing log:"
+          tail -n 200 backend.log || true
+          exit 1
+
+      - name: Boot Next.js (dev)
+        working-directory: apps/web
+        run: |
+          nohup pnpm dev --port 3000 > ../../frontend.log 2>&1 &
+          echo "FRONTEND_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for frontend
+        run: |
+          for i in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:3000/login >/dev/null 2>&1; then
+              echo "frontend up after $i attempts"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "frontend failed to boot; tailing log:"
+          tail -n 200 frontend.log || true
+          exit 1
+
+      - name: Run Playwright tests
+        working-directory: apps/web
+        run: pnpm exec playwright test --project=chromium
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Playwright test-results (videos + traces)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: apps/web/test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload server logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs
+          path: |
+            backend.log
+            frontend.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Stop servers
+        if: always()
+        run: |
+          if [ -n "${FRONTEND_PID:-}" ]; then kill "$FRONTEND_PID" 2>/dev/null || true; fi
+          if [ -n "${BACKEND_PID:-}" ]; then kill "$BACKEND_PID" 2>/dev/null || true; fi

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,65 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/frontend-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+
+    # Placeholder public env vars so `lib/env.ts`'s zod validator succeeds
+    # during `next build` / `pnpm typecheck`. These are never used at
+    # runtime in CI — they only satisfy the import-time schema check.
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+      BACKEND_API_URL: http://localhost:8000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -40,3 +40,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/playwright-report/
+/test-results/
+/playwright/.cache/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
@@ -24,6 +26,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the JobTracker web app.
+ *
+ * Design notes:
+ * - `webServer` is intentionally UNSET. In CI (`e2e-ci.yml`) we boot the
+ *   Next.js dev server and FastAPI backend as separate steps so their
+ *   stdout/stderr stream to artifacts and so we can probe their health
+ *   endpoints before Playwright starts. Locally, developers run
+ *   `pnpm dev` in one terminal and `pnpm e2e` in another.
+ * - `baseURL` defaults to localhost but can be overridden with
+ *   `PLAYWRIGHT_BASE_URL` to point at a Vercel Preview deployment once
+ *   the Preview-URL wiring lands (out of scope for C17).
+ * - `video: 'on'` and `trace: 'on-first-retry'` give us post-mortem
+ *   artifacts for any red test in CI without bloating every green run
+ *   with traces.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["list"]]
+    : [["list"]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+    video: "on",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+});

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 1.8.0(react@19.2.4)
       next:
         specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -45,6 +45,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -455,6 +458,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -1236,6 +1244,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1753,6 +1766,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2428,6 +2451,10 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -3349,6 +3376,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -3729,7 +3759,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -3748,6 +3778,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3842,6 +3873,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/apps/web/tests/e2e/smoke.spec.ts
+++ b/apps/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Golden-path E2E smoke test: the /login page must render its form.
+ *
+ * Guards against two classes of regression that would otherwise slip
+ * through unit CI:
+ *
+ * 1. A bad env-var schema change in `lib/env.ts` that throws on import
+ *    and 500s the route.
+ * 2. A Supabase/SSR cookie-handling bug in `proxy.ts` or
+ *    `lib/supabase/*` that crashes the route segment.
+ *
+ * Assertions are kept narrow — heading + submit button + both inputs —
+ * so copy tweaks don't cause red CI, but a truly broken page does.
+ */
+test("login page renders sign-in form", async ({ page }) => {
+  await page.goto("/login");
+
+  await expect(
+    page.getByRole("heading", { name: /sign in to jobtracker/i }),
+  ).toBeVisible();
+
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+  await expect(page.getByLabel(/password/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: /^sign in/i })).toBeVisible();
+});

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,144 @@
+# Deployment & CI Matrix
+
+This document describes the CI workflows that gate merges into
+`integration/web-migration`, `develop`, and `main`, plus the deployment
+surfaces each workflow protects.
+
+The workflows live under [`.github/workflows/`](../.github/workflows/)
+and are all path-filtered so unrelated changes don't trigger noisy
+runs.
+
+## CI workflows
+
+| Workflow | File | Trigger (paths) | Runtime | Gates |
+|---|---|---|---|---|
+| **Backend CI** | `backend-ci.yml` | `backend/**`, `scripts/install.sh`, `scripts/start_backend.sh`, itself | ubuntu-latest, Python 3.11 | pytest + classifier rules-v3 gate + hybrid v3 deterministic gate + cloud-smoke |
+| **Frontend CI** | `frontend-ci.yml` | `apps/web/**`, itself | ubuntu-latest, Node 20 + pnpm 10 | `pnpm install --frozen-lockfile` -> `typecheck` -> `lint` -> `build` |
+| **E2E CI** | `e2e-ci.yml` | `apps/web/**`, `backend/**`, `api/**`, itself | ubuntu-latest, Node 20 + Python 3.11 | Boots uvicorn + Next.js dev, runs Playwright chromium smoke, uploads `playwright-report` + `test-results` (videos, traces) as artifacts |
+| **macOS CI** | `macos-ci.yml` | `apps/macos/**`, `scripts/bundle.sh`, `scripts/generate_icons.sh`, itself | macos-latest, Xcode | `xcodebuild` Debug build of the SwiftUI app |
+| **ML monitoring (weekly)** | `ml-monitoring-weekly.yml` | cron | ubuntu-latest | Rolling classifier drift check |
+
+All workflows also respond to `workflow_dispatch` so maintainers can
+re-run a green gate on demand (e.g. after a flake).
+
+## Triggers
+
+Every workflow runs on:
+
+- `pull_request` against any branch, filtered by the paths above.
+- `push` to `main` or `develop` (no PR fired there, so this catches
+  direct-push emergencies).
+- Manual `workflow_dispatch`.
+
+Concurrency is scoped per ref (`group: <workflow>-${{ github.ref }}`
+with `cancel-in-progress: true`) so a force-push mid-run cleans up the
+stale job.
+
+## Backend CI deep dive
+
+`backend-ci.yml` runs two jobs in sequence:
+
+1. **`test`** — the status quo. Installs Python 3.11 + pip cache,
+   pulls CPU-only torch from the PyTorch index, runs `pytest tests -q`,
+   then both classifier evaluation gates (rules v3 and hybrid v3
+   deterministic) against frozen baselines in
+   `backend/data/evaluation/`. Any macro-F1 regression beyond
+   `--tolerance 0.001` fails the job.
+2. **`cloud-smoke`** (new in issue #28 / C17) — `needs: test`. Imports
+   `jobtracker.main_cloud:app` under `JOBTRACKER_DEPLOYMENT=cloud`,
+   probes `/health` via `httpx.ASGITransport` (no network), and runs
+   the focused `tests/test_main_cloud.py` suite. This catches two
+   regression classes unit tests miss:
+
+   - A new `backend/` module sneaks a `keyring` / `aiosqlite` / heavy
+     ML import into the cloud app's import graph, blowing Vercel's
+     250 MB function budget.
+   - A route that only exists in desktop mode (e.g.
+     `/ws/sync-status`) accidentally registers in cloud mode.
+
+## Frontend CI deep dive
+
+`frontend-ci.yml` runs a single `build` job:
+
+- pnpm 10 via `pnpm/action-setup@v4`, Node 20 via `actions/setup-node@v4`
+  with the built-in pnpm cache keyed off `apps/web/pnpm-lock.yaml`.
+- Placeholder public env vars (`NEXT_PUBLIC_SUPABASE_URL` etc.) are
+  injected via `env:` because `apps/web/lib/env.ts` validates them at
+  module import time with zod; missing values would crash `next build`.
+- Steps: `pnpm install --frozen-lockfile` ->
+  `pnpm typecheck` (`tsc --noEmit`) ->
+  `pnpm lint` (Next.js ESLint defaults) ->
+  `pnpm build` (Next.js 16 Turbopack production build).
+
+Any non-zero exit fails the job. `--frozen-lockfile` ensures
+`pnpm-lock.yaml` drift (e.g. a hand-edited `package.json`) is caught.
+
+## E2E CI deep dive
+
+`e2e-ci.yml` is broader because it protects both sides of the web stack:
+
+1. Installs backend + frontend dependencies (same caches as the other
+   jobs).
+2. `pnpm exec playwright install --with-deps chromium` fetches the
+   browser and its Linux system libs.
+3. Boots `uvicorn jobtracker.main:app` on `127.0.0.1:8000` in the
+   background (with `JOBTRACKER_ENVIRONMENT=test` so the backend uses
+   the in-memory SQLite fixture) and polls `/health` up to 60 s.
+4. Boots `pnpm dev` on `127.0.0.1:3000` in the background and polls
+   `/login` up to 90 s so Next.js has time to Turbopack-compile the
+   first route.
+5. Runs `pnpm exec playwright test --project=chromium`. The suite
+   currently contains one smoke test (`tests/e2e/smoke.spec.ts`) that
+   visits `/login` and asserts the form renders.
+6. On both success and failure, uploads:
+   - `apps/web/playwright-report` — the HTML report.
+   - `apps/web/test-results` — per-test folders with `.webm` videos,
+     screenshots, and trace zips.
+   - `backend.log` + `frontend.log` — server stdout/stderr for
+     post-mortem.
+
+We do **not** set `continue-on-error` on the Playwright step: a red
+test fails the workflow, which is the whole point of having the gate.
+
+## Deployment surfaces
+
+| Surface | Trigger | Gate |
+|---|---|---|
+| Vercel (Preview) — `apps/web/` + `api/index.py` | Every PR push (via the Vercel GitHub integration) | **frontend-ci** + **e2e-ci** green are required before merge |
+| Vercel (Production) — `main` branch | Merge to `main` | All of the above + **backend-ci** (both `test` and `cloud-smoke` jobs) |
+| macOS `.app` bundle | Manual release tag | **macos-ci** (Debug build on every PR), release script on tag |
+
+`PLAYWRIGHT_BASE_URL` is wired as an env var on the E2E job so a
+follow-up change can point the smoke suite at a real Vercel Preview
+deployment instead of a locally-booted dev server. That wiring is
+out-of-scope for C17 and tracked separately.
+
+## Local dry-run
+
+To reproduce each CI workflow locally:
+
+```bash
+# Frontend CI
+cd apps/web
+pnpm install --frozen-lockfile
+pnpm typecheck && pnpm lint && pnpm build
+
+# E2E CI
+# (Terminal 1) Boot backend
+cd backend
+JOBTRACKER_ENVIRONMENT=test python -m uvicorn jobtracker.main:app --port 8000
+
+# (Terminal 2) Boot frontend
+cd apps/web
+pnpm dev
+
+# (Terminal 3) Run Playwright
+cd apps/web
+pnpm exec playwright install chromium
+pnpm e2e
+
+# Backend cloud-smoke
+cd backend
+JOBTRACKER_DEPLOYMENT=cloud JOBTRACKER_CORS_ALLOWED_HOSTS=jobtracker.app \
+  pytest tests/test_main_cloud.py -q
+```


### PR DESCRIPTION
## Summary

Adds three CI artifacts that issue #28 (C17) requires before C11-C16 can merge behind a deterministic gate:

- **`.github/workflows/frontend-ci.yml`** — pnpm 10 / Node 20 install -> typecheck -> lint -> build on every `apps/web/**` change. Placeholder Supabase env injected so `lib/env.ts`'s zod validator doesn't throw at build time.
- **`.github/workflows/e2e-ci.yml`** — boots `uvicorn jobtracker.main:app` + `pnpm dev` locally, polls their health endpoints, runs `pnpm exec playwright test --project=chromium`. Uploads `playwright-report`, `test-results` (videos + traces), and server logs as artifacts on both success and failure. No `continue-on-error`.
- **`.github/workflows/backend-ci.yml`** — new `cloud-smoke` job (`needs: test`) imports `jobtracker.main_cloud:app` under `JOBTRACKER_DEPLOYMENT=cloud`, probes `/health` via `httpx.ASGITransport`, then runs `pytest tests/test_main_cloud.py -q`. The existing `test` job is untouched.

Plus the frontend test scaffolding: `apps/web/playwright.config.ts` (chromium 1440x900, video:'on', trace:'on-first-retry', `baseURL` from `PLAYWRIGHT_BASE_URL`, `webServer` unset), a single smoke spec at `apps/web/tests/e2e/smoke.spec.ts` that visits `/login` and asserts the form renders, and `docs/DEPLOYMENT.md` describing the full CI matrix.

Implements https://github.com/yadava5/jobtracker/issues/28.

## Changes

One commit per file (with `package.json`+`pnpm-lock.yaml` paired):

1. `ci(web): add frontend-ci workflow (pnpm/typecheck/lint/build)`
2. `ci(web): add e2e-ci workflow (Playwright chromium smoke)`
3. `ci(backend): add cloud-smoke job to backend-ci`
4. `test(web): add Playwright config for chromium E2E smoke`
5. `test(web): add golden-path /login smoke spec`
6. `build(web): add @playwright/test + e2e scripts`
7. `chore(web): ignore Playwright report + results dirs`
8. `docs(deployment): document CI matrix and workflow gates`

## Test plan

Local validation:

- [x] `pnpm install --frozen-lockfile` succeeds in `apps/web/`
- [x] `pnpm typecheck` (tsc --noEmit): no errors
- [x] `pnpm lint` (eslint): no warnings
- [x] `pnpm build` with placeholder Supabase env: Next.js 16 Turbopack compiles 4 routes + middleware
- [x] `yaml.safe_load` parses all three workflow files cleanly

CI (this PR should be the first to exercise the new workflows end-to-end):

- [ ] `frontend-ci / build` green (triggered by `apps/web/**` changes)
- [ ] `e2e-ci / playwright` green (triggered by `apps/web/**` changes; login heading match verified locally against `apps/web/app/(auth)/login/page.tsx`)
- [ ] `backend-ci / test` unchanged
- [ ] `backend-ci / cloud-smoke` green (new job)

## Out of scope (tracked in #28)

- Vercel Preview URL wiring (`PLAYWRIGHT_BASE_URL` -> Preview deployment)
- Visual regression / Chromatic / Percy
- Browser matrix beyond chromium
- README CI badges section update (can follow in a one-liner PR once PR numbers are known)

---

Draft PR — do not merge until all four CI checks above go green.