### PR TITLE
feat(web): C10 — typed API client generated from FastAPI openapi.json (#27) [rebased]

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -90,10 +90,55 @@ apps/web/
 6. Sign-out from `TopBar` calls `supabase.auth.signOut()` and redirects back
    to `/login`.
 
+## Updating the API client
+
+Typed bindings for the FastAPI backend live under `lib/api/`:
+
+```
+lib/api/
+├── schema.d.ts   # generated (or seed) OpenAPI types — `paths` / `components` / `operations`
+├── client.ts     # `createApiClient({ baseUrl, token? })` → typed openapi-fetch client
+└── server.ts     # `createServerApiClient()` — reads Supabase JWT from cookies
+```
+
+`schema.d.ts` is committed so screens (C11–C16) compile without a live
+backend. It is a **seed**: hand-authored to cover only the endpoints we
+currently touch (`GET /auth/me`, `GET /health`, `GET /applications`,
+`POST /applications`). Regenerate from the live OpenAPI whenever the
+backend contract changes:
+
+```bash
+# Against the deployed cloud backend (reads BACKEND_API_URL from env)
+pnpm -C apps/web api:gen
+
+# Against a local uvicorn (backend/jobtracker/main_cloud.py) on :8000
+pnpm -C apps/web api:gen:local
+```
+
+Both scripts run `openapi-typescript <url> -o lib/api/schema.d.ts` and
+will OVERWRITE the seed file with the full generated output — that is the
+intended flow. After regenerating, run `pnpm typecheck` to surface any
+shape changes in consuming screens.
+
+Typical usage in a Server Component:
+
+```tsx
+import { createServerApiClient } from "@/lib/api/server";
+
+export default async function Page() {
+  const api = await createServerApiClient();
+  const { data, error } = await api.GET("/auth/me");
+  // `data` is typed as `{ user_id: string; authenticated: boolean } | undefined`
+  if (error) return <p>Unauthorized</p>;
+  return <p>{data.user_id}</p>;
+}
+```
+
 ## Not yet in scope
 
-- Real backend API client (comes in C10).
-- Playwright E2E tests (separate issue).
+- Playwright E2E tests (separate issue, C17).
+- Auto-regenerate `schema.d.ts` in CI (manual `pnpm api:gen` for now).
+- Zod runtime validation layer on top of the static types.
 - shadcn/ui kit beyond `Button`.
 - Monorepo tooling (`pnpm-workspace.yaml`, `turbo.json`).
 

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,12 +1,84 @@
-export default function DashboardPage() {
+import { createServerApiClient } from "@/lib/api/server";
+
+/**
+ * Dashboard smoke screen.
+ *
+ * Intentionally minimal for C10: we make one server-side, typed fetch to
+ * `GET /auth/me` to prove the API client is wired up. Real dashboard
+ * widgets (pipeline totals, recent emails, follow-up reminders) land in
+ * C13 once the backend endpoints for them exist.
+ *
+ * The fetch is wrapped in try/catch so a backend outage renders a
+ * "Backend offline" placeholder rather than crashing the RSC — the
+ * protected shell above us has already confirmed the user is signed in,
+ * so the UX shouldn't degrade into a redirect loop if the backend is
+ * momentarily unreachable.
+ */
+type AuthMeState =
+  | { kind: "ok"; userId: string }
+  | { kind: "unauthorized"; message: string }
+  | { kind: "offline"; message: string };
+
+async function loadAuthMe(): Promise<AuthMeState> {
+  try {
+    const api = await createServerApiClient();
+    const { data, error, response } = await api.GET("/auth/me");
+
+    if (error || !data) {
+      return {
+        kind: "unauthorized",
+        message:
+          typeof error === "object" && error && "detail" in error
+            ? String((error as { detail: unknown }).detail)
+            : `Backend responded ${response.status}`,
+      };
+    }
+
+    return { kind: "ok", userId: data.user_id };
+  } catch (err) {
+    return {
+      kind: "offline",
+      message: err instanceof Error ? err.message : "Unknown fetch error",
+    };
+  }
+}
+
+export default async function DashboardPage() {
+  const authMe = await loadAuthMe();
+
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
-      <p className="text-sm text-neutral-600 dark:text-neutral-400">
-        Your JobTracker pipeline will show up here once the backend API
-        integration lands. For now this is an empty placeholder served by the
-        authenticated shell.
-      </p>
+    <section className="space-y-4">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          Your JobTracker pipeline will show up here once the backend API
+          integration lands. For now this is an empty placeholder served by
+          the authenticated shell.
+        </p>
+      </header>
+
+      <div
+        className="rounded-md border border-neutral-200 p-3 text-sm dark:border-neutral-800"
+        data-testid="auth-me-smoke"
+      >
+        {authMe.kind === "ok" ? (
+          <p>
+            <span className="font-medium">Backend reachable.</span>{" "}
+            <code className="font-mono text-xs">user_id={authMe.userId}</code>
+          </p>
+        ) : authMe.kind === "unauthorized" ? (
+          <p className="text-amber-700 dark:text-amber-400">
+            Backend reachable, but the session token was rejected:{" "}
+            {authMe.message}
+          </p>
+        ) : (
+          <p className="text-neutral-500 dark:text-neutral-400">
+            Backend offline — dashboard will populate once{" "}
+            <code className="font-mono text-xs">BACKEND_API_URL</code> is
+            reachable. ({authMe.message})
+          </p>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed API client factory.
+ *
+ * Wraps `openapi-fetch` with our generated (or seed) `paths` type so every
+ * `.GET` / `.POST` call is narrowed against the backend's OpenAPI schema.
+ * The factory is environment-agnostic — it does not touch cookies or
+ * Supabase directly. Pass `token` explicitly from whichever context can
+ * read it:
+ *
+ *   - Server Components / Route Handlers → `lib/api/server.ts` (uses the
+ *     Supabase SSR client to read the access token from cookies).
+ *   - Client Components → read `supabase.auth.getSession()` in the browser
+ *     and pass `session.access_token` here.
+ *
+ * Keeping the factory pure also makes it trivially testable.
+ */
+import createClient, { type Client } from "openapi-fetch";
+
+import type { paths } from "@/lib/api/schema";
+
+export interface CreateApiClientOptions {
+  /** FastAPI base URL, e.g. `https://api.jobtracker.app`. Required. */
+  baseUrl: string;
+  /**
+   * Supabase-issued JWT. When present, every request is sent with
+   * `Authorization: Bearer <token>`. Omit for unauthenticated probes
+   * such as `/health`.
+   */
+  token?: string;
+  /**
+   * Extra default headers merged in after the `Authorization` header.
+   * Useful for `X-Request-Id` tracing or custom `Accept` overrides.
+   */
+  headers?: Record<string, string>;
+}
+
+/** Convenience alias for callers that want to strongly type a returned client. */
+export type ApiClient = Client<paths>;
+
+/**
+ * Build an `openapi-fetch` client bound to our generated `paths` type.
+ */
+export function createApiClient(options: CreateApiClientOptions): ApiClient {
+  const { baseUrl, token, headers } = options;
+
+  const mergedHeaders: Record<string, string> = {
+    Accept: "application/json",
+    ...(headers ?? {}),
+  };
+
+  if (token) {
+    mergedHeaders.Authorization = `Bearer ${token}`;
+  }
+
+  return createClient<paths>({
+    baseUrl,
+    headers: mergedHeaders,
+  });
+}

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -1,0 +1,141 @@
+/**
+ * Seed schema — hand-authored minimal TypeScript bindings for the JobTracker
+ * FastAPI backend. Covers only the endpoints we need today so downstream
+ * screens (C11–C16) can compile against a typed client without a live
+ * backend running in CI.
+ *
+ * Run `pnpm api:gen` (or `pnpm api:gen:local` against a local `uvicorn`)
+ * when the backend is reachable to regenerate from the live openapi.json.
+ * The generated file will OVERWRITE this one — that is the desired flow.
+ *
+ * Shape mirrors `openapi-typescript`'s output: a single `paths` interface
+ * keyed by URL, each with per-method operation objects exposing
+ * `parameters`, `requestBody`, and `responses`. `openapi-fetch`'s
+ * generic parameter is `paths`, so consumers import this default export
+ * and pass it through to `createClient<paths>`.
+ *
+ * Source of truth for endpoint shapes: docs/API_SPEC.md and
+ * backend/jobtracker/main_cloud.py.
+ */
+
+export interface paths {
+  "/auth/me": {
+    get: operations["get_auth_me"];
+  };
+  "/health": {
+    get: operations["get_health"];
+  };
+  "/applications": {
+    get: operations["list_applications"];
+    post: operations["create_application"];
+  };
+}
+
+export interface components {
+  schemas: {
+    AuthMeResponse: {
+      user_id: string;
+      authenticated: boolean;
+    };
+    HealthResponse: {
+      status: string;
+      database?: string | null;
+      accounts?: Record<string, unknown> | null;
+      classifier?: Record<string, unknown> | null;
+    };
+    Application: {
+      id: number;
+      user_id: string;
+      company: string;
+      position: string;
+      status: string;
+      notes: string | null;
+      created_at: string;
+    };
+    ApplicationListResponse: {
+      applications: components["schemas"]["Application"][];
+      total: number;
+    };
+    ApplicationCreate: {
+      company: string;
+      position: string;
+      status?: string;
+      notes?: string | null;
+    };
+  };
+}
+
+export interface operations {
+  get_auth_me: {
+    responses: {
+      200: {
+        content: {
+          "application/json": components["schemas"]["AuthMeResponse"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": { detail: string };
+        };
+      };
+    };
+  };
+  get_health: {
+    responses: {
+      200: {
+        content: {
+          "application/json": components["schemas"]["HealthResponse"];
+        };
+      };
+    };
+  };
+  list_applications: {
+    parameters: {
+      query?: {
+        page?: number;
+        page_size?: number;
+        status?: string;
+        company?: string;
+        search?: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": components["schemas"]["ApplicationListResponse"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": { detail: string };
+        };
+      };
+    };
+  };
+  create_application: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ApplicationCreate"];
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": components["schemas"]["Application"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": { detail: string };
+        };
+      };
+      422: {
+        content: {
+          "application/json": { detail: unknown };
+        };
+      };
+    };
+  };
+}
+
+export type webhooks = Record<string, never>;

--- a/apps/web/lib/api/server.ts
+++ b/apps/web/lib/api/server.ts
@@ -1,0 +1,49 @@
+/**
+ * Server-side factory for the typed API client.
+ *
+ * Reads the Supabase session from the request cookie jar via
+ * `@supabase/ssr` and forwards the access token to `createApiClient` so
+ * every RSC / Route Handler / Server Action fetch carries the user's JWT.
+ *
+ * Usage inside an async Server Component:
+ *
+ * ```tsx
+ * const api = await createServerApiClient();
+ * const { data, error } = await api.GET("/auth/me");
+ * ```
+ *
+ * Notes:
+ * - This module is server-only: it imports `@/lib/supabase/server`, which
+ *   in turn pulls `next/headers` / `cookies()`. Any Client Component that
+ *   tries to import this file will fail the Next.js build with a clear
+ *   "server-only API in client bundle" error, so no separate `server-only`
+ *   guard is required.
+ * - The Supabase server client already handles cookie-refresh semantics
+ *   via `proxy.ts`; here we only need to READ the current session.
+ * - `baseUrl` comes from `serverEnv().BACKEND_API_URL`, which is validated
+ *   by zod at first access.
+ */
+import { createApiClient, type ApiClient } from "@/lib/api/client";
+import { serverEnv } from "@/lib/env";
+import { createClient as createSupabaseServerClient } from "@/lib/supabase/server";
+
+/**
+ * Build a typed API client carrying the caller's Supabase JWT (when the
+ * session exists). Safe to call from any server-side async context; if
+ * there is no authenticated session, the client is returned without an
+ * `Authorization` header so unauthenticated endpoints like `/health`
+ * still work.
+ */
+export async function createServerApiClient(): Promise<ApiClient> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const { BACKEND_API_URL } = serverEnv();
+
+  return createApiClient({
+    baseUrl: BACKEND_API_URL,
+    token: session?.access_token,
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui"
+    "e2e:ui": "playwright test --ui",
+    "api:gen": "openapi-typescript $BACKEND_API_URL/openapi.json -o lib/api/schema.d.ts",
+    "api:gen:local": "openapi-typescript http://localhost:8000/openapi.json -o lib/api/schema.d.ts"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
@@ -20,6 +22,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
+    "openapi-fetch": "^0.13.8",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tailwind-merge": "^3.5.0",
@@ -33,6 +36,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "openapi-typescript": "^7.13.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      openapi-fetch:
+        specifier: ^0.13.8
+        version: 0.13.8
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -66,6 +69,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.4
         version: 16.2.4(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      openapi-typescript:
+        specifier: ^7.13.0
+        version: 7.13.0(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -482,6 +488,16 @@ packages:
       '@types/react':
         optional: true
 
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/openapi-core@1.34.12':
+    resolution: {integrity: sha512-b32XWsz6enN6K4bx8xWsqUaXTJR/DnYT3lL1CzDYzIYKw243NNlz6fexmr71q/U4HrEcMoJGBvwAfcxOb8ymQw==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -821,8 +837,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -901,6 +925,9 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
@@ -937,6 +964,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -953,6 +983,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1342,6 +1375,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
@@ -1361,6 +1398,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1483,6 +1524,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1500,6 +1545,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1646,6 +1694,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -1725,6 +1777,18 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  openapi-fetch@0.13.8:
+    resolution: {integrity: sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript@7.13.0:
+    resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.x
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1744,6 +1808,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1776,6 +1844,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -1822,6 +1894,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1961,6 +2037,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2002,6 +2082,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2047,6 +2131,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2090,6 +2177,13 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2128,7 +2222,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2198,7 +2292,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2233,7 +2327,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -2249,7 +2343,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -2469,6 +2563,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/openapi-core@1.34.12(supports-color@10.2.2)':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
   '@rtsao/scc@1.1.0': {}
 
   '@supabase/auth-js@2.103.3':
@@ -2648,7 +2765,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2658,7 +2775,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2677,7 +2794,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -2692,7 +2809,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -2782,12 +2899,16 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-colors@4.1.3: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -2887,6 +3008,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
@@ -2929,6 +3054,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  change-case@5.4.4: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -2942,6 +3069,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
 
   concat-map@0.0.1: {}
 
@@ -2981,9 +3110,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   deep-is@0.1.4: {}
 
@@ -3156,7 +3287,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.4(jiti@2.6.1)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
@@ -3288,7 +3419,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -3473,6 +3604,13 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
@@ -3485,6 +3623,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -3619,6 +3759,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-levenshtein@1.1.6: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -3630,6 +3772,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3749,6 +3893,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
@@ -3835,6 +3983,22 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  openapi-fetch@0.13.8:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript@7.13.0(typescript@5.9.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.12(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3862,6 +4026,12 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3881,6 +4051,8 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -3936,6 +4108,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -4139,6 +4313,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4176,6 +4352,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -4262,6 +4440,8 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  uri-js-replace@1.0.1: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -4316,6 +4496,10 @@ snapshots:
   ws@8.20.0: {}
 
   yallist@3.1.1: {}
+
+  yaml-ast-parser@0.0.43: {}
+
+  yargs-parser@21.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #27. Rebased version of the original PR #29 after merging #30 (CI pipelines) and #31 (C4 credentials) into integration.

## Summary
Identical to #29 plus a clean rebase:
- `apps/web/lib/api/` with seed `schema.d.ts` (hand-authored, drop-in replacement for generated output), `createApiClient({ baseUrl, token? })` factory wrapping `openapi-fetch`, and a server-only `createServerApiClient()` that reads Supabase session from cookies.
- `pnpm api:gen` / `pnpm api:gen:local` scripts.
- Sample typed server-side `GET /auth/me` call from the dashboard with graceful "Backend offline" fallback.
- `apps/web/README.md` "Updating the API client" section.

## Rebase note
Original branch `feat/web-api-client` (PR #29) conflicted with #30's `package.json` + `pnpm-lock.yaml` changes after both merged simultaneously. Resolution:
- `package.json` scripts: merged both sets (`e2e`, `e2e:ui` from C17; `api:gen`, `api:gen:local` from C10). Deps were auto-merged by git.
- `pnpm-lock.yaml`: regenerated via `pnpm install` against the merged manifest.
- Resulting branch pushed as `feat/web-api-client-rebased` (avoids force-push to a shared feature branch).

## Validation (post-rebase)
\`\`\`
$ pnpm typecheck
(clean)

$ pnpm build  # with placeholder env
Route (app)
┌ ○ /_not-found
├ ƒ /callback
├ ƒ /dashboard
├ ○ /login
└ ○ /signup
ƒ Proxy (Middleware)
\`\`\`

## Expected CI
With C17 (#30) now merged, this PR will trigger `frontend-ci.yml` — expect typecheck + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)