### PR TITLE
fix(pipeline): an application is an employer AND a role, not an employer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-405%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-429%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,13 +373,13 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**405 tests collected, 0 skipped.** These figures were recorded on 2026-08-10 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 391 `test_*` functions across 27 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary and RLS work, two of which brought their own module. The remaining difference from 405 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**429 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 404 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 429 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
 Those tests drive the production machinery, not a fixture: `jobtracker.database.connection.get_session` with its real GUC and `search_path` handling, against a non-`BYPASSRLS` role, asserting that a raw query with the application-level `WHERE user_id = ...` filter *removed* still returns nothing for another tenant.
 
-**Coverage**, from the same run: **55.02%** overall — 8,817 statements, 3,966 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **80.9%**; `auth` 80.5%; `database` 76.9%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
+**Coverage**, from the same run: **55.57%** overall — 8,947 statements, 3,975 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **81.7%**; `auth` 80.5%; `database` 77.0%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -531,9 +531,9 @@ applied/
 │   │   ├── credentials/     # types · desktop (Keychain) · cloud (Fernet)
 │   │   ├── database/        # models, connection (the RLS GUC listener lives here)
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
-│   ├── alembic/versions/    # 9 revisions incl. the RLS + InitPlan-hoist migrations
+│   ├── alembic/versions/    # 10 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 27 modules
+│   └── tests/               # 28 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/backend/alembic/versions/f1a2c9b73d40_application_identity_req_id_role_token.py
+++ b/backend/alembic/versions/f1a2c9b73d40_application_identity_req_id_role_token.py
@@ -1,0 +1,83 @@
+"""application identity within an employer (req_id, role_token)
+
+Revision ID: f1a2c9b73d40
+Revises: e4cbb4aadccd
+Create Date: 2026-08-11 01:40:00.000000
+
+Adds ``applications.req_id`` / ``applications.role_token`` so an application is
+identified by (employer, requisition-or-role) instead of by employer alone.
+
+Why
+---
+
+Until now one company could hold exactly one application per user, by
+construction: ``pipeline.roll_up_applications`` grouped gated mail on the
+employer token and ``_find_application_by_token(...).first()`` resolved it to a
+single row. On 2026-08-11 the owner's own mailbox showed what that costs — four
+Amazon requisitions applied for in one evening (IDs 3177934, 3183020, 10414316,
+3130865), two Anthropic roles and two Crusoe roles, rendered as three cards.
+Five real applications were invisible.
+
+It was also actively wrong, not merely coarse: a merged row takes the furthest
+stage ANY of that company's mail reached, with a rejection as a terminal
+override, and ``advance_application_status`` never moves a row out of a terminal
+state. So the first per-requisition rejection would have settled the merged
+Amazon row permanently and silently discarded every later interview or offer for
+the other three.
+
+Design notes
+------------
+
+- Both columns are plain nullable adds. ``NULL`` on both is a legitimate,
+  permanent state meaning "this employer's mail names no role anywhere" —
+  Supabase, Twitch and Together AI are all like that in the live corpus — and it
+  is also the state every pre-existing row starts in, so the upgrade needs no
+  backfill and changes nothing a user sees until the next sync.
+- Existing rows are adopted IN PLACE on that next sync rather than rewritten
+  here: ``_resolve_application`` matches a cluster to the employer's single
+  identity-less row and stamps the identity onto it, which keeps the row id and
+  therefore every contact, interview, linked email and user correction attached
+  to it. Doing the split in SQL would have had to guess the same thing with less
+  information, and would not have been undoable.
+- **No unique constraint on (user_id, company, req_id).** Re-applying to the
+  same requisition after a rejection is a second application, and the resolver
+  only ever matches live rows. A unique index would forbid the legitimate case
+  to prevent one the resolver already prevents.
+- ``req_id`` is indexed because the resolver looks rows up by it on every sync;
+  ``role_token`` is not, because it is only ever compared within the handful of
+  rows already fetched for one employer.
+- ``batch_alter_table`` is for SQLite compatibility only. Its default
+  ``recreate="auto"`` leaves Postgres on a plain ``ALTER TABLE ADD COLUMN``, so
+  the RLS policies and the FORCE flag on ``applications`` are untouched.
+- The downgrade drops both columns. Rows survive it, but the employer's
+  applications become indistinguishable again and the next sync will re-merge
+  them, so it is a real loss of structure rather than a clean rollback.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2c9b73d40'
+down_revision: Union[str, Sequence[str], None] = 'e4cbb4aadccd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('req_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.add_column(sa.Column('role_token', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.create_index(batch_op.f('ix_applications_req_id'), ['req_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_applications_req_id'))
+        batch_op.drop_column('role_token')
+        batch_op.drop_column('req_id')

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -452,6 +452,28 @@ async def _find_application_by_token(
         Application.id.asc(),
     )
 
+    rows = await _company_rows(session, user_id, token)
+    return rows[0] if rows else None
+
+
+async def _company_rows(session, user_id: uuid.UUID, token: str) -> list[Application]:
+    """Every one of this user's applications at the employer named by ``token``.
+
+    One employer can now hold several applications, so the lookup returns the
+    whole set and :func:`_resolve_application` decides which one a given piece of
+    mail belongs to. The single-row ``.first()`` this replaced silently picked
+    one of four Amazon rows and let the other three drift.
+
+    Two queries, so the common case stays index-assisted: exact equality first,
+    then a prefix scan over the leading normalized word, confirmed in Python.
+    """
+
+    live_first = (
+        Application.dismissed_at.is_(None).desc(),
+        Application.created_at.asc(),
+        Application.id.asc(),
+    )
+
     exact = (
         await session.exec(
             select(Application)
@@ -460,15 +482,14 @@ async def _find_application_by_token(
                 func.lower(Application.company) == token,
             )
             .order_by(*live_first)
-            .limit(1)
         )
-    ).first()
-    if exact is not None:
-        return exact
+    ).all()
+    if exact:
+        return list(exact)
 
     prefix = pipeline.normalize_company_name(token).split(" ")[0]
     if not prefix:
-        return None
+        return []
     candidates = (
         await session.exec(
             select(Application)
@@ -479,10 +500,96 @@ async def _find_application_by_token(
             .order_by(*live_first)
         )
     ).all()
-    for row in candidates:
-        if pipeline.matches_company_token(row.company, token):
-            return row
-    return None
+    return [row for row in candidates if pipeline.matches_company_token(row.company, token)]
+
+
+async def _resolve_application(
+    session,
+    user_id: uuid.UUID,
+    rolled: pipeline.RolledApplication,
+) -> Application | None:
+    """Which stored application, if any, this rolled cluster is — or None to mint.
+
+    The employer narrows the field; these rules pick the row inside it. They are
+    the persistent mirror of :func:`pipeline.partition_applications`, and the
+    order is the whole point:
+
+    1. **Requisition id.** The employer's own number. Nothing outranks it.
+    2. **Role token.** The normalized title.
+    3. **A row that has no identity yet** — one minted before applications were
+       told apart within an employer — is ADOPTED by the cluster, in place, so
+       the migration keeps the row id and everything hanging off it. Only when
+       it is the sole such row: with two anonymous rows there is no way to know
+       which is which, and guessing would move a user's status onto the wrong
+       application.
+    4. **A cluster that names no role at all** joins the employer's only row if
+       there is exactly one, and otherwise mints nothing and matches nothing —
+       :func:`pipeline.collect_review_items` has already routed that message to
+       the queue for the user to assign.
+
+    Live rows are preferred over dismissed ones throughout (``_company_rows``
+    orders them first), so a dismissed duplicate can never shadow the row that is
+    actually on the board.
+    """
+
+    rows = await _company_rows(session, user_id, rolled.company_token)
+    return _pick_application(rows, rolled.req_id, rolled.role_token)
+
+
+def _pick_application(
+    rows: list[Application],
+    req_id: str | None,
+    role_token: str | None,
+) -> Application | None:
+    """The cascade itself, over rows already narrowed to one employer.
+
+    Split out from :func:`_resolve_application` because three call sites need it
+    and they arrive at ``(req_id, role_token)`` differently: the sync computes it
+    for a whole cluster, while the review-classify and orphan-reconcile paths
+    compute it from one message. Before this existed those two paths called
+    ``.first()``, which — the moment an employer holds more than one application
+    — files a user's own classification against an arbitrary sibling.
+    """
+
+    if not rows:
+        return None
+
+    if req_id is not None:
+        for row in rows:
+            if row.req_id and row.req_id == req_id:
+                return row
+    if role_token is not None:
+        for row in rows:
+            if row.role_token and row.role_token == role_token:
+                return row
+
+    if req_id is None and role_token is None:
+        # Rule 4. Deliberately looks at ALL rows, not just the identity-less
+        # ones: role-less mail at an employer with exactly one known application
+        # belongs to it. With several, there is nothing to choose between them.
+        return rows[0] if len(rows) == 1 else None
+
+    # Rule 3 — adopt the employer's single pre-identity row, in place.
+    unidentified = [row for row in rows if row.req_id is None and row.role_token is None]
+    return unidentified[0] if len(unidentified) == 1 else None
+
+
+async def _resolve_application_for_email(
+    session,
+    user_id: uuid.UUID,
+    token: str,
+    email: Email,
+) -> Application | None:
+    """Resolve the application ONE stored message belongs to, or None to mint."""
+
+    rows = await _company_rows(session, user_id, token)
+    subject = email.subject or ""
+    snippet = email.body_snippet or ""
+    return _pick_application(
+        rows,
+        pipeline.extract_req_id(subject, snippet),
+        pipeline.normalize_role_token(pipeline.role_from_message(subject, snippet)),
+    )
 
 
 async def _persist_message_refs(
@@ -550,7 +657,18 @@ async def _persist_message_refs(
             existing.sender_name = ref.sender_name
             existing.sender_email = ref.sender_email
             existing.received_at = received_at
-            existing.body_snippet = (ref.snippet or "")[:500]
+            # Only ever ADD a snippet, never blank one. A ref that carries no
+            # snippet means "this pass did not fetch one", not "this message has
+            # none" — and the unconditional assignment that used to be here is
+            # how the stored snippet was erased for every message that came back
+            # through the review queue. The role lives in the snippet, so erasing
+            # it erases the identity the board groups by.
+            if ref.snippet:
+                existing.body_snippet = ref.snippet[:500]
+            # A thread id, likewise: a metadata fetch that omits it must not
+            # unlink a message from its conversation.
+            if ref.thread_id:
+                existing.thread_id = ref.thread_id
             if not (existing.user_corrected or existing.is_reviewed):
                 existing.classified_as = category
                 existing.classification_confidence = ref.confidence
@@ -690,11 +808,24 @@ async def upsert_applications_for_user(
     created = 0
     updated = 0
     emptied: set[int] = set()
-    for r in rolled:
-        existing = await _find_application_by_token(session, user_id, r.company_token)
+    # Earliest-applied first WITHIN a company. When several applications at one
+    # employer meet a single pre-identity row, the earliest is the one that
+    # adopts it — so the row that has been on the board (and any status the user
+    # set on it) stays with the application it was actually about, and the later
+    # ones are minted fresh. Across companies the order is irrelevant.
+    for r in sorted(rolled, key=lambda x: (x.company_token, x.applied_at or datetime.max)):
+        existing = await _resolve_application(session, user_id, r)
         deeplink = _rolled_deeplink(r)
 
         if existing is not None:
+            # Stamp the identity on whatever row we landed on. For a row minted
+            # before this concept existed this is the migration: it happens on
+            # the next sync, in place, keeping the row id and therefore every
+            # contact, interview and user correction hanging off it.
+            if existing.req_id is None and r.req_id is not None:
+                existing.req_id = r.req_id
+            if existing.role_token is None and r.role_token is not None:
+                existing.role_token = r.role_token
             if existing.dismissed_at is not None:
                 if existing.dismissed_reason == DISMISSED_BY_USER:
                     continue  # a human said no; not counted as updated either
@@ -728,6 +859,8 @@ async def upsert_applications_for_user(
                 applied_date=r.applied_at.date() if r.applied_at else None,
                 source=SOURCE_GMAIL_AUTO,
                 url=deeplink,
+                req_id=r.req_id,
+                role_token=r.role_token,
             )
             session.add(app)
             await session.flush()
@@ -851,18 +984,24 @@ async def reconcile_orphaned_classifications(session, user_id: uuid.UUID) -> int
             continue  # still unnameable — never invent a company
         token, display = employer
 
-        app = await _find_application_by_token(session, user_id, token)
+        app = await _resolve_application_for_email(session, user_id, token, email)
         if app is None:
+            # Stamp the identity the message carries onto the row it mints, so
+            # the next sync recognises this application instead of filing a
+            # second one beside it.
+            role = pipeline.role_from_message(email.subject or "", email.body_snippet or "")
             app = Application(
                 user_id=user_id,
                 company=display,
-                position=_NO_ROLE,
+                position=role or _NO_ROLE,
                 status=ApplicationStatus(status_value),
                 applied_date=email.received_at.date() if email.received_at else None,
                 source=SOURCE_GMAIL_USER,  # came from a human decision → sticky
                 url=pipeline.gmail_deeplink(
                     thread_id=email.thread_id, message_id=email.message_id
                 ),
+                req_id=pipeline.extract_req_id(email.subject or "", email.body_snippet or ""),
+                role_token=pipeline.normalize_role_token(role),
             )
             session.add(app)
             await session.flush()
@@ -960,7 +1099,7 @@ async def _persist_review_items(session, user_id: uuid.UUID, review) -> int:
             received_at=item.received_at,
             category="needs_review",
             confidence=item.confidence,
-            snippet="",
+            snippet=item.snippet,
         )
         for item in review
     ]
@@ -995,7 +1134,7 @@ async def _persist_review_items_additive(session, user_id: uuid.UUID, review) ->
             received_at=item.received_at,
             category="needs_review",
             confidence=item.confidence,
-            snippet="",
+            snippet=item.snippet,
         )
         for item in review
     ]
@@ -1490,18 +1629,21 @@ async def classify_review_item(
 
     if status_value is not None and employer is not None:
         token, display = employer
-        app = await _find_application_by_token(session, user_id, token)
+        app = await _resolve_application_for_email(session, user_id, token, email)
         if app is None:
+            role = pipeline.role_from_message(email.subject or "", email.body_snippet or "")
             app = Application(
                 user_id=user_id,
                 company=display,
-                position=_NO_ROLE,
+                position=role or _NO_ROLE,
                 status=ApplicationStatus(status_value),
                 applied_date=email.received_at.date() if email.received_at else None,
                 source=SOURCE_GMAIL_USER,  # human-classified → sticky
                 url=pipeline.gmail_deeplink(
                     thread_id=email.thread_id, message_id=email.message_id
                 ),
+                req_id=pipeline.extract_req_id(email.subject or "", email.body_snippet or ""),
+                role_token=pipeline.normalize_role_token(role),
             )
             session.add(app)
             await session.flush()

--- a/backend/jobtracker/cloud/pipeline.py
+++ b/backend/jobtracker/cloud/pipeline.py
@@ -24,7 +24,7 @@ import re
 import urllib.parse
 from collections import defaultdict
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 
 # The full category vocabulary the cloud rules classifier can emit. Kept in one
@@ -603,6 +603,153 @@ _ROLE_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
 )
 
+# Role named in the BODY. Real ATS confirmations put the company in the subject
+# and the role in the first sentence, which is why every one of the owner's four
+# Amazon confirmations shares the subject "Thank you for Applying to Amazon!" and
+# differs only here. Measured against the live corpus: these three patterns name
+# the role for Amazon, Roblox, DoorDash, SimpliSafe, Crusoe, Baseten, Cursor,
+# MotherDuck and Anthropic; Supabase, Twitch, Together AI and IXL genuinely name
+# no role anywhere in the mail, and must degrade to None rather than to a guess.
+#
+# Ordered most-specific first. Each capture is bounded to one clause (no ``.``,
+# ``!``, ``?`` or newline) so a runaway match cannot swallow the next sentence.
+_ROLE_BODY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Ashby: "Thank you for applying to our role: Software Engineer I, Storage."
+    re.compile(r"\brole:\s*(?P<role>[^.!?\n]{3,90}?)\s*(?=[.!?\n]|$)", re.IGNORECASE),
+    # "...application for the <ROLE> position", "...interest in the <ROLE> position",
+    # "...applying to our <ROLE> role", "...application for the <ROLE> role"
+    re.compile(
+        r"\b(?:for|in|to)\s+(?:the|our|your|a|an)\s+"
+        r"(?P<role>[^.!?\n]{3,90}?)\s+"
+        r"(?:position|role|opening|opportunity|req)\b",
+        re.IGNORECASE,
+    ),
+    # DoorDash-shaped: "...applying to DoorDash's <ROLE> position!" — the employer
+    # sits between the verb and the title, so no article anchors the capture.
+    re.compile(
+        r"\b(?:applying|applied|application)\b[^.!?\n]{0,40}?"
+        r"(?P<role>[A-Z][^.!?\n]{3,90}?)\s+(?:position|role)\b",
+    ),
+)
+
+# A requisition id, when the employer prints one. DELIBERATELY conservative: a
+# false shared id merges two genuinely different applications, which is strictly
+# worse than having no id at all and falling back to the role token. So every
+# pattern requires an explicit label or a recognised ATS shape, and a bare number
+# (a year, a salary, "2026") never qualifies.
+_REQ_ID_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Amazon: "(ID: 3177934)". Also "Job ID 12345", "Requisition ID: R-4821".
+    re.compile(
+        r"\b(?:job\s*|requisition\s*|req\s*|posting\s*)?id[:\s#]+(?P<id>[A-Z]{0,3}-?\d{4,12})\b",
+        re.IGNORECASE,
+    ),
+    # Workday/Greenhouse style standalone requisition codes: "R-4821", "JR0093214".
+    re.compile(r"\b(?P<id>(?:R|JR|REQ)-?\d{4,10})\b"),
+)
+
+# Words a role token drops before comparison, so "Software Engineer I, Storage"
+# and "Software Engineer I - Storage" are the same application and not two.
+_ROLE_TOKEN_STRIP = re.compile(r"[^a-z0-9]+")
+
+
+def _unescape_basic_entities(text: str) -> str:
+    """Undo the handful of HTML entities Gmail snippets arrive carrying.
+
+    Snippets come back pre-escaped (``We&#39;ve received your application``), and
+    an escaped apostrophe inside a captured role would make two spellings of one
+    title compare unequal.
+    """
+
+    if "&" not in text:
+        return text
+    return (
+        text.replace("&#39;", "'")
+        .replace("&quot;", '"')
+        .replace("&amp;", "&")
+        .replace("&nbsp;", " ")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+
+
+def extract_req_id(subject: str, snippet: str = "") -> str | None:
+    """Return the employer's own requisition id for this application, or None.
+
+    This is the strongest identity signal available: two Amazon confirmations
+    with different ids are two applications no matter how similar their titles
+    read, and two messages carrying the same id are one application no matter
+    how differently they word it.
+    """
+
+    for text in (subject or "", _unescape_basic_entities(snippet or "")):
+        for pattern in _REQ_ID_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                return match.group("id").upper()
+    return None
+
+
+def _clean_role(raw: str) -> str | None:
+    """Normalize a captured role, or None if the capture is not a real title."""
+
+    role = re.sub(r"\s+", " ", raw).strip(" .,;:-–—")
+    # The requisition id is identity, not part of the human-readable title.
+    role = re.sub(r"\s*\(\s*(?:job\s*|requisition\s*|req\s*)?id[:\s#][^)]*\)", "", role, flags=re.IGNORECASE)
+    # "applying to DoorDash's Software Engineer I" — the employer's possessive
+    # rides in ahead of the title because no article separates them.
+    role = re.sub(r"^\w+['’]s\s+", "", role)
+    role = role.strip(" .,;:-–—")
+    words = role.split()
+    if not words or len(role) < 3:
+        return None
+    if all(_normalize_token(w) in _ROLE_FILLER for w in words):
+        return None
+    # A real job title in an ATS template is Title Case — "Software Engineer I,
+    # Storage", "TPU Kernel Engineer". An all-lowercase capture is prose that
+    # happened to sit between the anchors, and prose must never become an
+    # identity: Supabase's "Thanks for your interest in a role with Supabase"
+    # yielded the role "interest in a", which would have keyed an application.
+    if not any(w[:1].isupper() for w in words):
+        return None
+    return role
+
+
+def role_from_message(subject: str, snippet: str = "") -> str | None:
+    """Extract the job title this message is about, or None. Never a guess.
+
+    Subject first (it is the cleaner signal when present), then the body. The
+    body half is what makes per-application tracking possible at all: ATS
+    templates repeat one subject across every role a candidate applies to.
+    """
+
+    from_subject = _role_from_subject(subject)
+    if from_subject is not None:
+        return from_subject
+
+    body = _unescape_basic_entities(snippet or "")
+    for pattern in _ROLE_BODY_PATTERNS:
+        match = pattern.search(body)
+        if not match:
+            continue
+        role = _clean_role(match.group("role"))
+        if role is not None:
+            return role
+    return None
+
+
+def normalize_role_token(role: str | None) -> str | None:
+    """Collapse a role title to a comparison key, or None.
+
+    Punctuation and spacing vary between an employer's confirmation and its own
+    later interview mail ("Software Engineer I, Storage" vs "Software Engineer I
+    - Storage"); the token has to survive that or one application becomes two.
+    """
+
+    if not role:
+        return None
+    token = _ROLE_TOKEN_STRIP.sub(" ", role.lower()).strip()
+    return token or None
+
 
 @dataclass(frozen=True)
 class MessageRef:
@@ -621,7 +768,13 @@ class MessageRef:
 
 @dataclass(frozen=True)
 class RolledApplication:
-    """One company's applications rolled into a single tracker row."""
+    """ONE application — an employer plus the specific role applied for.
+
+    Not "one company's applications rolled into a single row", which is what
+    this used to be and what made four different Amazon requisitions render as
+    one card. ``company_token`` alone is no longer an identity; the identity is
+    ``(company_token, req_id or role_token)``.
+    """
 
     company_token: str  # normalized match key (e.g. "acme")
     company_display: str  # human display (e.g. "Acme")
@@ -630,6 +783,13 @@ class RolledApplication:
     applied_at: datetime | None  # earliest application date
     last_activity: datetime | None  # most recent relevant date
     messages: tuple[MessageRef, ...] = ()  # contributing mail, newest-first
+    # Identity within the employer. ``req_id`` is the employer's own requisition
+    # number when it prints one; ``role_token`` is the normalized title. Both are
+    # None for an employer that names no role anywhere in its mail (Supabase,
+    # Twitch, Together AI in the live corpus) — that degrades to one row, which
+    # is the honest floor when the mail genuinely does not distinguish.
+    req_id: str | None = None
+    role_token: str | None = None
 
 
 @dataclass(frozen=True)
@@ -650,6 +810,12 @@ class ReviewItem:
     category: str  # the tentative lifecycle category
     confidence: float
     company_display: str | None  # best-effort; may be None (unknown employer)
+    # Carried so the persisted Email keeps its snippet. It used to be dropped
+    # here and hard-coded to "" at the two persist sites, and because the persist
+    # path assigns `body_snippet` unconditionally, a message that came back
+    # through review had its stored snippet ERASED — taking the role with it,
+    # which is the one field per-application identity depends on.
+    snippet: str = ""
 
 
 def _rank_to_status(rank: int) -> str:
@@ -823,6 +989,39 @@ def _brand_display(brand: str, sender_name: str | None) -> str:
     return brand.replace("-", " ").title()
 
 
+# "Thanks for applying to Twitch", "Thank you for applying to DoorDash" — the
+# employer, spelled by the employer, in its own subject line.
+_SUBJECT_NAMES_EMPLOYER = re.compile(
+    r"\bapply(?:ing)?\s+(?:to|with|for)\s+(?:the\s+)?(?P<name>[A-Z][\w&.\-]*(?:\s+[A-Z][\w&.\-]*){0,2})",
+)
+
+
+def _corporate_display(brand: str, subject: str, sender_name: str | None) -> str:
+    """Human display for an employer that mailed from its own domain.
+
+    The domain is the right thing to TRUST but the wrong thing to PRINT. Two
+    live rows show why: ``no-reply@twitchjobs.tv`` rendered the company as
+    "Twitchjobs" while its own subject said "Thank you for applying to Twitch",
+    and ``no-reply@doordash.com`` rendered "Doordash" because title-casing a
+    lowercase domain label cannot know where the intercap goes.
+
+    So when the subject names a company and the domain agrees with it — the
+    domain brand starts with, or is started by, the normalized subject name —
+    the subject's spelling wins. The agreement test is what keeps this from
+    picking up a company merely *mentioned* in a subject: "Your application to
+    Acme via Workday" mailed from workday.com resolves nothing here, and falls
+    through to the relay branches as before.
+    """
+
+    match = _SUBJECT_NAMES_EMPLOYER.search(subject or "")
+    if match:
+        named = _clean_company_display(match.group("name"))
+        token = _normalize_token(named).replace(" ", "")
+        if token and (brand.startswith(token) or token.startswith(brand)):
+            return named
+    return _brand_display(brand, sender_name)
+
+
 def resolve_employer(
     sender_email: str,
     subject: str = "",
@@ -872,7 +1071,7 @@ def resolve_employer(
         and not brand.isdigit()
     )
     if corporate:
-        return brand, _brand_display(brand, sender_name)
+        return brand, _corporate_display(brand, subject, sender_name)
 
     from_subject = _employer_from_subject(subject)
     if from_subject:
@@ -962,33 +1161,167 @@ def _qualifies_for_hard_row(item: PipelineItem) -> tuple[str, str] | None:
     return resolve_employer(item.sender_email, item.subject, item.sender_name)
 
 
-def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplication]:
-    """Group high-confidence lifecycle mail into one row per real employer.
+@dataclass(frozen=True)
+class _Cluster:
+    """One application's worth of gated mail, before it becomes a row."""
 
-    Only messages that clear the precision gate (:func:`_qualifies_for_hard_row`)
-    contribute: at/above the 0.85 auto-file confidence, a real lifecycle
-    category, and a nameable employer. A company's status is the furthest stage
-    its *gated* mail reached (applied < assessment < interview < offer), with a
-    gated rejection as a terminal override. Uncertain mail never lands here — it
-    goes to :func:`collect_review_items` instead — so the board shows real rows,
-    not noise parsed out of job alerts.
+    company_token: str
+    company_display: str
+    req_id: str | None
+    role_token: str | None
+    role: str | None
+    items: list[PipelineItem]
 
-    Deterministic and DB-free — the same input always yields the same rows,
-    which is what makes the downstream upsert idempotent.
+
+def partition_applications(
+    items: Iterable[PipelineItem],
+) -> tuple[list[_Cluster], list[PipelineItem]]:
+    """Split gated mail into per-application clusters, plus what it cannot place.
+
+    This is the identity resolution the whole product rests on, and it is pure so
+    it can be reasoned about and tested without a database.
+
+    Within one employer, a message is placed by the first rule that fires:
+
+    1. its requisition id matches a cluster (the strongest signal — two Amazon
+       confirmations with different ids are two applications however similar
+       their titles read);
+    2. its normalized role token matches a cluster;
+    3. it names no role at all, and the employer has exactly ONE cluster — so it
+       joins that one. This is what keeps Roblox's separate email-verification
+       message (different sender, no shared role text, no shared thread) on the
+       same application as its confirmation, and it means behaviour changes only
+       for employers with several applications.
+
+    A role-less message at an employer with SEVERAL applications is returned in
+    the second element instead of being guessed at. Guessing here is not a cosmetic
+    error: attributing a rejection to the wrong one of four Amazon rows settles a
+    live application terminally and, because ``advance_application_status`` treats
+    terminal states as final, freezes it against every later interview or offer.
+    Those messages go to the review queue for the user to assign.
+
+    A role-less message at an employer with NO other cluster mints its own
+    ``(company, None)`` cluster — which is exactly the old behaviour, so an
+    employer that genuinely never names a role (Supabase, Twitch, Together AI in
+    the live corpus) still gets one honest row.
     """
 
-    grouped: dict[str, tuple[str, list[PipelineItem]]] = {}
+    by_company: dict[str, list[tuple[PipelineItem, str, str | None, str | None, str | None]]] = {}
     for item in items:
         resolved = _qualifies_for_hard_row(item)
         if resolved is None:
             continue
         token, display = resolved
-        if token not in grouped:
-            grouped[token] = (display, [])
-        grouped[token][1].append(item)
+        role = role_from_message(item.subject, item.snippet)
+        by_company.setdefault(token, []).append(
+            (item, display, extract_req_id(item.subject, item.snippet), normalize_role_token(role), role)
+        )
+
+    clusters: list[_Cluster] = []
+    unplaced: list[PipelineItem] = []
+
+    for token, entries in by_company.items():
+        display = entries[0][1]
+        keyed: list[_Cluster] = []
+        # Two passes, so placement never depends on arrival order: every message
+        # that carries its own identity mints or joins first, and only then do the
+        # anonymous ones look for a home.
+        #
+        # Scanning the clusters rather than keying a dict on ``req_id or
+        # role_token`` is deliberate. Those are two namespaces that would
+        # otherwise never meet: a confirmation carries the requisition id, the
+        # interview invite that follows carries only the title, and a dict keyed
+        # on "whichever we have" would file one application under two keys.
+        for item, _display, req_id, role_token, role in entries:
+            if req_id is None and role_token is None:
+                continue
+            match = next(
+                (
+                    c
+                    for c in keyed
+                    if (req_id is not None and c.req_id == req_id)
+                    or (role_token is not None and c.role_token == role_token)
+                ),
+                None,
+            )
+            if match is None:
+                keyed.append(
+                    _Cluster(
+                        company_token=token,
+                        company_display=_display,
+                        req_id=req_id,
+                        role_token=role_token,
+                        role=role,
+                        items=[item],
+                    )
+                )
+                continue
+            match.items.append(item)
+            # Each message may carry the half of the identity the other lacked.
+            keyed[keyed.index(match)] = replace(
+                match,
+                req_id=match.req_id or req_id,
+                role_token=match.role_token or role_token,
+                role=match.role or role,
+                items=match.items,
+            )
+
+        anonymous = [e[0] for e in entries if e[2] is None and e[3] is None]
+        if anonymous:
+            if not keyed:
+                keyed.append(
+                    _Cluster(
+                        company_token=token,
+                        company_display=display,
+                        req_id=None,
+                        role_token=None,
+                        role=None,
+                        items=list(anonymous),
+                    )
+                )
+            elif len(keyed) == 1:
+                keyed[0].items.extend(anonymous)
+            else:
+                unplaced.extend(anonymous)
+
+        clusters.extend(keyed)
+
+    return clusters, unplaced
+
+
+def unplaceable_message_ids(items: Iterable[PipelineItem]) -> set[str]:
+    """Message ids that name no role at an employer holding several applications.
+
+    :func:`collect_review_items` promotes these into the queue so the user can
+    say which application they belong to, rather than the pipeline picking one.
+    """
+
+    _clusters, unplaced = partition_applications(items)
+    return {item.message_id for item in unplaced}
+
+
+def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplication]:
+    """Group high-confidence lifecycle mail into one row per real APPLICATION.
+
+    Only messages that clear the precision gate (:func:`_qualifies_for_hard_row`)
+    contribute: at/above the 0.85 auto-file confidence, a real lifecycle
+    category, and a nameable employer. Identity within an employer comes from
+    :func:`partition_applications`. An application's status is the furthest stage
+    *its own* gated mail reached (applied < assessment < interview < offer), with
+    a gated rejection as a terminal override — per application, so one
+    requisition's rejection can no longer settle three live ones beside it.
+    Uncertain mail never lands here — it goes to :func:`collect_review_items`
+    instead — so the board shows real rows, not noise parsed out of job alerts.
+
+    Deterministic and DB-free — the same input always yields the same rows,
+    which is what makes the downstream upsert idempotent.
+    """
+
+    clusters, _unplaced = partition_applications(items)
 
     rolled: list[RolledApplication] = []
-    for token, (display, msgs) in grouped.items():
+    for cluster in clusters:
+        token, display, msgs = cluster.company_token, cluster.company_display, cluster.items
         categories = {m.category for m in msgs}
         has_rejection = "rejection" in categories
         max_rank = max((_STAGE_RANK.get(c, 0) for c in categories), default=1)
@@ -1008,14 +1341,7 @@ def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplicatio
         )
         last_activity = max(dated) if dated else None
 
-        role = next(
-            (
-                _role_from_subject(m.subject)
-                for m in msgs
-                if _role_from_subject(m.subject)
-            ),
-            None,
-        )
+        role = cluster.role
 
         refs = sorted(
             (_message_ref(m) for m in msgs),
@@ -1032,10 +1358,15 @@ def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplicatio
                 applied_at=applied_at,
                 last_activity=last_activity,
                 messages=tuple(refs),
+                req_id=cluster.req_id,
+                role_token=cluster.role_token,
             )
         )
 
-    return sorted(rolled, key=lambda r: r.company_token)
+    # Sorted by the full identity, not just the company: several applications at
+    # one employer must come back in a stable order across syncs or the upsert
+    # stops being idempotent.
+    return sorted(rolled, key=lambda r: (r.company_token, r.req_id or "", r.role_token or ""))
 
 
 def collect_review_items(items: Iterable[PipelineItem]) -> list[ReviewItem]:
@@ -1057,9 +1388,17 @@ def collect_review_items(items: Iterable[PipelineItem]) -> list[ReviewItem]:
     first overall.
     """
 
+    items = list(items)
+    # Gated mail that names no role at an employer holding several applications.
+    # It clears the precision gate, so the loop below would skip it as "already a
+    # real application row" — but there is no single row it belongs to, and
+    # picking one would settle the wrong application (see
+    # :func:`partition_applications`). Asking is the only honest move.
+    unplaceable = unplaceable_message_ids(items)
+
     best: dict[str, ReviewItem] = {}
     for item in items:
-        if _qualifies_for_hard_row(item) is not None:
+        if item.message_id not in unplaceable and _qualifies_for_hard_row(item) is not None:
             continue  # already a real application row
 
         is_needs_review = item.category == "needs_review"
@@ -1085,6 +1424,7 @@ def collect_review_items(items: Iterable[PipelineItem]) -> list[ReviewItem]:
             category=item.category,
             confidence=item.confidence,
             company_display=employer[1] if employer else None,
+            snippet=item.snippet,
         )
         key = item.thread_id or item.message_id
         current = best.get(key)

--- a/backend/jobtracker/database/models.py
+++ b/backend/jobtracker/database/models.py
@@ -279,6 +279,28 @@ class Application(TimestampMixin, table=True):
         description="Who removed it: 'user' (explicit dismiss) or 'resync'",
     )
 
+    # Identity WITHIN an employer. Until 2026-08-11 the identity of an
+    # application was its company alone, so four different Amazon requisitions
+    # applied for on one evening became one row and three real applications were
+    # invisible. These two are what tell them apart on the next sync:
+    # ``req_id`` is the employer's own requisition number when it prints one
+    # ("(ID: 3177934)"), ``role_token`` the normalized job title. Both NULL is
+    # legitimate and means the mail named no role anywhere — that employer keeps
+    # exactly one row, which is the honest floor rather than a guess.
+    #
+    # Deliberately NOT a unique constraint: re-applying to the same role after a
+    # rejection is a second application, and the resolver only ever matches
+    # against live rows.
+    req_id: Optional[str] = Field(
+        default=None,
+        index=True,
+        description="Employer's own requisition id for this application, if any",
+    )
+    role_token: Optional[str] = Field(
+        default=None,
+        description="Normalized job title, used to tell one employer's applications apart",
+    )
+
     # Relationships
     emails: list["Email"] = Relationship(back_populates="application")
     contacts: list["Contact"] = Relationship(back_populates="application")

--- a/backend/tests/test_application_identity.py
+++ b/backend/tests/test_application_identity.py
@@ -1,0 +1,380 @@
+"""One employer, several applications.
+
+Every case here is drawn from the owner's real mailbox on 2026-08-11, where the
+board showed three cards for eight genuine applications. The message shapes are
+reproduced verbatim (including the HTML entities Gmail snippets arrive carrying)
+because the whole design rests on what those templates actually contain, and a
+fixture written from memory would prove nothing about them.
+
+The assertions are deliberately about OUTCOMES a user would notice — how many
+rows, which role, whose rejection settles what — rather than about the internals
+that produce them, so a future refactor of the clustering is free to change
+shape without these needing edits.
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from jobtracker.cloud import pipeline as p
+
+BASE = datetime.datetime(2026, 8, 11, 2, 0)
+
+
+def item(
+    message_id: str,
+    subject: str,
+    sender: str,
+    snippet: str = "",
+    *,
+    category: str = "applied",
+    confidence: float = 0.95,
+    thread_id: str | None = None,
+    minutes: int = 0,
+) -> p.PipelineItem:
+    return p.PipelineItem(
+        message_id=message_id,
+        thread_id=thread_id,
+        subject=subject,
+        sender_email=sender,
+        sender_name=None,
+        received_at=BASE + datetime.timedelta(minutes=minutes),
+        category=category,
+        confidence=confidence,
+        snippet=snippet,
+    )
+
+
+AMAZON_SENDER = "noreply@mail.amazon.jobs"
+AMAZON_SUBJECT = "Thank you for Applying to Amazon!"
+
+
+def amazon(message_id: str, role: str, req: str, minutes: int = 0) -> p.PipelineItem:
+    """One real Amazon confirmation. All four share a subject AND a thread."""
+
+    return item(
+        message_id,
+        AMAZON_SUBJECT,
+        AMAZON_SENDER,
+        f"Amazon.jobs Hi Ayush, Thanks for applying to Amazon! We&#39;ve received "
+        f"your application for the {role} (ID: {req}) position. What happens next?",
+        thread_id="19fee99ce7d5feb8",
+        minutes=minutes,
+    )
+
+
+AMAZON_FOUR = [
+    amazon("a1", "Software Development Engineer - 2026 (US)", "3177934", 0),
+    amazon("a2", "Software Development Engineer – Embedded Systems 2026 (US)", "3183020", 2),
+    amazon("a3", "Software Development Engineer, AWS Data Services - 2026 (US)", "10414316", 3),
+    amazon("a4", "Software Development Engineer – Database 2026 (US)", "3130865", 4),
+]
+
+
+# --- the headline defect ------------------------------------------------------
+
+
+def test_four_amazon_requisitions_are_four_applications():
+    """The defect this whole change exists for.
+
+    Four different roles, applied for in one evening, sharing one subject line
+    and one Gmail thread. Grouping on the employer — or on the thread — makes
+    them one row and hides three real applications.
+    """
+
+    rolled = p.roll_up_applications(AMAZON_FOUR)
+
+    assert len(rolled) == 4
+    assert {r.req_id for r in rolled} == {"3177934", "3183020", "10414316", "3130865"}
+    assert all(r.company_display == "Amazon" for r in rolled)
+    # And each names its own role, which is the only thing distinguishing the
+    # four cards on the board.
+    assert len({r.role for r in rolled}) == 4
+
+
+def test_the_same_requisition_seen_twice_is_still_one_application():
+    """Idempotence: a re-scan must not grow the board."""
+
+    again = [amazon("a1-again", "Software Development Engineer - 2026 (US)", "3177934", 60)]
+    rolled = p.roll_up_applications(AMAZON_FOUR + again)
+
+    assert len(rolled) == 4
+    by_req = {r.req_id: r for r in rolled}
+    assert len(by_req["3177934"].messages) == 2
+
+
+def test_amazon_follow_up_naming_only_the_requisition_joins_its_own_row():
+    """"Keep track of your application" carries the id but not a clean title."""
+
+    follow_up = item(
+        "a5",
+        "Keep track of your application",
+        AMAZON_SENDER,
+        "Amazon.jobs Hi Ayush, Thank you for your interest in Software Development "
+        "Engineer – Database 2026 (US) (ID: 3130865). If you have completed the application:",
+        thread_id="19fedfd7036353f4",  # a DIFFERENT Gmail thread
+        minutes=90,
+    )
+    rolled = p.roll_up_applications(AMAZON_FOUR + [follow_up])
+
+    assert len(rolled) == 4
+    joined = next(r for r in rolled if r.req_id == "3130865")
+    assert {m.message_id for m in joined.messages} == {"a4", "a5"}
+
+
+# --- the case that forbids the naive "split on role" fix ----------------------
+
+
+def test_roblox_verification_mail_does_not_mint_a_second_application():
+    """Two messages, two senders, no shared role text, no shared thread — one job.
+
+    A key of ``(employer, role)`` alone splits this into two rows. The rule that
+    saves it is that role-less mail joins the employer's only application.
+    """
+
+    confirmation = item(
+        "r1",
+        "Thank you for applying to Roblox!",
+        "no-reply@roblox.com",
+        "Early Career Talent Hi Ayush, Thank you for applying to Roblox! We received "
+        "your application for the [2027] Software Engineer, Early Career role",
+    )
+    verification = item(
+        "r2",
+        "[Action Required] Your Roblox Application",
+        "assessment@email.roblox.com",
+        "Email Verification Hi Ayush, Thank you for submitting your application for a "
+        "position at Roblox! Please click here to verify your email address",
+        minutes=1,
+    )
+
+    rolled = p.roll_up_applications([confirmation, verification])
+
+    assert len(rolled) == 1
+    assert {m.message_id for m in rolled[0].messages} == {"r1", "r2"}
+
+
+def test_an_employer_that_names_no_role_keeps_exactly_one_row():
+    """Supabase confirms twice, two hours apart, naming no role either time.
+
+    Ambiguous by construction. One row is the honest floor — inventing two would
+    assert a distinction the mail does not make.
+    """
+
+    first = item(
+        "s1",
+        "Thanks for applying to Supabase",
+        "no-reply@ashbyhq.com",
+        "Hi Ayush, Thanks for applying to Supabase. We&#39;re really glad you&#39;re "
+        "interested in what we&#39;re building.",
+    )
+    second = item(
+        "s2",
+        "Thank you for applying to Supabase!",
+        "no-reply@ashbyhq.com",
+        "Hey Ayush, Thanks for your interest in a role with Supabase; we confirm your "
+        "application has been received.",
+        minutes=120,
+    )
+
+    rolled = p.roll_up_applications([first, second])
+
+    assert len(rolled) == 1
+    # "interest in a" is prose sitting between the anchors, not a job title. If
+    # it were accepted it would key an application and split this employer in two.
+    assert rolled[0].role is None
+    assert rolled[0].role_token is None
+
+
+# --- what a rejection may and may not settle ----------------------------------
+
+
+def test_one_requisitions_rejection_does_not_settle_the_other_three():
+    """The reason this is a correctness bug and not a display bug.
+
+    ``advance_application_status`` treats ``rejected`` as terminal, so a merged
+    row settled by one rejection silently discards every later interview and
+    offer for the other three requisitions.
+    """
+
+    rejection = amazon("a6", "Software Development Engineer – Database 2026 (US)", "3130865", 200)
+    rejection = p.PipelineItem(**{**rejection.__dict__, "category": "rejection"})
+
+    rolled = p.roll_up_applications(AMAZON_FOUR + [rejection])
+    by_req = {r.req_id: r.status for r in rolled}
+
+    assert by_req["3130865"] == "rejected"
+    assert by_req["3177934"] == "applied"
+    assert by_req["3183020"] == "applied"
+    assert by_req["10414316"] == "applied"
+
+
+def test_a_rejection_naming_no_role_is_asked_about_not_guessed():
+    """"Update on your application" names the company and nothing else.
+
+    With four live Amazon applications there is no way to know which one it
+    settles, and settling the wrong one freezes a live application permanently.
+    So it settles none of them and goes to the review queue for the user.
+    """
+
+    rejection = item(
+        "a7",
+        "Update on your Amazon application",
+        AMAZON_SENDER,
+        "Hi Ayush, Thank you for your interest in Amazon. After careful consideration "
+        "we will not be moving forward at this time.",
+        category="rejection",
+        minutes=300,
+    )
+    everything = AMAZON_FOUR + [rejection]
+
+    rolled = p.roll_up_applications(everything)
+    assert len(rolled) == 4
+    assert {r.status for r in rolled} == {"applied"}
+    assert all("a7" not in {m.message_id for m in r.messages} for r in rolled)
+
+    queued = {r.message_id for r in p.collect_review_items(everything)}
+    assert "a7" in queued
+
+
+def test_a_role_less_rejection_at_a_single_application_employer_still_settles_it():
+    """The same message must NOT be punted when there is nothing to confuse it with.
+
+    Sending every role-less rejection to the queue would make the product worse
+    for the overwhelmingly common case of one application per employer.
+    """
+
+    # A corporate sender, so the employer is nameable from the domain alone —
+    # a role-less rejection relayed by a shared ATS names no employer at all and
+    # is refused a step earlier, by `resolve_employer`.
+    confirmation = item(
+        "c1",
+        "Thank you for applying to DoorDash",
+        "no-reply@doordash.com",
+        "Hi Ayush, Thank you for applying to DoorDash&#39;s Software Engineer I, "
+        "Entry-Level position! We&#39;ve received your application",
+    )
+    rejection = item(
+        "c2",
+        "Update on your application",
+        "no-reply@doordash.com",
+        "Hi Ayush, we have decided not to move forward.",
+        category="rejection",
+        minutes=500,
+    )
+
+    rolled = p.roll_up_applications([confirmation, rejection])
+
+    assert len(rolled) == 1
+    assert rolled[0].status == "rejected"
+    assert {m.message_id for m in rolled[0].messages} == {"c1", "c2"}
+
+
+# --- role extraction ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("subject", "snippet", "expected"),
+    [
+        (
+            "Crusoe | Application Received",
+            "Hi Ayush, Thank you for applying to our role: Software Engineer I, Storage. "
+            "We appreciate your interest in joining the team!",
+            "Software Engineer I, Storage",
+        ),
+        (
+            "Thank you for applying to DoorDash",
+            "Hi Ayush, Thank you for applying to DoorDash&#39;s Software Engineer I, "
+            "Entry-Level (Graduation Date: Fall 2025-Summer 2026) position!",
+            "Software Engineer I, Entry-Level (Graduation Date: Fall 2025-Summer 2026)",
+        ),
+        (
+            "Thank you for applying to Anthropic",
+            "Hi Ayush, We appreciate you taking the time to submit an application for the "
+            "TPU Kernel Engineer position, and are delighted",
+            "TPU Kernel Engineer",
+        ),
+        (
+            "Thank you for applying with MotherDuck!",
+            "Hi Ayush, Thank you for your interest in joining the flock here at MotherDuck. "
+            "We appreciate your interest in the Software Engineer - Database position.",
+            "Software Engineer - Database",
+        ),
+        (
+            "Thanks for applying to Cursor!",
+            "Hi Ayush, Thank you for applying for the Software Engineer, Model Routing "
+            "&amp; Inference role at Cursor!",
+            "Software Engineer, Model Routing & Inference",
+        ),
+        # Names no role anywhere. Must stay None rather than become a guess.
+        (
+            "Thank you for applying to Twitch",
+            "Ayush, Thanks for applying to Twitch. Your application has been received "
+            "and we will review it right away.",
+            None,
+        ),
+    ],
+)
+def test_role_is_read_from_the_body_when_the_subject_does_not_carry_it(subject, snippet, expected):
+    assert p.role_from_message(subject, snippet) == expected
+
+
+def test_role_token_ignores_punctuation_drift():
+    """One employer wording its own title two ways is still one application."""
+
+    assert p.normalize_role_token("Software Engineer I, Storage") == p.normalize_role_token(
+        "Software Engineer I - Storage"
+    )
+    assert p.normalize_role_token("TPU Kernel Engineer") != p.normalize_role_token(
+        "Performance Engineer, Inference Systems"
+    )
+
+
+@pytest.mark.parametrize(
+    ("subject", "snippet", "expected"),
+    [
+        ("Thank you for Applying to Amazon!", "your application for the SDE (ID: 3177934) position", "3177934"),
+        ("Requisition ID: R-4821", "", "R-4821"),
+        ("Your application JR0093214", "", "JR0093214"),
+        # A bare year is not an id. Accepting one would merge every 2026 role at
+        # an employer into a single application.
+        ("Software Development Engineer - 2026 (US)", "", None),
+        ("Thanks for applying to Supabase", "We review every application carefully.", None),
+    ],
+)
+def test_requisition_ids_are_only_read_from_explicit_labels(subject, snippet, expected):
+    assert p.extract_req_id(subject, snippet) == expected
+
+
+# --- employer display names ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sender", "subject", "expected"),
+    [
+        # The careers subdomain is the right thing to trust and the wrong thing
+        # to print: this rendered "Twitchjobs" on the live board.
+        ("no-reply@twitchjobs.tv", "Thank you for applying to Twitch", "Twitch"),
+        # Title-casing a lowercase domain label cannot know where the intercap
+        # goes; the employer's own subject line can.
+        ("no-reply@doordash.com", "Thank you for applying to DoorDash", "DoorDash"),
+        ("jobs@ixl.com", "Thank you for applying to IXL Learning!", "IXL Learning"),
+    ],
+)
+def test_the_subject_spelling_of_an_employer_beats_its_domain(sender, subject, expected):
+    resolved = p.resolve_employer(sender, subject)
+    assert resolved is not None
+    assert resolved[1] == expected
+
+
+def test_a_company_merely_mentioned_in_a_subject_does_not_rename_the_relay():
+    """The agreement test is what keeps the subject from hijacking the name.
+
+    An ATS relay's subject can mention an employer the domain knows nothing
+    about; only a subject that AGREES with the domain may override its spelling.
+    """
+
+    resolved = p.resolve_employer("no-reply@us.greenhouse-mail.io", "Thank you for applying to Anthropic")
+    assert resolved is not None
+    assert resolved[1] == "Anthropic"

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -1,10 +1,10 @@
 {
   "$comment": "Recorded facts for README.md \u2014 figures that require executing something. Regenerate with `python3 scripts/readme_facts.py --record`, then apply with `--write`. Do not hand-edit: the point of this file is that these numbers have a command behind them.",
-  "recordedAt": "2026-08-10",
-  "machine": "Darwin-arm64, 3.14.4",
+  "recordedAt": "2026-08-11",
+  "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 405,
+      "value": 429,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,19 +12,19 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 55.02,
+      "value": 55.57,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 8817,
+      "value": 8947,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3966,
+      "value": 3975,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
-      "value": 80.9,
+      "value": 81.7,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageAuth": {
@@ -32,7 +32,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageDatabase": {
-      "value": 76.9,
+      "value": 77.0,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScriptsStatements": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 405,
+    "passed": 429,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
## The defect

One company could hold exactly one application per user — by construction, not by accident. `pipeline.roll_up_applications` grouped gated mail on the employer token, and `_find_application_by_token(...).first()` resolved it to a single row.

Reproduced on the owner's real mailbox against production `25e5ca8`:

| employer | real applications | rows on the board |
|---|---|---|
| Amazon | 4 (req 3177934, 3183020, 10414316, 3130865) | 1 |
| Anthropic | 2 (Performance Engineer Inference Systems, TPU Kernel Engineer) | 1 |
| Crusoe | 2 (SWE I Storage, SWE I DCIE) | 1 |

All four Amazon confirmations share the subject *"Thank you for Applying to Amazon!"* **and one Gmail thread** — so neither the subject nor the thread can tell them apart. The discriminating role and requisition id are in the message body, in a snippet the app was already storing and never reading.

### It was worse than a display problem

`roll_up_applications` gave a merged row the furthest stage *any* of that company's mail reached, with a rejection as a terminal override, and `advance_application_status` never moves a row out of a terminal state. So the first per-requisition Amazon rejection would have settled the merged row permanently and silently discarded every later interview or offer for the other three — the tracker asserting a live pipeline was dead, during an active search.

## The design

Identity is `(employer, requisition-id or role-token)`. `partition_applications` is the single, pure place that decides it. Within one employer a message is placed by the first rule that fires:

1. **requisition id** — the employer's own number, nothing outranks it;
2. **role token** — the normalized title, punctuation-insensitive;
3. **names no role, employer has exactly one application** → joins it.

Rule 3 is what forbids the naive "split on role" fix. Roblox sends a confirmation *and* an email-verification message from a **different sender**, with no shared role text and no shared thread — one application, two messages. Splitting on role makes it two rows.

A message that names no role at an employer with **several** applications is routed to the review queue rather than guessed at, because settling the wrong one of four Amazon rows freezes a live application.

An employer that genuinely never names a role anywhere (Supabase, Twitch, Together AI in the live corpus) still gets exactly one row. That is the honest floor, not a regression.

## Also fixed here, because identity depends on them

- **Roles are read from the body.** Every live row had `position = ""`; the role is in the snippet, not the subject.
- **`_persist_message_refs` no longer blanks a stored snippet or thread id** when a later pass carries none. That unconditional assignment is how mail returning through the review queue erased the snippet the role is extracted from — three live rows had lost theirs.
- **Employer display names prefer the employer's own spelling** when the sending domain agrees. `no-reply@twitchjobs.tv` rendered **"Twitchjobs"** on the live board while its subject said "applying to Twitch"; `doordash.com` rendered **"Doordash"**.
- **`.first()` is gone from all three resolution sites.** The review-classify and orphan-reconcile paths would otherwise file a user's own classification against an arbitrary sibling.

## Migration

`f1a2c9b73d40` adds two nullable columns and an index on `req_id`. **Migrations are applied by hand in this project — this must run before the deploy.**

No unique constraint: re-applying to the same requisition after a rejection is a second application, and the resolver only ever matches live rows.

Existing rows are adopted **in place** on the next sync — the employer's single identity-less row takes its earliest cluster and keeps its id, so contacts, interviews, linked mail and user corrections stay attached. Doing the split in SQL would have guessed the same thing with less information and would not have been undoable.

## Verification

- **429 backend tests pass** (405 before; 24 new).
- **The new assertions were mutation-tested.** Reverting the clustering to employer-only fails 7 of them and leaves the other 17 passing — so they measure the behaviour they claim to, rather than passing for free.
- `alembic check` reports no drift.
- The clustering was run over the owner's real 17-message corpus: 16 applications, correct roles and requisition ids, zero unplaceable messages, Roblox joined into one, Supabase and Twitch honestly role-less.

## Known follow-ups, deliberately not in this PR

- The **frontend** still renders one card per company and has no assign-to-application picker or split prompt. Being redesigned on a separate branch against this model.
- `purge_and_rebuild`'s `keep_tokens` check stays company-level. That is the conservative direction (keeps too much) and is safe; tightening it in the same change as the identity switch is how the previous re-sync data loss happened.
- `flag_follow_ups` still groups ghost nudges by company, so a rejection for role A can suppress the nudge for a genuinely ghosted role B.
