### PR TITLE
fix(sync): re-take an auto row's role when extraction improves

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-441%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-443%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,7 +373,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**441 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 415 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 441 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**443 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 417 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 443 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -893,7 +893,17 @@ async def upsert_applications_for_user(
                     and pipeline.matches_company_token(existing.company, r.company_token)
                 ):
                     existing.company = r.company_display
-            if r.role and not existing.position:
+            if r.role and (
+                not existing.position
+                # An auto row's role belongs to the sync, exactly as its company
+                # does. Filling only an EMPTY position means every improvement to
+                # role extraction reaches new rows and never the ones already on
+                # the board: "Path Robotics · interest in the Software Engineer,
+                # C#" survived the fix that stopped producing it, because the
+                # wrong string was already stored. A user-corrected or manual row
+                # keeps whatever the human wrote.
+                or (_is_auto_row(existing.source) and r.role != existing.position)
+            ):
                 existing.position = r.role
             if r.applied_at and existing.applied_date is None:
                 existing.applied_date = r.applied_at.date()

--- a/backend/tests/test_application_identity.py
+++ b/backend/tests/test_application_identity.py
@@ -643,3 +643,52 @@ def test_a_domain_that_disagrees_with_the_subject_keeps_its_own_token():
 
     assert resolved is not None
     assert resolved[0] == "stripe"
+
+
+async def test_a_stored_role_is_re_taken_when_extraction_improves(test_session):
+    """The same gap as the company name, one field over.
+
+    Filling only an EMPTY position means an extraction fix reaches new rows and
+    never the ones already on the board. "Path Robotics · interest in the
+    Software Engineer, C#" outlived the fix that stopped producing it.
+    """
+
+    row = stored("Path Robotics", source="gmail", role_token="software engineer c")
+    row.position = "interest in the Software Engineer, C#"
+    await _seed(test_session, [row])
+
+    rolled = p.RolledApplication(
+        company_token="path",
+        company_display="Path Robotics",
+        role="Software Engineer, C#",
+        status="applied",
+        applied_at=None,
+        last_activity=None,
+        role_token="software engineer c",
+    )
+    await apps.upsert_applications_for_user(test_session, USER, [rolled])
+
+    rows = await apps._company_rows(test_session, USER, "path")
+    assert [r.position for r in rows] == ["Software Engineer, C#"]
+
+
+async def test_a_role_the_user_wrote_is_never_overwritten(test_session):
+    """A hand-filed row's title is the human's, and the sync does not own it."""
+
+    row = stored("Path Robotics", source="manual", role_token="software engineer c")
+    row.position = "SWE (C#) — the one Dana referred me for"
+    await _seed(test_session, [row])
+
+    rolled = p.RolledApplication(
+        company_token="path",
+        company_display="Path Robotics",
+        role="Software Engineer, C#",
+        status="applied",
+        applied_at=None,
+        last_activity=None,
+        role_token="software engineer c",
+    )
+    await apps.upsert_applications_for_user(test_session, USER, [rolled])
+
+    rows = await apps._company_rows(test_session, USER, "path")
+    assert [r.position for r in rows] == ["SWE (C#) — the one Dana referred me for"]

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 441,
+      "value": 443,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 441,
+    "passed": 443,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
The same gap as #84, one field over.

`position` was only ever filled when it was **empty**:

```python
if r.role and not existing.position:
    existing.position = r.role
```

So every improvement to role extraction reached new rows and none of the ones already on the board.

Measured on the live board: after #85 stopped producing `interest in the Software Engineer, C#`, that string was **still there across three further rebuilds** — the wrong value was already stored, and the upsert had no reason to touch it. A fix that cannot reach the rows it was written for is not a fix.

An auto row's role belongs to the sync, exactly as its company does, so it is now re-taken when it differs. A manual or user-corrected row keeps whatever the human wrote — that is their record, not the sync's to rewrite.

This is the third instance of one shape tonight (**#84** company name, **#85** the extraction itself, this one the stored role), so it is worth naming: *a correction to a derivation only reaches rows created after it, unless the sync is told the field is its own.* Worth checking the remaining `and not existing.<field>` guards in `upsert_applications_for_user` against the same question — `applied_date` and `url` are both still fill-only, which is probably right for a date but arguable for a deep link.

443 tests pass (441 before). Two new, one per direction: the auto row is re-taken, the hand-written one is not.
