### PR TITLE
fix(pipeline): treat ats.rippling.com as a relay, not as the employer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-443%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-444%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,7 +373,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**443 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 417 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 443 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**444 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 418 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 444 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 

--- a/backend/jobtracker/cloud/pipeline.py
+++ b/backend/jobtracker/cloud/pipeline.py
@@ -98,6 +98,12 @@ ATS_RELAY_DOMAINS: frozenset[str] = frozenset(
         "avature",
         "phenom",
         "paradox",
+        # Rippling fronts other employers' careers mail from ats.rippling.com.
+        # Observed live: "Thank You for Applying to Supernova Technology" sent by
+        # no-reply@ats.rippling.com filed an application at *Rippling*, which is
+        # not a company the owner applied to. The sender display name already
+        # said "Supernova Technology"; the domain overrode it.
+        "rippling",
         "pageuppeople",
         "pageup",
         "jobs",

--- a/backend/tests/test_application_identity.py
+++ b/backend/tests/test_application_identity.py
@@ -692,3 +692,24 @@ async def test_a_role_the_user_wrote_is_never_overwritten(test_session):
 
     rows = await apps._company_rows(test_session, USER, "path")
     assert [r.position for r in rows] == ["SWE (C#) — the one Dana referred me for"]
+
+
+def test_an_ats_relay_subdomain_does_not_become_the_employer():
+    """Observed live: a "Rippling" row the owner never applied to.
+
+    "Thank You for Applying to Supernova Technology", sent by
+    no-reply@ats.rippling.com, filed an application at Rippling — the ATS — while
+    the sender display name said Supernova Technology all along. A relay's own
+    brand is never the employer.
+    """
+
+    resolved = p.resolve_employer(
+        "no-reply@ats.rippling.com",
+        "Thank You for Applying to Supernova Technology",
+        "Supernova Technology",
+    )
+
+    assert resolved is not None
+    token, display = resolved
+    assert token != "rippling"
+    assert display.startswith("Supernova")

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 443,
+      "value": 444,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 443,
+    "passed": 444,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
Spotted on the live board: a **"Rippling"** application the owner never made.

Its single email is *"Thank You for Applying to Supernova Technology"*, sent by `no-reply@ats.rippling.com`. Rippling is the applicant tracking system; Supernova Technology is the employer, and the sender display name said so all along. The domain brand won because `rippling` was not in `ATS_RELAY_DOMAINS`.

Adding it lets the existing relay branches do their job — the subject and the sender display name are consulted, and the row resolves to Supernova.

### The failure mode is worth naming, because this list will need extending again

An unrecognised relay does **not** degrade to "employer unknown". It confidently files an application at the ATS vendor, with full confidence and no signal that anything is off. Every SaaS company that also sells hiring software is a candidate for the same mistake, and each one produces a plausible-looking row for a company the user never applied to.

That asymmetry — unknown-relay fails *loud and wrong* rather than quiet and absent — is arguably the thing to fix rather than the list. A cheap check would be: when the domain brand resolves an employer but the sender display name names a *different* company, prefer the display name, or hold the message for review rather than picking. Not doing that here; noting it as the follow-up, because it needs its own evidence rather than being bolted onto a one-line list addition.

444 tests pass (443 before), the new one asserting the resolved token is not `rippling` and the display starts with Supernova.
