### PR TITLE
fix(web): the role on a card has to stay readable

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -849,6 +849,20 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
+ * Board column widths (components/dashboard/PipelineBoard.tsx). At desktop,
+ * space follows content: the component writes per-column tracks into
+ * `--board-cols` (populated 3fr, empty a compressed readable floor), because
+ * a real search is one heavy column and three near-empty ones — an even
+ * four-way split starves the only column that holds cards. Below `lg` the
+ * Tailwind sm:grid-cols-2 flow applies and this rule is inert.
+ * ------------------------------------------------------------------------- */
+@media (min-width: 64rem) {
+  .board-grid {
+    grid-template-columns: var(--board-cols, repeat(4, minmax(0, 1fr)));
+  }
+}
+
+/* ---------------------------------------------------------------------------
  * Board drag-and-drop (components/dashboard/PipelineBoard.tsx). The dragged
  * card dims in place; a column being hovered as a drop target raises its
  * border and washes its surface. Pure state styling — no keyframes, so there

--- a/apps/web/components/dashboard/ApplicationCard.tsx
+++ b/apps/web/components/dashboard/ApplicationCard.tsx
@@ -297,7 +297,17 @@ export function ApplicationCard({
                 </span>
               )}
             </span>
-            {role ? <span className="block truncate text-xs text-foreground">{role}</span> : null}
+            {/* The role WRAPS (two lines) instead of ellipsizing: a job title's
+                discriminating part is its tail — "…, AWS Data Services - 2026"
+                — which is exactly what a one-line truncate eats. Four real
+                Amazon roles measured 244–353px against a 198px box and
+                rendered as identical text. `title` is the floor, not the fix:
+                the board must read without hovering. */}
+            {role ? (
+              <span title={role} className="line-clamp-2 break-words text-xs text-foreground">
+                {role}
+              </span>
+            ) : null}
           </button>
         ) : (
           <div className="min-w-0">
@@ -309,7 +319,11 @@ export function ApplicationCard({
                 </span>
               )}
             </p>
-            {role ? <p className="truncate text-xs text-foreground">{role}</p> : null}
+            {role ? (
+              <p title={role} className="line-clamp-2 break-words text-xs text-foreground">
+                {role}
+              </p>
+            ) : null}
           </div>
         )}
         <div className="flex shrink-0 items-center gap-1">

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -46,7 +46,13 @@ function StaticApplicationCard({
           </span>
         )}
       </p>
-      {role ? <p className="truncate text-xs text-foreground">{role}</p> : null}
+      {/* Wraps, never ellipsizes — the role's tail is the discriminator (see
+          ApplicationCard). */}
+      {role ? (
+        <p title={role} className="line-clamp-2 break-words text-xs text-foreground">
+          {role}
+        </p>
+      ) : null}
       {sameCompanyCount > 0 && onFilterCompany ? (
         <button
           type="button"
@@ -178,6 +184,25 @@ export function PipelineBoard({
 
   const showSearch = applications.length > SEARCH_AFTER;
 
+  // --- Column widths: space follows content --------------------------------
+  // A real search's board is one heavy column and three near-empty ones, and
+  // an even four-way split hands three quarters of the width to "none yet"
+  // while the column holding every card is the narrowest it can be — which is
+  // how four real Amazon roles ended up ellipsized into identical text.
+  // Populated columns take 3fr, empty ones compress to a readable floor
+  // (desktop only — `.board-grid` in globals.css; narrower widths keep the
+  // stacked/two-up flow). The weight is binary (has cards / hasn't) and reads
+  // the UNFILTERED counts, so typing a search or dragging between two
+  // populated columns never reflows the widths; only genuinely emptying or
+  // populating a column does.
+  const boardCols = boardColumns(STAGES)
+    .map((column) =>
+      applications.some((app) => stageOf(shownStatus(app)) === column.key)
+        ? "minmax(0, 3fr)"
+        : "minmax(8rem, 1fr)",
+    )
+    .join(" ");
+
   return (
     <div className="space-y-3">
       {/* --- Board filters ------------------------------------------------- */}
@@ -225,7 +250,10 @@ export function PipelineBoard({
       ) : null}
 
       {/* --- Columns -------------------------------------------------------- */}
-      <div className="grid items-start gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <div
+        className="board-grid grid items-start gap-3 sm:grid-cols-2"
+        style={{ ["--board-cols" as string]: boardCols }}
+      >
         {boardColumns(STAGES).map((column) => {
           const items = filtered.filter((a) => stageOf(shownStatus(a)) === column.key);
           const isExpanded = expanded[column.key] === true;

--- a/apps/web/components/gmail/LastSynced.tsx
+++ b/apps/web/components/gmail/LastSynced.tsx
@@ -5,32 +5,30 @@ import { useEffect, useState } from "react";
 import {
   NOT_SYNCED_YET,
   absoluteInstant,
-  absoluteSyncLabel,
   relativeSyncLabel,
 } from "@/lib/gmail/sync-state";
 
 /**
  * "last synced 3 minutes ago" — the one place the sync instant is rendered.
  *
- * Hydration-safe by construction. Relative time is a function of `now`, and the
- * server's `now` is minutes stale by the time the browser hydrates, so
- * computing it during SSR (or in a `useState` initializer, which runs during
- * hydration) mismatches the server HTML — the class of mistake that produced
- * React #418 in production here.
+ * ONE format, everywhere: relative. This component used to server-render the
+ * absolute UTC form and swap to relative after mount (hydration-safe, but the
+ * live header was observed holding "last synced 2026-08-11 06:42 UTC" beside
+ * a rail reading "34 minutes ago" — same fact, two formats, one screen). Now
+ * nothing visible is rendered until the browser knows `now`: the server (and
+ * the client's hydration pass) emit the bare <time> shell, and the first
+ * effect fills in the relative label. That is hydration-safe by construction
+ * — both sides render identical empty content — and makes a stuck absolute
+ * form impossible, because the absolute string only ever appears in `title`
+ * (hover) and `dateTime` (machines).
  *
- * So the first render — server AND client — is the ABSOLUTE instant, which is a
- * pure function of the ISO string's characters and therefore identical in both.
- * Only after `useEffect` (which never runs on the server, and runs after
- * hydration has already committed) does the label become relative. The absolute
- * form stays reachable on hover via `title`, and the machine-readable instant
- * stays in `dateTime`.
- *
- * The minute ticker matters more than it looks: this chip lives in the app
+ * The minute ticker matters more than it looks: this renders in the app
  * shell, and a long-open tab that still reads "just now" an hour later is the
  * same lie the product told before it had any sync memory at all.
  */
 export function LastSynced({ at, className }: { at: string | null; className?: string }) {
-  const [label, setLabel] = useState(() => absoluteSyncLabel(at));
+  /** `null` until mounted — the server has no honest `now` to compute from. */
+  const [label, setLabel] = useState<string | null>(null);
 
   useEffect(() => {
     const tick = () => setLabel(relativeSyncLabel(at, Date.now()));

--- a/apps/web/components/shell/Sidebar.tsx
+++ b/apps/web/components/shell/Sidebar.tsx
@@ -90,9 +90,16 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
           </ul>
         </nav>
 
-        <div className="mt-5 px-3">
-          <RailPipeline pipeline={rail.pipeline} />
-        </div>
+        {/* The pipeline snapshot is for the pages that DON'T show the
+            pipeline (inbox, settings, import) — glanceable truth plus the
+            needs-review deep link. On /dashboard the real board is on screen,
+            and a miniature of it beside itself is the count-duplication this
+            redesign removed from the page; so here, it yields. */}
+        {isNavItemActive(pathname, "/dashboard") ? null : (
+          <div className="mt-5 px-3">
+            <RailPipeline pipeline={rail.pipeline} />
+          </div>
+        )}
       </div>
 
       <div className="shrink-0 border-t border-line-soft px-3 py-3">

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -75,6 +75,24 @@ test.describe("live demo (/demo)", () => {
     );
   });
 
+  test("the populated column claims the space empty ones don't use", async ({ page }) => {
+    // A real search is one heavy column and three near-empty ones. An even
+    // split starved the only column with cards until four real Amazon roles
+    // ellipsized into identical text; now space follows content at desktop.
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.goto("/demo");
+    const applied = await page.getByRole("region", { name: /applied — 10/i }).boundingBox();
+    const offered = await page.getByRole("region", { name: /offered — 0/i }).boundingBox();
+    expect(applied, "applied column renders").not.toBeNull();
+    expect(offered, "offered column renders").not.toBeNull();
+    expect(applied!.width).toBeGreaterThan(offered!.width * 1.5);
+
+    // And the full role is always reachable on the card itself: it wraps to
+    // two lines rather than ellipsizing its discriminating tail, with the
+    // complete text in `title` as the floor.
+    await expect(page.getByTitle("ML Engineer, Platform")).toBeVisible();
+  });
+
   test("a card moves between stages by drag, and by its select", async ({ page }) => {
     await page.goto("/demo");
     await expect(page.getByRole("region", { name: /interviewing — 1/i })).toBeVisible();


### PR DESCRIPTION
Found by looking at the live board with the owner's real data right after #83 deployed. It lands on exactly the thing the redesign existed to fix.

**Four Amazon cards rendered as visually identical text.** The role span was `white-space: nowrap` + `text-overflow: ellipsis` in a **198 px** box, and the real roles need 244–353 px:

| role | width needed |
|---|---|
| Software Development Engineer - 2026 (US) | 244 px |
| Software Development Engineer – Database 2026 (US) | 301 px |
| Software Development Engineer, AWS Data Services - 2026 (US) | 353 px |
| Software Development Engineer – Embedded Systems 2026 (US) | ~350 px |

All four clipped to "Software Development Engineer …", with no `title` attribute, so hovering revealed nothing either. A job title's discriminating part is its **tail** — the specialisation — which is precisely what a one-line ellipsis eats.

It was never a space shortage. At 1600 px the four stage columns split the width evenly while three of them are empty, so the one column holding every card was as narrow as it could be. That is the real shape of a job search: one heavy column, three near-empty.

### Two moves that compound

1. **Roles wrap** — `line-clamp-2 break-words` + `title={role}` on both card variants. The `title` is the floor, deliberately not the answer: the board has to be readable without hovering.
2. **Space follows content** — the board writes per-column grid tracks into a `--board-cols` custom property (populated `minmax(0, 3fr)`, empty `minmax(8rem, 1fr)`), applied by a `lg`-only rule so the two-up mobile flow is untouched. The weight is **binary** and reads **unfiltered** counts, so typing a search or dragging between two populated columns never reflows widths — only genuinely emptying or populating a column does, once.

On the owner's board this gives a ~558 px populated column at 1600 px, where the longest Amazon role fits on a **single** line.

**Measured, not eyeballed.** All four real Amazon strings were injected into live cards in the demo's *tighter* three-populated layout and every one rendered fully visible (`scrollHeight == clientHeight`). Worth recording that the first measurement was wrong and was replaced: canvas `measureText` against `clientWidth` is meaningless when the flex item shrinks to content, so capacity was re-measured from live DOM wrapping instead. Head-clipping was considered and rejected — unstable, odd-reading strings, and unnecessary once the column can breathe.

### Two shell items from the same look

- **`RailPipeline` no longer renders on `/dashboard`.** A miniature of the board, beside the board, is the same count duplication the redesign removed from the page. It stays on inbox/settings/import, where it is the only pipeline signal.
- **`LastSynced` renders one format everywhere — relative.** The header showed `last synced 2026-08-11 07:18 UTC` while the rail two inches away said "just now". Rather than guess at the cause (it needs a session to reproduce), the absolute string is gone from the visible tree entirely and lives only in `title`/`dateTime`; both surfaces use the same component, so they cannot diverge again.

One new e2e assertion: populated column > 1.5× an empty one at 1600 px, and the role `title` is present.
