### PR TITLE
fix(pipeline): a resolved employer must be able to find its own stored row

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-446%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-450%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,7 +373,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**446 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 420 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 446 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**450 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 421 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 450 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 

--- a/backend/jobtracker/cloud/pipeline.py
+++ b/backend/jobtracker/cloud/pipeline.py
@@ -1059,7 +1059,14 @@ def _corporate_identity(
     match = _SUBJECT_NAMES_EMPLOYER.search(subject or "")
     if match:
         named = _clean_company_display(match.group("name"))
-        token = _normalize_token(named).replace(" ", "")
+        # The FIRST normalized word, not the whole name space-stripped. Every
+        # other token in this module is a single word, and
+        # `matches_company_token` compares normalized names word-wise — so a
+        # concatenated "ixllearning" matches the stored "IXL Learning" under no
+        # rule at all. It cost the owner's board a fresh row per rebuild: the
+        # lookup never found the existing one, the upsert minted another, and the
+        # emptied predecessor was dismissed, forever.
+        token = _normalize_token(named).split(" ")[0]
         if token and (brand.startswith(token) or token.startswith(brand)):
             return token, named
     return brand, _brand_display(brand, sender_name)

--- a/backend/tests/test_application_identity.py
+++ b/backend/tests/test_application_identity.py
@@ -753,3 +753,36 @@ async def test_company_rows_puts_live_before_dismissed_across_both_queries(test_
     rows = await apps._company_rows(test_session, USER, "ixl")
 
     assert [r.company for r in rows] == ["IXL Learning", "IXL"]
+
+
+@pytest.mark.parametrize(
+    ("sender", "subject"),
+    [
+        ("jobs@ixl.com", "Thank you for applying to IXL Learning!"),
+        ("no-reply@twitchjobs.tv", "Thank you for applying to Twitch"),
+        ("no-reply@doordash.com", "Thank you for applying to DoorDash"),
+        ("careers@torc.ai", "Thank you for applying to Torc Robotics"),
+    ],
+)
+def test_a_resolved_employer_can_always_find_its_own_stored_row(sender, subject):
+    """The invariant that ties the two halves of identity together.
+
+    `_company_rows` finds a stored row by running `matches_company_token` over
+    its display name. If `resolve_employer` ever returns a token that does not
+    match the display it returned alongside it, the lookup misses its own row
+    and the upsert mints another — every sync, forever.
+
+    That is not hypothetical: a multi-word name was space-stripped into
+    "ixllearning", which matches the stored "IXL Learning" under no rule, and the
+    owner's board grew a fresh "IXL Learning" and "Torc Robotics" row on every
+    single rebuild.
+    """
+
+    resolved = p.resolve_employer(sender, subject)
+
+    assert resolved is not None
+    token, display = resolved
+    assert p.matches_company_token(display, token), (
+        f"resolve_employer returned token {token!r} for display {display!r}, "
+        "which cannot find its own row"
+    )

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 446,
+      "value": 450,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 446,
+    "passed": 450,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
**My own regression from #84**, caught by watching the live board rather than by any test.

When the employer's name is taken from its subject line, the match token was built by space-stripping the whole name — `"IXL Learning"` became `"ixllearning"`. Every other token in this module is a single word, and `matches_company_token` compares normalized names word-wise, so `"ixllearning"` matches the stored `"IXL Learning"` under **no rule at all**.

So the lookup never found the existing row. The upsert minted a fresh one, linked the mail to it, left the predecessor empty, and dismissed it as an auto row. Every rebuild. Forever.

The owner's board accumulated **eight `IXL Learning` rows and seven `Torc Robotics` rows in under two hours**, and none of the four PRs in between made it visible — including #89, which fixed a *different* cause of the same symptom and made this one look solved for one more rebuild.

```
id  84  created 06:34:24  dismissed 06:39:50
id  88  created 06:39:52  dismissed 06:40:37
id  90  created 06:40:38  dismissed 06:41:37
id  94  created 06:41:38  dismissed 06:41:57
id  95  created 06:41:58  live
id  99  created 07:42:44  dismissed 07:55:10
id 101  created 07:55:12  live, holds the mail
```

The token is now the **first normalized word**, which is what every other token in the module already is.

### The test asserts the invariant, not the fix

`matches_company_token(display, token)` must hold for whatever `resolve_employer` returns — checked across four real sender/subject pairs. That is the property whose absence caused this, and it is what would have caught it; a test of "IXL resolves to IXL Learning" would have passed throughout.

Mutation-tested: restoring the concatenation fails exactly the two multi-word cases and leaves the other 43 in the file green.

450 tests pass (446 before).

### Worth saying plainly

Three of tonight's PRs (#84, #89, this one) are the same shape: a change that was correct in isolation, unsafe in combination with another, and invisible to a suite that tested each half. The thing that found all three was looking at the production table after deploying — not the tests, and not the UI, which rendered the duplicates as perfectly ordinary cards.
