### PR TITLE
feat(web): motion, company sets, and signal on the dashboard

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { createServerApiClient } from "@/lib/api/server";
 import { AddApplicationForm } from "@/components/applications/AddApplicationForm";
 import { PipelineBoard } from "@/components/dashboard/PipelineBoard";
+import { PipelinePulse } from "@/components/dashboard/PipelinePulse";
 import { DashboardEmptyState, ForwardRoutes } from "@/components/dashboard/DashboardEmptyState";
 import { RetryLoadButton } from "@/components/dashboard/RetryLoadButton";
 import { ReviewQueue, type ReviewItem } from "@/components/dashboard/ReviewQueue";
@@ -24,6 +25,12 @@ import { getCurrentUser } from "@/lib/supabase/auth";
  * recent-activity feed are gone: each was a second (or sixth) rendering of a
  * number already on screen, and the classifier strip was CI provenance shown
  * to somebody trying to find a job.
+ *
+ * The pulse strip (`PipelinePulse`) is not those coming back: every cell on it
+ * is DERIVED signal the subtitle and the columns cannot express — filed-per-
+ * week momentum, the age distribution of open rows, and how much of the board
+ * the classifier built / is holding — each computed once, in `lib/dashboard/
+ * age.ts`, from the same rows the board renders.
  *
  * Data path unchanged: the counts come from the O(1) `GET
  * /applications/summary`, the board from one bounded page of
@@ -110,13 +117,13 @@ async function loadDashboard(): Promise<LoadState> {
   }
 }
 
-/** The page's one prose data line — its only rendering of the totals. */
-function buildSubtitle(summary: PipelineSummary, needsReview: number): string {
-  const reviewNote =
-    needsReview > 0 ? ` · ${needsReview} need${needsReview === 1 ? "s" : ""} review` : "";
+/** The page's one prose data line — its only rendering of the totals. The
+ *  needs-review count is NOT here anymore: the pulse strip's classifier cell
+ *  owns it (with the deep link), so the number renders once. */
+function buildSubtitle(summary: PipelineSummary): string {
   return `${summary.total} filed · ${summary.inMotion} in motion · ${summary.offers} offer${
     summary.offers === 1 ? "" : "s"
-  }${reviewNote}`;
+  }`;
 }
 
 export default async function DashboardPage() {
@@ -251,7 +258,7 @@ export default async function DashboardPage() {
 
   // --- Populated dashboard ---------------------------------------------------
   const { summary } = state;
-  const subtitle = buildSubtitle(summary, state.needsReview);
+  const subtitle = buildSubtitle(summary);
 
   // Only fetch the queue's rows when the summary says there is something to show.
   const reviewItems = state.needsReview > 0 ? await loadReviewQueue() : [];
@@ -266,6 +273,15 @@ export default async function DashboardPage() {
       <SyncBar subtitle={subtitle} gmail={gmail}>
         <AddApplicationForm compact />
       </SyncBar>
+
+      {/* The three signals the rows carry that the board can't show as
+          columns: momentum over time, how the open pipeline is ageing, and
+          what the classifier built/held (see PipelinePulse). */}
+      <PipelinePulse
+        applications={state.applications}
+        total={state.total}
+        needsReview={state.needsReview}
+      />
 
       {/* The in-app weekly digest — pref-gated, and only when there is a week
           to report. The review half of the old NotificationCues banner is gone:

--- a/apps/web/app/(app)/inbox/page.tsx
+++ b/apps/web/app/(app)/inbox/page.tsx
@@ -88,13 +88,16 @@ export default async function InboxPage() {
     const { configured, connected, email } = result.status;
 
     if (configured && connected) {
+      // The connected inbox is a data surface: it spans the shell's full
+      // column like the dashboard board does (the capped reading measure is
+      // for the prose/CTA states below). Header voice matches every tab —
+      // h1 + one mono line of state.
       return (
-        <section className="max-w-3xl space-y-6">
+        <section className="space-y-6">
           <header>
             <h1 className="text-2xl font-semibold tracking-tight text-strong">Classified inbox</h1>
-            <p className="mt-1 text-sm text-muted">
-              Mine your mail for your real pipeline. Pick a range and volume — every message gets one
-              verdict, and applications no one answered are flagged to follow up.
+            <p className="mt-1 font-mono text-xs text-dim">
+              read-only mine · one verdict per message · unanswered applications get flagged
             </p>
           </header>
           <InboxWorkbench email={email} />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -89,7 +89,11 @@
   --line: rgb(0 0 0 / 0.1);
   --line-soft: rgb(0 0 0 / 0.06);
   --line-strong: rgb(0 0 0 / 0.24);
-  --green: #16a34a;
+  /* Darkened from #16a34a, which measured 3.30:1 (APCA Lc 60) on white — a
+   * WCAG AA failure for every small green text use (the confidence
+   * percentages, "rebuild finished", the live dot's label). #15803d measures
+   * 5.02:1 / Lc 74 on white and 4.56:1 / Lc 68 on the paper surface-2. */
+  --green: #15803d;
   --amber: #b45309;
   --red: #dc2626;
   /* Ink counterpart of the dark ramp's #b3b9c2 — measured 9.93:1 on white,
@@ -824,26 +828,33 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
- * Application detail sheet (components/dashboard/ApplicationDetail.tsx) — the
- * side panel slides in from the right edge. Enhancement only: collapses to a
- * static, fully visible panel under prefers-reduced-motion; the content is
- * present either way (never gated on the animation).
+ * Pulse strip (components/dashboard/PipelinePulse.tsx) — the momentum bars
+ * rise from the baseline and the distribution segments grow left-to-right on
+ * mount, staggered, echoing the rail's `.rail-seg` entrance. Transform-only
+ * (the numbers beside them are the content), so nothing is ever hidden and
+ * both collapse to the fully-drawn state under prefers-reduced-motion.
  * ------------------------------------------------------------------------- */
-.sheet-panel {
-  animation: sheet-in 0.28s cubic-bezier(0.22, 1, 0.36, 1) both;
+.pulse-seg {
+  transform-origin: bottom;
+  animation: pulse-seg-in 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--i, 0) * 50ms);
 }
-@keyframes sheet-in {
+@keyframes pulse-seg-in {
   from {
-    opacity: 0;
-    transform: translateX(1.5rem);
+    transform: scaleY(0);
   }
   to {
-    opacity: 1;
-    transform: none;
+    transform: scaleY(1);
   }
 }
+.pulse-seg-x {
+  transform-origin: left;
+  animation: rail-seg-in 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--i, 0) * 70ms);
+}
 @media (prefers-reduced-motion: reduce) {
-  .sheet-panel {
+  .pulse-seg,
+  .pulse-seg-x {
     animation: none !important;
   }
 }
@@ -882,38 +893,7 @@ body {
   cursor: grabbing;
 }
 
-/* ---------------------------------------------------------------------------
- * Modal dialog (components/ui/Dialog.tsx) — a quick fade for the scrim and a
- * spring rise for the panel. Enhancement only: collapses to a static, fully
- * visible state under prefers-reduced-motion.
- * ------------------------------------------------------------------------- */
-.dialog-overlay {
-  animation: dialog-fade 0.16s ease both;
-}
-.dialog-panel {
-  animation: dialog-rise 0.22s cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-@keyframes dialog-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes dialog-rise {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.985);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-@media (prefers-reduced-motion: reduce) {
-  .dialog-overlay,
-  .dialog-panel {
-    animation: none !important;
-  }
-}
+/* Modal/sheet motion note: the Dialog's scrim fade, panel rise and the detail
+ * sheet's slide (plus their exits) live in components/ui/Dialog.tsx via the
+ * motion library now — one implementation for enter AND exit, collapsed to
+ * instant under prefers-reduced-motion there (`useReducedMotion`). */

--- a/apps/web/app/import/page.tsx
+++ b/apps/web/app/import/page.tsx
@@ -35,7 +35,13 @@ export default async function ImportPage() {
 
   const intro = (
     <div className="space-y-3">
-      <h1 className="text-2xl font-semibold tracking-tight text-strong">Import your mail</h1>
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-strong">Import your mail</h1>
+        {/* Header voice shared by every tab: h1 + one mono line of state. */}
+        <p className="mt-1 font-mono text-xs text-dim">
+          on-device · classified in your browser · nothing is uploaded
+        </p>
+      </header>
       <p className="max-w-2xl text-muted">
         Classify your own job-search mail without connecting Gmail and without signing in. Export
         your mail from <span className="text-strong">Google Takeout</span> (or drop a single{" "}

--- a/apps/web/components/dashboard/ApplicationCard.tsx
+++ b/apps/web/components/dashboard/ApplicationCard.tsx
@@ -4,9 +4,11 @@ import { ExternalLink, Loader2, TriangleAlert, Undo2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 
+import { FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { RowActionsMenu, type RowMenuItem } from "@/components/dashboard/RowActionsMenu";
 import { cardQualifier } from "@/lib/dashboard/board";
-import { filedAt, shortDate } from "@/lib/dashboard/dates";
+import { todayISO } from "@/lib/dashboard/age";
+import { filedAt } from "@/lib/dashboard/dates";
 import {
   CANCEL_LABEL,
   DELETE_CONFIRM_LABEL,
@@ -59,6 +61,7 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
 export function ApplicationCard({
   app,
   columnLabel,
+  today = todayISO(),
   onOpenDetail,
   sameCompanyCount = 0,
   onFilterCompany,
@@ -70,19 +73,23 @@ export function ApplicationCard({
   app: Application;
   /** The heading of the column this card is rendered in (see `board.ts`). */
   columnLabel?: string;
+  /** Today's UTC calendar day — the board threads one read of the clock down
+   *  so every card's age tag derives from the same instant. */
+  today?: string;
   /** Opens the detail sheet (the mail behind this card). */
   onOpenDetail?: (app: Application) => void;
   /**
    * How many OTHER applications share this company. A card is an application,
    * not a company — one employer can hold several — so this is a light
-   * affordance ("3 more at Amazon"), never a grouping.
+   * affordance ("+3 at Amazon"), never a merge. The board passes 0 while its
+   * active filter already IS this company.
    */
   sameCompanyCount?: number;
-  /** Filters the board to this card's company. */
+  /** Filters the board to this card's company (opens the set view). */
   onFilterCompany?: (company: string) => void;
   /** True while this card is the one being dragged. */
   dragging?: boolean;
-  onDragStart?: (event: React.DragEvent<HTMLLIElement>) => void;
+  onDragStart?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd?: () => void;
   /** How mutations reach data — the live proxy by default, fixtures on /demo. */
   transport?: BoardTransport;
@@ -232,7 +239,7 @@ export function ApplicationCard({
   // --- Pending removal: the row is still here, and one click keeps it --------
   if (removalPending) {
     return (
-      <li className="rounded-lg border border-dashed border-line bg-surface-2/60 p-3">
+      <div className="rounded-lg border border-dashed border-line bg-surface-2/60 p-3">
         <p role="status" className="font-mono text-[11px] leading-snug text-muted">
           {removalPendingMessage(app.company, secondsLeft ?? 0)}
         </p>
@@ -248,7 +255,7 @@ export function ApplicationCard({
           <Undo2 className="h-3.5 w-3.5" aria-hidden />
           {UNDO_LABEL}
         </button>
-      </li>
+      </div>
     );
   }
 
@@ -256,18 +263,18 @@ export function ApplicationCard({
   // WHICH of the two happened — one is still on disk, the other is gone. -----
   if (removed) {
     return (
-      <li className="rounded-lg border border-dashed border-line-soft bg-surface-2/40 p-3">
+      <div className="rounded-lg border border-dashed border-line-soft bg-surface-2/40 p-3">
         <p role="status" className="font-mono text-[11px] text-dim">
           {removed === "deleted" ? deletedMessage(app.company) : removedMessage(app.company)}
         </p>
-      </li>
+      </div>
     );
   }
 
   const role = app.position.trim();
 
   return (
-    <li
+    <div
       aria-busy={busy !== null}
       draggable={onDragStart ? true : undefined}
       onDragStart={onDragStart}
@@ -340,14 +347,7 @@ export function ApplicationCard({
       </div>
 
       {sameCompanyCount > 0 && onFilterCompany ? (
-        <button
-          type="button"
-          onClick={() => onFilterCompany(app.company)}
-          aria-label={`Show all applications at ${app.company}`}
-          className="mt-1 font-mono text-[10px] text-dim underline-offset-2 hover:text-strong hover:underline"
-        >
-          {sameCompanyCount} more at {app.company} →
-        </button>
+        <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
       ) : null}
 
       <div className="mt-2 flex items-center justify-between gap-2">
@@ -368,7 +368,7 @@ export function ApplicationCard({
             </option>
           ))}
         </select>
-        <span className="tabular font-mono text-[10px] text-dim">{shortDate(filed)}</span>
+        <FiledStamp filed={filed} status={shownStatus} today={today} />
       </div>
 
       {busy === "status" || optimistic ? (
@@ -444,6 +444,6 @@ export function ApplicationCard({
           <span>{error}</span>
         </p>
       ) : null}
-    </li>
+    </div>
   );
 }

--- a/apps/web/components/dashboard/ApplicationDetail.tsx
+++ b/apps/web/components/dashboard/ApplicationDetail.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Dialog } from "@/components/ui/Dialog";
+import { AUTO_FILE_GATE, GateMeter } from "@/components/viz/GateMeter";
 import { filedAt, longDate, shortDate } from "@/lib/dashboard/dates";
 import {
   readApplicationDetail,
@@ -66,10 +67,24 @@ function TrailMessage({ message, isLast }: { message: DetailData["messages"][num
       </div>
       <p className="truncate text-xs text-muted">{sender}</p>
       {meta ? (
+        // The verdict, in the DecisionTrace's vocabulary: category, then the
+        // confidence drawn against the 0.85 gate — green cleared it, amber
+        // waited for a human. The number stays as the accessible value.
         <p className="mt-0.5 flex items-center gap-2 font-mono text-[10px] text-dim">
           {meta.label}
           {typeof message.confidence === "number" ? (
-            <span className="tabular">{pct(message.confidence)}</span>
+            <>
+              <GateMeter confidence={message.confidence} className="w-12" />
+              <span
+                className="tabular"
+                style={{
+                  color:
+                    message.confidence >= AUTO_FILE_GATE ? "var(--green)" : "var(--amber)",
+                }}
+              >
+                {pct(message.confidence)}
+              </span>
+            </>
           ) : null}
         </p>
       ) : null}
@@ -214,22 +229,29 @@ export function ApplicationDetail({
     return () => window.clearTimeout(id);
   }, [app, load]);
 
-  if (!app) return null;
+  // The card last inspected, retained through close: the Dialog's exit
+  // animation plays over real content instead of a blank panel (guarded
+  // render-adjustment — the same pattern the board's optimistic overlay uses).
+  const [shown, setShown] = useState<Application | null>(app);
+  if (app && app !== shown) setShown(app);
 
-  const shownStatus = optimistic ?? app.status;
+  if (!shown) return null;
+  const active = shown;
+
+  const shownStatus = optimistic ?? active.status;
   const stage = STAGES.find((s) => s.key === stageOf(shownStatus))!;
-  const role = app.position.trim();
+  const role = active.position.trim();
 
   async function onStageChange(next: string) {
-    if (!app || next === shownStatus) return;
+    if (next === shownStatus) return;
     setStageError(null);
     setOptimistic(next);
     setStageBusy(true);
-    const result = await transport.changeStatus(app.id, next);
+    const result = await transport.changeStatus(active.id, next);
     setStageBusy(false);
     if (!result.ok) {
       setOptimistic(null);
-      setStageError(statusChangeFailure(next, app.status, result.detail));
+      setStageError(statusChangeFailure(next, active.status, result.detail));
       return;
     }
     router.refresh();
@@ -237,21 +259,21 @@ export function ApplicationDetail({
 
   return (
     <Dialog
-      open
+      open={app !== null}
       onClose={onClose}
       variant="sheet"
-      title={app.company}
+      title={active.company}
       description={role || "role not captured yet"}
     >
       <div className="space-y-5">
         {/* --- The row's own facts + the working stage control ------------- */}
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <div className="flex items-center gap-2">
-            <label className="sr-only" htmlFor={`detail-status-${app.id}`}>
-              Change stage for {app.company}
+            <label className="sr-only" htmlFor={`detail-status-${active.id}`}>
+              Change stage for {active.company}
             </label>
             <select
-              id={`detail-status-${app.id}`}
+              id={`detail-status-${active.id}`}
               value={statusSelectValue(shownStatus)}
               disabled={stageBusy}
               onChange={(e) => void onStageChange(e.target.value)}
@@ -268,10 +290,10 @@ export function ApplicationDetail({
               <Loader2 className="h-3.5 w-3.5 animate-spin text-dim motion-reduce:animate-none" aria-hidden />
             ) : null}
           </div>
-          <span className="tabular font-mono text-[11px] text-dim">filed {longDate(filedAt(app))}</span>
-          {app.url ? (
+          <span className="tabular font-mono text-[11px] text-dim">filed {longDate(filedAt(active))}</span>
+          {active.url ? (
             <a
-              href={app.url}
+              href={active.url}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 font-mono text-[11px] text-dim underline-offset-2 hover:text-strong hover:underline"
@@ -292,9 +314,9 @@ export function ApplicationDetail({
           </p>
         ) : null}
 
-        {app.notes ? (
+        {active.notes ? (
           <p className="rounded-lg border border-line-soft bg-surface-2 p-3 text-[12px] leading-relaxed text-muted">
-            {app.notes}
+            {active.notes}
           </p>
         ) : null}
 
@@ -311,7 +333,7 @@ export function ApplicationDetail({
               <p className="text-xs text-strong">Couldn&apos;t load the mail behind this card.</p>
               <button
                 type="button"
-                onClick={() => void load(app.id)}
+                onClick={() => void load(active.id)}
                 className="mt-2 rounded border border-line px-2 py-1 font-mono text-[11px] text-foreground transition-colors hover:border-line-strong hover:text-strong"
               >
                 try again
@@ -336,8 +358,8 @@ export function ApplicationDetail({
 
         {state.kind === "ready" ? (
           <SplitPrompt
-            applicationId={app.id}
-            company={app.company}
+            applicationId={active.id}
+            company={active.company}
             candidates={state.detail.splitCandidates}
             onSplit={() => {
               onClose();
@@ -346,9 +368,9 @@ export function ApplicationDetail({
           />
         ) : null}
 
-        {app.source ? (
+        {active.source ? (
           <p className="border-t border-line-soft pt-3 font-mono text-[10px] text-dim">
-            source · {app.source === "gmail" ? "filed automatically from gmail" : app.source}
+            source · {active.source === "gmail" ? "filed automatically from gmail" : active.source}
           </p>
         ) : null}
       </div>

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Layers } from "lucide-react";
+
+import { QUIET_AFTER_DAYS, daysBetween } from "@/lib/dashboard/age";
+import { shortDate } from "@/lib/dashboard/dates";
+import { stageOf } from "@/lib/dashboard/summary";
+
+/**
+ * The small shared pieces of a board card's anatomy, used by both the
+ * interactive `ApplicationCard` and the read-only demo/sample card so the two
+ * can never drift apart visually.
+ */
+
+/**
+ * The card's date stamp, now carrying the ageing signal: an applied-stage row
+ * ≥ {@link QUIET_AFTER_DAYS} days old with no stage movement gets an amber
+ * "quiet Nd" tag — the same threshold the pulse strip counts, so the board and
+ * the strip always agree on what "quiet" means. Other stages show the date
+ * alone: their filed date says nothing honest about how stale the *contact*
+ * is, so no claim is made.
+ */
+export function FiledStamp({
+  filed,
+  status,
+  today,
+}: {
+  /** ISO date/timestamp the card treats as its filed moment (`filedAt`). */
+  filed: string;
+  status: string;
+  /** `todayISO()` — computed once per board render, threaded down. */
+  today: string;
+}) {
+  const age = daysBetween(filed, today);
+  const quiet = stageOf(status) === "applied" && age !== null && age >= QUIET_AFTER_DAYS;
+  return (
+    <span className="tabular font-mono text-[10px] text-dim">
+      {shortDate(filed)}
+      {quiet ? (
+        <span className="text-review" title={`filed ${age} days ago and still at applied`}>
+          {" "}
+          · quiet {age}d
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * The same-company affordance: "+N at Amazon" opens the employer's set view
+ * (the board filters to the company and the `CompanyBand` names the set).
+ * The accessible name stays "Show all applications at …" — the contract the
+ * board's tests and muscle memory rely on. The caller suppresses it while the
+ * active filter already IS this company (rendering "3 more at Amazon" inside
+ * Amazon's own set view was the bug).
+ */
+export function SameCompanyChip({
+  company,
+  count,
+  onFilter,
+}: {
+  company: string;
+  /** How many OTHER applications share the company. */
+  count: number;
+  onFilter: (company: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onFilter(company)}
+      aria-label={`Show all applications at ${company}`}
+      className="mt-1.5 inline-flex items-center gap-1 rounded border border-line-soft px-1.5 py-0.5 font-mono text-[10px] text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+    >
+      <Layers className="h-3 w-3" aria-hidden />+{count} at {company}
+    </button>
+  );
+}

--- a/apps/web/components/dashboard/CompanyBand.tsx
+++ b/apps/web/components/dashboard/CompanyBand.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Layers, X } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+
+import { filedAt, shortDate } from "@/lib/dashboard/dates";
+import { STAGES, stageOf, type Application } from "@/lib/dashboard/summary";
+
+/**
+ * The employer-as-a-set header. When the board is filtered to one company,
+ * this band names the set the cards below now form: how many applications the
+ * employer holds, how they sit across the stages, and the span they were filed
+ * over. Four Amazon applications stop being four unrelated cards — the board
+ * gathers them (the cards glide together via the shared layout animation) and
+ * this band states what the set is.
+ *
+ * Facts are computed from the company's FULL row set (never the search-
+ * narrowed one), so the band describes the employer even while a search
+ * narrows what is visible. The clear control carries the same accessible name
+ * the old filter chip did ("Stop filtering by …"), so the affordance's
+ * contract is unchanged.
+ */
+export function CompanyBand({
+  company,
+  apps,
+  statusOf,
+  onClear,
+}: {
+  company: string;
+  /** Every board row at this company, unfiltered. */
+  apps: Application[];
+  /** Status resolver — the board passes its optimistic-overlay-aware one. */
+  statusOf: (app: Application) => string;
+  onClear: () => void;
+}) {
+  const reduceMotion = useReducedMotion();
+
+  const byStage = STAGES.map((stage) => ({
+    stage,
+    count: apps.filter((app) => stageOf(statusOf(app)) === stage.key).length,
+  })).filter(({ count }) => count > 0);
+
+  const filedDates = apps.map((app) => filedAt(app)).sort();
+  const earliest = filedDates[0];
+  const latest = filedDates[filedDates.length - 1];
+  const span =
+    apps.length > 1 && shortDate(earliest) !== shortDate(latest)
+      ? `filed ${shortDate(earliest)} – ${shortDate(latest)}`
+      : `filed ${shortDate(latest)}`;
+
+  return (
+    <motion.section
+      aria-label={`All applications at ${company}`}
+      data-testid="company-band"
+      initial={reduceMotion ? false : { opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-line-strong bg-surface px-4 py-3"
+    >
+      <Layers className="h-4 w-4 shrink-0 text-muted" aria-hidden />
+      <div className="min-w-0">
+        <p className="truncate text-base font-medium leading-tight text-strong">{company}</p>
+        <p className="font-mono text-[11px] text-dim">
+          {apps.length} application{apps.length === 1 ? "" : "s"} · {span}
+        </p>
+      </div>
+      <ul className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1">
+        {byStage.map(({ stage, count }) => (
+          <li key={stage.key} className="flex items-center gap-1.5 font-mono text-[11px]">
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: stage.color }}
+            />
+            <span className="text-muted">{stage.label}</span>
+            <span className="tabular text-strong">{count}</span>
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={onClear}
+        aria-label={`Stop filtering by ${company}`}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-line px-3 py-1 font-mono text-[11px] text-strong transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+      >
+        clear
+        <X className="h-3 w-3" aria-hidden />
+      </button>
+    </motion.section>
+  );
+}

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { Search } from "lucide-react";
+import { LayoutGroup, motion, useReducedMotion } from "motion/react";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { ApplicationCard } from "@/components/dashboard/ApplicationCard";
 import { ApplicationDetail } from "@/components/dashboard/ApplicationDetail";
+import { FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
+import { CompanyBand } from "@/components/dashboard/CompanyBand";
+import { todayISO } from "@/lib/dashboard/age";
 import { boardColumns, cardQualifier } from "@/lib/dashboard/board";
-import { filedAt, shortDate } from "@/lib/dashboard/dates";
+import { filedAt } from "@/lib/dashboard/dates";
 import { type Application, STAGES, stageOf, type StageKey } from "@/lib/dashboard/summary";
 import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transport";
 
@@ -21,11 +25,13 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
 function StaticApplicationCard({
   app,
   columnLabel,
+  today,
   sameCompanyCount = 0,
   onFilterCompany,
 }: {
   app: Application;
   columnLabel: string;
+  today: string;
   sameCompanyCount?: number;
   onFilterCompany?: (company: string) => void;
 }) {
@@ -34,7 +40,7 @@ function StaticApplicationCard({
   const filed = filedAt(app);
   const role = app.position.trim();
   return (
-    <li
+    <div
       className="rounded-lg border border-line-soft bg-surface-2 p-3 transition-colors hover:border-line-strong"
       style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
     >
@@ -54,18 +60,13 @@ function StaticApplicationCard({
         </p>
       ) : null}
       {sameCompanyCount > 0 && onFilterCompany ? (
-        <button
-          type="button"
-          onClick={() => onFilterCompany(app.company)}
-          aria-label={`Show all applications at ${app.company}`}
-          className="mt-1 font-mono text-[10px] text-dim underline-offset-2 hover:text-strong hover:underline"
-        >
-          {sameCompanyCount} more at {app.company} →
-        </button>
+        <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
       ) : null}
       {app.notes && <p className="mt-1.5 line-clamp-2 text-[11px] leading-snug text-dim">{app.notes}</p>}
-      <p className="mt-2 font-mono text-[10px] text-dim">filed {shortDate(filed)}</p>
-    </li>
+      <p className="mt-2">
+        <FiledStamp filed={filed} status={app.status} today={today} />
+      </p>
+    </div>
   );
 }
 
@@ -75,8 +76,20 @@ function StaticApplicationCard({
  * A card is an APPLICATION, not a company: one employer can hold several cards
  * (four Amazon roles in one evening is the proven case), they can sit in
  * different columns simultaneously, and the role line is the discriminator.
- * Company stays an attribute — the only company-level affordance is the light
- * "N more at Amazon" link on a card, which filters the board.
+ * Company stays an attribute — the company-level affordances are the "+N at
+ * Amazon" chip on a card and the set view it opens: the board filters to the
+ * employer and a `CompanyBand` names the set (count, stage spread, filing
+ * span). While that filter is active the chip is suppressed — "3 more at
+ * Amazon" inside Amazon's own set view was a bug, not information.
+ *
+ * Motion (the `motion` library): every card cell is a `motion.li` with a
+ * shared `layoutId`, so search/filter changes glide survivors into place, a
+ * card dropped (or selected) into another column visibly travels there, and
+ * clearing a filter gathers the board back. Entrances only run for cards that
+ * appear AFTER hydration (`entering` below) — server HTML is never hidden
+ * behind an animation — exits are instant (a filter must feel like a filter,
+ * not a curtain call), and `useReducedMotion` collapses the whole layer to
+ * static rendering.
  *
  * Density rules, deliberately without a nested scroller: the page is the one
  * scroll context. A tall column shows its first {@link COLLAPSED_COUNT} cards
@@ -103,6 +116,35 @@ const COLLAPSED_COUNT = 8;
 /** Below this many rows, search would be chrome without a job. */
 const SEARCH_AFTER = 5;
 
+/**
+ * One board cell: the layout-animated `li` around a card. `layoutId` is what
+ * lets a card travel between columns as one continuous element; `entering`
+ * gates the fade-in to post-hydration appearances only.
+ */
+function BoardCell({
+  id,
+  entering,
+  children,
+}: {
+  id: number;
+  entering: boolean;
+  children: ReactNode;
+}) {
+  const reduceMotion = useReducedMotion();
+  if (reduceMotion) return <li>{children}</li>;
+  return (
+    <motion.li
+      layout
+      layoutId={`app-${id}`}
+      initial={entering ? { opacity: 0, y: 6 } : false}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+    >
+      {children}
+    </motion.li>
+  );
+}
+
 export function PipelineBoard({
   applications,
   interactive = true,
@@ -123,6 +165,17 @@ export function PipelineBoard({
   /** Optimistic overlay: id → the status a drop just chose, until the server confirms. */
   const [pendingMoves, setPendingMoves] = useState<Record<number, string>>({});
   const [moveError, setMoveError] = useState<string | null>(null);
+  /** False for the server-rendered pass — entrance animations start only after
+   *  hydration, so no card is ever server-rendered invisible. Deferred off the
+   *  effect body (house rule — no synchronous setState in an effect). */
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    const id = window.setTimeout(() => setHydrated(true), 0);
+    return () => window.clearTimeout(id);
+  }, []);
+
+  /** One clock read per render — every card's age tag derives from it. */
+  const today = todayISO();
 
   // Server data caught up with an optimistic move → drop the overlay entry and
   // let the row's own status speak. Render-adjustment (guarded, so it settles
@@ -137,7 +190,7 @@ export function PipelineBoard({
     setPendingMoves(next);
   }
 
-  /** How many OTHER cards share each company — drives the "N more at" link. */
+  /** How many OTHER cards share each company — drives the "+N at" chip. */
   const companyCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const app of applications) {
@@ -155,6 +208,20 @@ export function PipelineBoard({
     if (q !== "" && !`${app.company} ${app.position}`.toLowerCase().includes(q)) return false;
     return true;
   });
+
+  /** The active employer's FULL set — what the band describes. */
+  const companySet =
+    companyFilter !== null
+      ? applications.filter((app) => app.company === companyFilter)
+      : null;
+
+  /**
+   * The chip is suppressed for the company the board is already filtered to —
+   * "N more at Amazon" while looking at exactly Amazon's set was the bug this
+   * argument exists to keep fixed.
+   */
+  const sameCompanyCount = (app: Application) =>
+    companyFilter === app.company ? 0 : (companyCounts.get(app.company) ?? 1) - 1;
 
   async function moveTo(appId: number, stageKey: StageKey) {
     const app = applications.find((a) => a.id === appId);
@@ -206,7 +273,7 @@ export function PipelineBoard({
   return (
     <div className="space-y-3">
       {/* --- Board filters ------------------------------------------------- */}
-      {showSearch || companyFilter !== null ? (
+      {showSearch || filterActive ? (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           {showSearch ? (
             <div className="relative flex-1 basis-56">
@@ -224,23 +291,22 @@ export function PipelineBoard({
               />
             </div>
           ) : null}
-          {companyFilter !== null ? (
-            <button
-              type="button"
-              onClick={() => setCompanyFilter(null)}
-              aria-label={`Stop filtering by ${companyFilter}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-line-strong px-3 py-1 font-mono text-[11px] text-strong transition-colors hover:border-line"
-            >
-              {companyFilter}
-              <span aria-hidden>×</span>
-            </button>
-          ) : null}
           {filterActive ? (
             <span className="font-mono text-[11px] text-dim" role="status">
               {filtered.length} of {applications.length} shown
             </span>
           ) : null}
         </div>
+      ) : null}
+
+      {/* --- The employer's set, named ------------------------------------- */}
+      {companyFilter !== null && companySet !== null ? (
+        <CompanyBand
+          company={companyFilter}
+          apps={companySet}
+          statusOf={shownStatus}
+          onClear={() => setCompanyFilter(null)}
+        />
       ) : null}
 
       {moveError ? (
@@ -250,107 +316,111 @@ export function PipelineBoard({
       ) : null}
 
       {/* --- Columns -------------------------------------------------------- */}
-      <div
-        className="board-grid grid items-start gap-3 sm:grid-cols-2"
-        style={{ ["--board-cols" as string]: boardCols }}
-      >
-        {boardColumns(STAGES).map((column) => {
-          const items = filtered.filter((a) => stageOf(shownStatus(a)) === column.key);
-          const isExpanded = expanded[column.key] === true;
-          const visible = isExpanded ? items : items.slice(0, COLLAPSED_COUNT);
-          const hidden = items.length - visible.length;
-          return (
-            <section
-              key={column.key}
-              aria-label={`${column.label} — ${items.length}`}
-              data-drop={dropStage === column.key || undefined}
-              onDragOver={
-                interactive && draggingId !== null
-                  ? (event) => {
-                      event.preventDefault();
-                      event.dataTransfer.dropEffect = "move";
-                      setDropStage(column.key);
+      <LayoutGroup>
+        <div
+          className="board-grid grid items-start gap-3 sm:grid-cols-2"
+          style={{ ["--board-cols" as string]: boardCols }}
+        >
+          {boardColumns(STAGES).map((column) => {
+            const items = filtered.filter((a) => stageOf(shownStatus(a)) === column.key);
+            const isExpanded = expanded[column.key] === true;
+            const visible = isExpanded ? items : items.slice(0, COLLAPSED_COUNT);
+            const hidden = items.length - visible.length;
+            return (
+              <section
+                key={column.key}
+                aria-label={`${column.label} — ${items.length}`}
+                data-drop={dropStage === column.key || undefined}
+                onDragOver={
+                  interactive && draggingId !== null
+                    ? (event) => {
+                        event.preventDefault();
+                        event.dataTransfer.dropEffect = "move";
+                        setDropStage(column.key);
+                      }
+                    : undefined
+                }
+                onDrop={
+                  interactive
+                    ? (event) => {
+                        event.preventDefault();
+                        const id = Number(event.dataTransfer.getData("text/plain"));
+                        setDropStage(null);
+                        setDraggingId(null);
+                        if (Number.isInteger(id) && id > 0) void moveTo(id, column.key);
+                      }
+                    : undefined
+                }
+                className="board-col flex flex-col rounded-xl border border-line-soft bg-surface p-3 transition-colors"
+              >
+                <div className="mb-2 flex items-baseline justify-between px-1">
+                  <span className="label-mono inline-flex items-center gap-1.5">
+                    <span
+                      className="h-1.5 w-1.5 rounded-full"
+                      style={{ background: column.color }}
+                      aria-hidden="true"
+                    />
+                    {column.label}
+                  </span>
+                  <span className="tabular font-mono text-xs text-muted">{items.length}</span>
+                </div>
+                <ul className="space-y-2">
+                  {items.length === 0 ? (
+                    <li className="rounded-lg border border-dashed border-line-soft p-3 text-center font-mono text-[11px] text-dim">
+                      {filterActive ? "none match" : "none yet"}
+                    </li>
+                  ) : (
+                    visible.map((app) => (
+                      <BoardCell key={app.id} id={app.id} entering={hydrated}>
+                        {interactive ? (
+                          <ApplicationCard
+                            app={app}
+                            columnLabel={column.label}
+                            today={today}
+                            transport={transport}
+                            onOpenDetail={setDetailApp}
+                            sameCompanyCount={sameCompanyCount(app)}
+                            onFilterCompany={setCompanyFilter}
+                            dragging={draggingId === app.id}
+                            onDragStart={(event) => {
+                              event.dataTransfer.setData("text/plain", String(app.id));
+                              event.dataTransfer.effectAllowed = "move";
+                              setDraggingId(app.id);
+                            }}
+                            onDragEnd={() => {
+                              setDraggingId(null);
+                              setDropStage(null);
+                            }}
+                          />
+                        ) : (
+                          <StaticApplicationCard
+                            app={app}
+                            columnLabel={column.label}
+                            today={today}
+                            sameCompanyCount={sameCompanyCount(app)}
+                            onFilterCompany={setCompanyFilter}
+                          />
+                        )}
+                      </BoardCell>
+                    ))
+                  )}
+                </ul>
+                {hidden > 0 || isExpanded ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setExpanded((e) => ({ ...e, [column.key]: !isExpanded }))
                     }
-                  : undefined
-              }
-              onDrop={
-                interactive
-                  ? (event) => {
-                      event.preventDefault();
-                      const id = Number(event.dataTransfer.getData("text/plain"));
-                      setDropStage(null);
-                      setDraggingId(null);
-                      if (Number.isInteger(id) && id > 0) void moveTo(id, column.key);
-                    }
-                  : undefined
-              }
-              className="board-col flex flex-col rounded-xl border border-line-soft bg-surface p-3 transition-colors"
-            >
-              <div className="mb-2 flex items-baseline justify-between px-1">
-                <span className="label-mono inline-flex items-center gap-1.5">
-                  <span
-                    className="h-1.5 w-1.5 rounded-full"
-                    style={{ background: column.color }}
-                    aria-hidden="true"
-                  />
-                  {column.label}
-                </span>
-                <span className="tabular font-mono text-xs text-muted">{items.length}</span>
-              </div>
-              <ul className="space-y-2">
-                {items.length === 0 ? (
-                  <li className="rounded-lg border border-dashed border-line-soft p-3 text-center font-mono text-[11px] text-dim">
-                    {filterActive ? "none match" : "none yet"}
-                  </li>
-                ) : (
-                  visible.map((app) =>
-                    interactive ? (
-                      <ApplicationCard
-                        key={app.id}
-                        app={app}
-                        columnLabel={column.label}
-                        transport={transport}
-                        onOpenDetail={setDetailApp}
-                        sameCompanyCount={(companyCounts.get(app.company) ?? 1) - 1}
-                        onFilterCompany={setCompanyFilter}
-                        dragging={draggingId === app.id}
-                        onDragStart={(event) => {
-                          event.dataTransfer.setData("text/plain", String(app.id));
-                          event.dataTransfer.effectAllowed = "move";
-                          setDraggingId(app.id);
-                        }}
-                        onDragEnd={() => {
-                          setDraggingId(null);
-                          setDropStage(null);
-                        }}
-                      />
-                    ) : (
-                      <StaticApplicationCard
-                        key={app.id}
-                        app={app}
-                        columnLabel={column.label}
-                        sameCompanyCount={(companyCounts.get(app.company) ?? 1) - 1}
-                        onFilterCompany={setCompanyFilter}
-                      />
-                    ),
-                  )
-                )}
-              </ul>
-              {hidden > 0 || isExpanded ? (
-                <button
-                  type="button"
-                  onClick={() =>
-                    setExpanded((e) => ({ ...e, [column.key]: !isExpanded }))
-                  }
-                  className="mt-2 rounded-lg border border-dashed border-line px-2 py-1.5 font-mono text-[11px] text-muted transition-colors hover:border-line-strong hover:text-strong"
-                >
-                  {isExpanded ? "show fewer" : `show all ${items.length}`}
-                </button>
-              ) : null}
-            </section>
-          );
-        })}
-      </div>
+                    className="mt-2 rounded-lg border border-dashed border-line px-2 py-1.5 font-mono text-[11px] text-muted transition-colors hover:border-line-strong hover:text-strong"
+                  >
+                    {isExpanded ? "show fewer" : `show all ${items.length}`}
+                  </button>
+                ) : null}
+              </section>
+            );
+          })}
+        </div>
+      </LayoutGroup>
 
       {interactive ? (
         <ApplicationDetail app={detailApp} onClose={() => setDetailApp(null)} transport={transport} />

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -131,14 +131,28 @@ function BoardCell({
   children: ReactNode;
 }) {
   const reduceMotion = useReducedMotion();
-  if (reduceMotion) return <li>{children}</li>;
+  // ONE element type in every case, and the same one the server rendered.
+  //
+  // Returning a plain `<li>` under reduced motion looked equivalent and was not:
+  // `useReducedMotion` cannot read a media query during SSR, so the server always
+  // took the `motion.li` branch while a reduced-motion client took the other one.
+  // The differing tree shape shifts every descendant `useId`, and production
+  // React does not repair a server-rendered `id` attribute — so
+  // `RowActionsMenu`'s `aria-labelledby` pointed at an id that no longer existed
+  // on every card, for exactly the people reduced motion exists to serve.
+  //
+  // Reduced motion is now expressed by neutralising the animation PROPS, which
+  // changes nothing about the tree. `layout={false}` disables the shared-layout
+  // glide; the zero duration makes the remaining opacity settle instant.
   return (
     <motion.li
-      layout
+      layout={!reduceMotion}
       layoutId={`app-${id}`}
-      initial={entering ? { opacity: 0, y: 6 } : false}
+      initial={entering && !reduceMotion ? { opacity: 0, y: 6 } : false}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+      transition={
+        reduceMotion ? { duration: 0 } : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }
+      }
     >
       {children}
     </motion.li>

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -1,0 +1,197 @@
+import Link from "next/link";
+
+import {
+  MOMENTUM_WEEKS,
+  bucketAges,
+  daysBetween,
+  momentumDelta,
+  todayISO,
+  weeklyCounts,
+} from "@/lib/dashboard/age";
+import { filedAt } from "@/lib/dashboard/dates";
+import { stageOf, type Application } from "@/lib/dashboard/summary";
+
+/**
+ * The pulse strip — the three signals the rows actually carry, drawn instead
+ * of restated. Sits under the SyncBar; everything on it is NEW information the
+ * subtitle and the board don't already say:
+ *
+ *   - **momentum** — applications filed per week (8 weeks of bars) and the
+ *     last-4-weeks-vs-prior-4 delta, from the same one derivation
+ *     (`lib/dashboard/age.ts`) so the arrow can never contradict the bars;
+ *   - **ageing** — the open (applied + interviewing) rows bucketed by days
+ *     since filed; the ≥{@link QUIET_AFTER_DAYS}-day share is the amber
+ *     "quiet" signal, the same threshold that tags individual cards;
+ *   - **classifier** — how much of this pipeline the classifier built
+ *     (source = "gmail" rows) and what it is holding under the 0.85 gate,
+ *     deep-linked to the review queue.
+ *
+ * Honesty rules: the board fetch is one bounded page, so when the loaded rows
+ * are fewer than the account's total the row-derived cells say they describe
+ * the newest N rather than pretending to describe everything. Ages/weeks are
+ * calendar-day math in UTC on both server and client (`age.ts`), so the strip
+ * hydrates cleanly. The micro-bars are `aria-hidden` decoration over the
+ * numbers, animate in with a transform-only CSS entrance (`.pulse-seg`,
+ * globals.css), and collapse to their final state under
+ * `prefers-reduced-motion` — nothing here is gated on an animation.
+ */
+export function PipelinePulse({
+  applications,
+  total,
+  needsReview,
+}: {
+  /** The board's loaded rows — the same page `PipelineBoard` renders. */
+  applications: Application[];
+  /** The account's true total, from the counts-only summary endpoint. */
+  total: number;
+  /** Verdicts held under the gate for the user (0 when the queue is clear). */
+  needsReview: number;
+}) {
+  const today = todayISO();
+  /** True when the single board page holds every row the account has. */
+  const complete = applications.length >= total;
+
+  // --- momentum -------------------------------------------------------------
+  const weeks = weeklyCounts(
+    applications.map((app) => filedAt(app)),
+    today,
+  );
+  const peak = Math.max(...weeks, 1);
+  const { recent, prior } = momentumDelta(weeks);
+  const arrow = recent > prior ? "↑" : recent < prior ? "↓" : "→";
+
+  // --- ageing (open rows only — a closed row's age answers nothing) ---------
+  const openAges = applications
+    .filter((app) => {
+      const stage = stageOf(app.status);
+      return stage === "applied" || stage === "interviewing";
+    })
+    .map((app) => daysBetween(filedAt(app), today));
+  const ages = bucketAges(openAges);
+  const openTotal = ages.fresh + ages.waiting + ages.quiet;
+
+  // --- classifier -----------------------------------------------------------
+  const autoFiled = applications.filter((app) => app.source === "gmail").length;
+
+  const scopeNote = complete ? null : `newest ${applications.length} of ${total}`;
+
+  return (
+    <section
+      aria-label="Pipeline pulse"
+      data-testid="pipeline-pulse"
+      className="grid overflow-hidden rounded-xl border border-line-soft bg-surface sm:grid-cols-3"
+    >
+      {/* --- momentum -------------------------------------------------------- */}
+      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+        <h2 className="label-mono">momentum · filed per wk</h2>
+        <div
+          role="img"
+          aria-label={`Applications filed per week, oldest first: ${weeks.join(", ")}`}
+          className="mt-3 flex h-9 items-end gap-1"
+        >
+          {weeks.map((count, i) => (
+            <span
+              key={i}
+              data-testid="pulse-week"
+              title={`${count} filed`}
+              className="pulse-seg min-w-0 flex-1 rounded-sm"
+              style={{
+                height: count > 0 ? `${Math.max(18, (count / peak) * 100)}%` : "2px",
+                background: count > 0 ? "var(--stage-applied)" : "var(--line-strong)",
+                ["--i" as string]: i,
+              }}
+            />
+          ))}
+        </div>
+        <div className="mt-1 flex justify-between font-mono text-[9px] text-dim" aria-hidden="true">
+          <span>{MOMENTUM_WEEKS} wk ago</span>
+          <span>now</span>
+        </div>
+        <p className="mt-2 font-mono text-[11px] text-muted">
+          <span className="tabular text-strong">{recent}</span> last 4 wk{" "}
+          <span aria-hidden="true">{arrow}</span> vs {prior} prior
+          {scopeNote ? <span className="text-dim"> · {scopeNote}</span> : null}
+        </p>
+      </div>
+
+      {/* --- ageing ---------------------------------------------------------- */}
+      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+        <h2 className="label-mono">open · age since filed</h2>
+        {openTotal === 0 ? (
+          <p className="mt-3 font-mono text-[11px] text-dim">no open applications</p>
+        ) : (
+          <>
+            <div
+              role="img"
+              aria-label={`Open applications by age: ${ages.fresh} under a week, ${ages.waiting} one to two weeks, ${ages.quiet} quiet two weeks or more`}
+              className="mt-3 flex h-1.5 overflow-hidden rounded-full bg-surface-2"
+            >
+              {(
+                [
+                  [ages.fresh, "var(--stage-applied)"],
+                  [ages.waiting, "var(--text-dim)"],
+                  [ages.quiet, "var(--amber)"],
+                ] as const
+              )
+                .filter(([count]) => count > 0)
+                .map(([count, color], i) => (
+                  <span
+                    key={color}
+                    className="pulse-seg-x h-full"
+                    style={{
+                      width: `${(count / openTotal) * 100}%`,
+                      background: color,
+                      ["--i" as string]: i,
+                    }}
+                  />
+                ))}
+            </div>
+            <p className="mt-2 font-mono text-[11px] text-muted">
+              <span className="tabular text-strong">{ages.fresh}</span> &lt;1 wk ·{" "}
+              <span className="tabular">{ages.waiting}</span> 1–2 wk ·{" "}
+              <span className={ages.quiet > 0 ? "text-review" : ""}>
+                <span className="tabular">{ages.quiet}</span> quiet ≥2 wk
+              </span>
+              {scopeNote ? <span className="text-dim"> · {scopeNote}</span> : null}
+            </p>
+          </>
+        )}
+      </div>
+
+      {/* --- classifier ------------------------------------------------------ */}
+      <div className="p-4">
+        <h2 className="label-mono">classifier</h2>
+        <div
+          role="img"
+          aria-label={`${autoFiled} of ${applications.length} loaded rows were filed automatically from mail`}
+          className="mt-3 flex h-1.5 overflow-hidden rounded-full bg-surface-2"
+        >
+          {autoFiled > 0 ? (
+            <span
+              className="pulse-seg-x h-full"
+              style={{
+                width: `${applications.length > 0 ? (autoFiled / applications.length) * 100 : 0}%`,
+                background: "var(--viz-setfit)",
+                ["--i" as string]: 0,
+              }}
+            />
+          ) : null}
+        </div>
+        <p className="mt-2 font-mono text-[11px] text-muted">
+          <span className="tabular text-strong">{autoFiled}</span> of {applications.length}{" "}
+          auto-filed from mail
+        </p>
+        {needsReview > 0 ? (
+          <Link
+            href="/dashboard#needs-classification"
+            className="mt-1 inline-flex items-center gap-1 font-mono text-[11px] text-review underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+          >
+            <span className="tabular">{needsReview}</span> held under the 0.85 gate →
+          </Link>
+        ) : (
+          <p className="mt-1 font-mono text-[11px] text-dim">queue clear · gate 0.85</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/dashboard/ReviewQueue.tsx
+++ b/apps/web/components/dashboard/ReviewQueue.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import { AUTO_FILE_GATE, GateMeter } from "@/components/viz/GateMeter";
 import { shortDate } from "@/lib/dashboard/dates";
 import {
   CLASSIFY_FAILED,
@@ -136,6 +137,27 @@ function ReviewRow({
         </span>
       </div>
       <p className="truncate text-xs text-muted">{sender}</p>
+      {/* WHY this email is here, in the classifier's own numbers: its
+          confidence drawn against the auto-file gate. Most held mail sits
+          under the gate; a confident verdict in this queue was held because
+          no employer could be named — two different questions for the user,
+          so the line says which one this is. */}
+      {typeof item.confidence === "number" ? (
+        <p className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] text-dim">
+          <GateMeter confidence={item.confidence} className="w-12" />
+          <span
+            className="tabular"
+            style={{
+              color: item.confidence >= AUTO_FILE_GATE ? "var(--green)" : "var(--amber)",
+            }}
+          >
+            {Math.round(item.confidence * 100)}%
+          </span>
+          {item.confidence >= AUTO_FILE_GATE
+            ? "cleared the gate · held for a missing employer name"
+            : `below the ${AUTO_FILE_GATE} gate · your call decides it`}
+        </p>
+      ) : null}
       {item.snippet ? (
         <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-dim">{item.snippet}</p>
       ) : null}

--- a/apps/web/components/dashboard/SyncBar.tsx
+++ b/apps/web/components/dashboard/SyncBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2, MoreHorizontal, RefreshCw, X } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
@@ -178,6 +179,7 @@ export function SyncBar({
   const connected = gmail?.connected === true;
   const hasCursor = gmail?.hasCursor === true;
   const lastSyncAt = gmail?.lastSyncAt ?? null;
+  const reduceMotion = useReducedMotion();
   const simulated = transport.mode === "simulated";
   const memoryKey = simulated ? REBUILD_MEMORY_DEMO_KEY : REBUILD_MEMORY_KEY;
   const busy = phase.kind === "syncing" || phase.kind === "rebuilding";
@@ -488,15 +490,24 @@ export function SyncBar({
         </div>
       </header>
 
-      {/* Persistent live regions — visually empty when idle. */}
+      {/* Persistent live regions — visually empty when idle. The inner span is
+          keyed by the machine's state so each transition (idle → syncing →
+          synced…) slides its sentence in — the state CHANGE is visible, not
+          just the state. Reduced motion renders each state statically. */}
       <p
         role="status"
         aria-live="polite"
-        className={`flex items-center gap-2 font-mono text-[11px] text-muted ${
-          statusContent === null ? "sr-only" : ""
-        }`}
+        className={`font-mono text-[11px] text-muted ${statusContent === null ? "sr-only" : ""}`}
       >
-        {statusContent}
+        <motion.span
+          key={phase.kind}
+          initial={reduceMotion ? false : { opacity: 0, y: 3 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.18, ease: "easeOut" }}
+          className="flex items-center gap-2"
+        >
+          {statusContent}
+        </motion.span>
       </p>
       <p
         role="alert"
@@ -594,7 +605,9 @@ export function SyncBar({
  * (`POST /applications/{id}/restore`), which is what makes the purge
  * auditable rather than final. Amber border when rows were removed or the
  * scan stopped early (needs attention; nothing failed), red when it broke,
- * quiet otherwise. No entrance animation — this panel's job is to be read.
+ * quiet otherwise. The entrance is a fast fade-rise (0.18s) that pulls the
+ * eye to the receipt without ever delaying reading it; reduced motion
+ * renders it statically.
  *
  * The heading is the end state, not a pleasantry: a rebuild that stopped
  * early did NOT finish, and one that removed rows on a partial scan judged
@@ -617,6 +630,7 @@ function RebuildReceipt({
 }) {
   const [restoringId, setRestoringId] = useState<number | null>(null);
   const [failedId, setFailedId] = useState<number | null>(null);
+  const reduceMotion = useReducedMotion();
 
   async function restore(id: number) {
     setRestoringId(id);
@@ -643,7 +657,12 @@ function RebuildReceipt({
         ? "border-review/40"
         : "border-line-soft";
   return (
-    <div className={`rounded-xl border bg-surface px-4 py-3 ${border}`}>
+    <motion.div
+      initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18, ease: "easeOut" }}
+      className={`rounded-xl border bg-surface px-4 py-3 ${border}`}
+    >
       <div className="flex items-start justify-between gap-3">
         <div>
           {endKind === "complete" ? (
@@ -727,6 +746,6 @@ function RebuildReceipt({
           ))}
         </ul>
       ) : null}
-    </div>
+    </motion.div>
   );
 }

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddApplicationForm } from "@/components/applications/AddApplicationForm";
 import { PipelineBoard } from "@/components/dashboard/PipelineBoard";
+import { PipelinePulse } from "@/components/dashboard/PipelinePulse";
 import { SyncBar, type SyncGmailState } from "@/components/dashboard/SyncBar";
 import { summarize, type Application } from "@/lib/dashboard/summary";
 import type { BoardTransport, SyncTransport } from "@/lib/dashboard/transport";
@@ -207,6 +208,15 @@ export function DemoDashboard() {
       <SyncBar subtitle={subtitle} gmail={DEMO_GMAIL} transport={syncTransport}>
         <AddApplicationForm mode="demo" />
       </SyncBar>
+      {/* Same strip as the signed-in dashboard, over the fixture store: the
+          fixtures are the full board, so total is exact and the momentum /
+          ageing / classifier cells derive from what is actually on screen —
+          press Sync and the fresh rows move the bars. */}
+      <PipelinePulse
+        applications={snapshot.apps}
+        total={snapshot.apps.length}
+        needsReview={0}
+      />
       <PipelineBoard applications={snapshot.apps} transport={boardTransport} />
     </section>
   );

--- a/apps/web/components/gmail/InboxWorkbench.tsx
+++ b/apps/web/components/gmail/InboxWorkbench.tsx
@@ -8,6 +8,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ConnectGmailButton } from "@/components/gmail/ConnectGmailButton";
 import { selectClass } from "@/components/ui/formStyles";
 import { Segmented } from "@/components/ui/Segmented";
+import { GateMeter } from "@/components/viz/GateMeter";
+import { shortDate } from "@/lib/dashboard/dates";
 import { filedSummary, type SyncCounts } from "@/lib/gmail/sync-state";
 import {
   buildInboxParams,
@@ -102,31 +104,48 @@ function pct(n: number) {
   return `${Math.round(n * 100)}%`;
 }
 
+/**
+ * One classified message — the verdict rendered as the product's own visual,
+ * not debug output: category chip, the confidence drawn against the 0.85
+ * auto-file gate (the landing DecisionTrace's meter, via `GateMeter`), the
+ * percentage in the cleared/held hue, and the receipt date. Fixed column
+ * widths keep the meters aligned down the list so confidence reads as a
+ * column, not a scatter.
+ */
 function VerdictRow({ v }: { v: InboxVerdict }) {
   const meta = CATEGORY_META[v.category] ?? { label: v.category, dot: "bg-dim" };
   return (
-    <li className="flex items-start justify-between gap-4 border-b border-line-soft px-1 py-3 last:border-b-0">
-      <div className="min-w-0">
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-line-soft px-1 py-3 last:border-b-0">
+      {/* basis-full on mobile gives the subject its own line; sm+ restores the
+          single-row layout (same rule as the landing trace rows). */}
+      <div className="min-w-0 basis-full sm:basis-0 sm:flex-1">
         <p className="truncate text-sm font-medium text-strong">{v.subject}</p>
         <p className="truncate font-mono text-[11px] text-dim">
           {v.sender_name ? `${v.sender_name} · ` : ""}
           {v.sender_email}
         </p>
       </div>
-      <div className="flex shrink-0 items-center gap-3 text-right">
-        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-muted">
-          <span className={`h-1.5 w-1.5 rounded-full ${meta.dot}`} aria-hidden />
-          {meta.label}
+      <span className="inline-flex w-24 items-center gap-1.5 font-mono text-[11px] text-muted">
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${meta.dot}`} aria-hidden />
+        <span className="truncate">{meta.label}</span>
+      </span>
+      <GateMeter confidence={v.confidence} className="hidden sm:inline-block" />
+      <span
+        className="tabular w-10 text-right font-mono text-[11px]"
+        style={{ color: v.needs_review ? "var(--amber)" : "var(--green)" }}
+      >
+        {pct(v.confidence)}
+      </span>
+      {v.needs_review ? (
+        <span className="rounded-full border border-review/40 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-review">
+          review
         </span>
-        <span className="tabular w-10 font-mono text-[11px] text-dim">{pct(v.confidence)}</span>
-        {v.needs_review ? (
-          <span className="rounded-full border border-line px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-review">
-            review
-          </span>
-        ) : (
-          <span className="w-[52px]" aria-hidden />
-        )}
-      </div>
+      ) : (
+        <span className="w-[52px]" aria-hidden />
+      )}
+      <span className="tabular hidden w-12 shrink-0 text-right font-mono text-[10px] text-dim md:inline">
+        {v.received_at ? shortDate(v.received_at) : ""}
+      </span>
     </li>
   );
 }

--- a/apps/web/components/shell/Sidebar.tsx
+++ b/apps/web/components/shell/Sidebar.tsx
@@ -90,16 +90,14 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
           </ul>
         </nav>
 
-        {/* The pipeline snapshot is for the pages that DON'T show the
-            pipeline (inbox, settings, import) — glanceable truth plus the
-            needs-review deep link. On /dashboard the real board is on screen,
-            and a miniature of it beside itself is the count-duplication this
-            redesign removed from the page; so here, it yields. */}
-        {isNavItemActive(pathname, "/dashboard") ? null : (
-          <div className="mt-5 px-3">
-            <RailPipeline pipeline={rail.pipeline} />
-          </div>
-        )}
+        {/* The pipeline snapshot renders on EVERY tab, including /dashboard.
+            It briefly yielded there (a miniature of the board beside itself),
+            but the cost was a rail that changed shape as you navigated —
+            chrome must be constant, and the snapshot is the rail's identity,
+            not page content. The duplication is accepted, on purpose. */}
+        <div className="mt-5 px-3">
+          <RailPipeline pipeline={rail.pipeline} />
+        </div>
       </div>
 
       <div className="shrink-0 border-t border-line-soft px-3 py-3">

--- a/apps/web/components/ui/Dialog.tsx
+++ b/apps/web/components/ui/Dialog.tsx
@@ -1,19 +1,23 @@
 "use client";
 
 import { useEffect, useId, useRef, type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { X } from "lucide-react";
 
 const FOCUSABLE =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 /**
- * A minimal, dependency-free modal dialog: focus is moved in on open and
- * restored to the trigger on close, Tab is trapped inside the panel, Escape
- * and backdrop clicks dismiss, and body scroll is locked while open. Rendered
- * as a fixed overlay (no portal) so it composes cleanly inside the app shell.
+ * A minimal modal dialog: focus is moved in on open and restored to the
+ * trigger on close, Tab is trapped inside the panel, Escape and backdrop
+ * clicks dismiss, and body scroll is locked while open. Rendered as a fixed
+ * overlay (no portal) so it composes cleanly inside the app shell.
  *
- * Motion is CSS-only (`.dialog-*` in globals.css) and collapses to a static
- * state under prefers-reduced-motion.
+ * Motion runs through the motion library (`AnimatePresence`) so the panel has
+ * a real exit as well as an entrance — the scrim fades, the centre panel
+ * rises, the sheet slides from the right edge. Fast by design (a tool opened
+ * twenty times a day), and `useReducedMotion` collapses every transition to
+ * instant: the content itself is never gated on an animation.
  */
 export function Dialog({
   open,
@@ -40,6 +44,7 @@ export function Dialog({
   const panelRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
   const descId = useId();
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
     if (!open) return;
@@ -85,57 +90,85 @@ export function Dialog({
     };
   }, [open, onClose]);
 
-  if (!open) return null;
-
   const overlayClass =
     variant === "sheet"
-      ? "dialog-overlay fixed inset-0 z-[100] flex justify-end bg-background/70 backdrop-blur-sm"
-      : "dialog-overlay fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto bg-background/70 p-4 backdrop-blur-sm sm:items-center sm:p-6";
+      ? "fixed inset-0 z-[100] flex justify-end bg-background/70 backdrop-blur-sm"
+      : "fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto bg-background/70 p-4 backdrop-blur-sm sm:items-center sm:p-6";
   const panelClass =
     variant === "sheet"
       ? // The sheet owns its scroll: the page behind is scroll-locked while it
         // is open, so this is the only scroll context on screen.
-        `sheet-panel relative h-dvh w-full max-w-xl overflow-y-auto border-l border-line-strong bg-surface p-5 shadow-[0_0_80px_-24px_rgba(0,0,0,0.85)] outline-none sm:p-6 ${className}`.trim()
-      : `dialog-panel relative my-auto w-full max-w-lg rounded-2xl border border-line-strong bg-surface p-5 shadow-[0_30px_80px_-24px_rgba(0,0,0,0.85)] outline-none sm:p-6 ${className}`.trim();
+        `relative h-dvh w-full max-w-xl overflow-y-auto border-l border-line-strong bg-surface p-5 shadow-[0_0_80px_-24px_rgba(0,0,0,0.85)] outline-none sm:p-6 ${className}`.trim()
+      : `relative my-auto w-full max-w-lg rounded-2xl border border-line-strong bg-surface p-5 shadow-[0_30px_80px_-24px_rgba(0,0,0,0.85)] outline-none sm:p-6 ${className}`.trim();
+
+  // Enter/exit for each geometry. Exits are quicker than entrances — closing
+  // must never feel like waiting.
+  const panelMotion = reduceMotion
+    ? {
+        initial: false as const,
+        animate: { opacity: 1 },
+        exit: { opacity: 1, transition: { duration: 0 } },
+      }
+    : variant === "sheet"
+      ? {
+          initial: { opacity: 0, x: 24 },
+          animate: { opacity: 1, x: 0 },
+          exit: { opacity: 0, x: 16 },
+        }
+      : {
+          initial: { opacity: 0, y: 8, scale: 0.985 },
+          animate: { opacity: 1, y: 0, scale: 1 },
+          exit: { opacity: 0, y: 6, scale: 0.99 },
+        };
 
   return (
-    <div
-      className={overlayClass}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={description ? descId : undefined}
-        tabIndex={-1}
-        className={panelClass}
-      >
-        <div className="mb-4 flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <h2 id={titleId} className="text-lg font-medium text-strong">
-              {title}
-            </h2>
-            {description ? (
-              <p id={descId} className="mt-1 text-sm text-muted">
-                {description}
-              </p>
-            ) : null}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close dialog"
-            className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+    <AnimatePresence>
+      {open ? (
+        <motion.div
+          className={overlayClass}
+          initial={reduceMotion ? false : { opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={reduceMotion ? { opacity: 1, transition: { duration: 0 } } : { opacity: 0 }}
+          transition={{ duration: 0.15, ease: "easeOut" }}
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) onClose();
+          }}
+        >
+          <motion.div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            aria-describedby={description ? descId : undefined}
+            tabIndex={-1}
+            className={panelClass}
+            {...panelMotion}
+            transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
           >
-            <X className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-        {children}
-      </div>
-    </div>
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 id={titleId} className="text-lg font-medium text-strong">
+                  {title}
+                </h2>
+                {description ? (
+                  <p id={descId} className="mt-1 text-sm text-muted">
+                    {description}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close dialog"
+                className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            {children}
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 }

--- a/apps/web/components/viz/GateMeter.tsx
+++ b/apps/web/components/viz/GateMeter.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * The classifier's confidence drawn against the 0.85 auto-file gate — the
+ * landing DecisionTrace's meter, miniaturised for dense rows (inbox verdicts,
+ * the detail sheet's mail trail, the review queue). One component so every
+ * surface renders the gate identically: green fill when the verdict cleared
+ * it, amber when a human presides, a hairline tick where the gate sits.
+ *
+ * `aria-hidden` by design: the meter always sits beside the numeric
+ * percentage, which is the accessible rendering of the same fact.
+ */
+
+/** The auto-file threshold — mirrors the backend's gate (see DecisionTrace). */
+export const AUTO_FILE_GATE = 0.85;
+
+export function GateMeter({
+  confidence,
+  gate = AUTO_FILE_GATE,
+  className,
+}: {
+  /** 0–1. Values outside the range are clamped, never invented. */
+  confidence: number;
+  gate?: number;
+  className?: string;
+}) {
+  const pct = Math.min(100, Math.max(0, confidence * 100));
+  const cleared = confidence >= gate;
+  return (
+    <span
+      data-testid="gate-meter"
+      aria-hidden="true"
+      className={cn(
+        "relative inline-block h-1 w-14 shrink-0 rounded-full bg-line align-middle",
+        className,
+      )}
+    >
+      <span
+        className="absolute inset-y-0 left-0 rounded-full"
+        style={{ width: `${pct}%`, background: cleared ? "var(--green)" : "var(--amber)" }}
+      />
+      <span className="absolute -inset-y-[3px] w-px bg-line-strong" style={{ left: `${gate * 100}%` }} />
+    </span>
+  );
+}

--- a/apps/web/lib/dashboard/age.ts
+++ b/apps/web/lib/dashboard/age.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure age/momentum math for the dashboard's honest signals. Everything here
+ * is a function of calendar-day strings — the same "read the characters, never
+ * construct a local Date" rule as `dates.ts` (see its header for the timezone
+ * bug that rule exists to prevent). `todayISO()` is the one clock read, and it
+ * is UTC on both server and client, so hydration can only disagree across the
+ * instant of UTC midnight itself.
+ *
+ * Kept import-free (the `CALENDAR_PREFIX` regex is duplicated from `dates.ts`
+ * on purpose) so `node --test` can load it under type stripping, same as
+ * `board.ts`.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Leading `YYYY-MM-DD` of an ISO date or timestamp; anything after it is ignored. */
+const CALENDAR_PREFIX = /^(\d{4})-(\d{2})-(\d{2})(?:[T ]|$)/;
+
+/**
+ * An applied-stage application this many days old with no stage change is
+ * "quiet" — the amber signal on cards and in the pulse strip. One threshold,
+ * used everywhere, so the card tag and the strip's count can never disagree.
+ */
+export const QUIET_AFTER_DAYS = 14;
+
+/** How many week-buckets the momentum strip renders. */
+export const MOMENTUM_WEEKS = 8;
+
+/** Today's calendar day, UTC — identical on server and client. */
+export function todayISO(now: number = Date.now()): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+/** UTC-midnight epoch of a calendar-day prefix, or `null` if unparsable. */
+function utcDay(value: string | null | undefined): number | null {
+  if (typeof value !== "string") return null;
+  const match = CALENDAR_PREFIX.exec(value.trim());
+  if (!match) return null;
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return Date.UTC(Number(match[1]), month - 1, day);
+}
+
+/** Whole calendar days from `fromISO` to `toISO` (negative = future). */
+export function daysBetween(
+  fromISO: string | null | undefined,
+  toISO: string,
+): number | null {
+  const from = utcDay(fromISO);
+  const to = utcDay(toISO);
+  if (from === null || to === null) return null;
+  return Math.round((to - from) / DAY_MS);
+}
+
+/** The three age buckets the pulse strip draws for open applications. */
+export interface AgeBuckets {
+  /** under one week old */
+  fresh: number;
+  /** one to two weeks — waiting, not yet worrying */
+  waiting: number;
+  /** ≥ {@link QUIET_AFTER_DAYS} days — the amber share */
+  quiet: number;
+}
+
+/** Bucket a list of ages (in days); unknown/future ages are dropped, not guessed. */
+export function bucketAges(ages: (number | null)[]): AgeBuckets {
+  const buckets: AgeBuckets = { fresh: 0, waiting: 0, quiet: 0 };
+  for (const age of ages) {
+    if (age === null || age < 0) continue;
+    if (age < 7) buckets.fresh += 1;
+    else if (age < QUIET_AFTER_DAYS) buckets.waiting += 1;
+    else buckets.quiet += 1;
+  }
+  return buckets;
+}
+
+/**
+ * Filed-per-week counts for the momentum bars, oldest week first (index
+ * `weeks - 1` is the current, still-running week). Dates outside the window —
+ * or unparsable — simply don't count; the bars claim only what they can see.
+ */
+export function weeklyCounts(
+  filedDates: (string | null | undefined)[],
+  today: string,
+  weeks: number = MOMENTUM_WEEKS,
+): number[] {
+  const counts = new Array<number>(weeks).fill(0);
+  for (const filed of filedDates) {
+    const age = daysBetween(filed, today);
+    if (age === null || age < 0 || age >= weeks * 7) continue;
+    counts[weeks - 1 - Math.floor(age / 7)] += 1;
+  }
+  return counts;
+}
+
+/**
+ * The momentum comparison the delta line states: the last 4 full-ish weeks
+ * against the 4 before them, from the same buckets the bars draw — one
+ * derivation, so the arrow can never contradict the picture.
+ */
+export function momentumDelta(counts: number[]): { recent: number; prior: number } {
+  const half = Math.floor(counts.length / 2);
+  const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0);
+  return { recent: sum(counts.slice(half)), prior: sum(counts.slice(0, half)) };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
+    "motion": "^13.1.0",
     "next": "16.2.11",
     "openapi-fetch": "^0.17.0",
     "react": "19.2.4",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.4)
+      motion:
+        specifier: ^13.1.0
+        version: 13.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.2.11
         version: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.59.1)(@types/node@20.19.39)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1327,6 +1330,17 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  framer-motion@13.1.0:
+    resolution: {integrity: sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1754,6 +1768,23 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  motion-dom@13.0.0:
+    resolution: {integrity: sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
+
+  motion@13.1.0:
+    resolution: {integrity: sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3584,6 +3615,15 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  framer-motion@13.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 13.0.0
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fsevents@2.3.2:
     optional: true
 
@@ -3982,6 +4022,20 @@ snapshots:
       brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
+
+  motion-dom@13.0.0:
+    dependencies:
+      motion-utils: 13.0.0
+
+  motion-utils@13.0.0: {}
+
+  motion@13.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 13.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   ms@2.1.3: {}
 

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -218,9 +218,9 @@ test.describe("live demo (/demo)", () => {
     await expect(pulse.getByText(/last 4 wk/)).toBeVisible();
 
     // Ageing: the fixture board's open rows are weeks old, so the quiet share
-    // is non-zero (the exact count drifts as real time passes — assert the
-    // signal, not today's number).
-    await expect(pulse.getByText(/\d+ quiet ≥2 wk/)).toBeVisible();
+    // is non-zero. `\d+` would also match "0 quiet", which is the claim this
+    // is here to make — so require a non-zero leading digit.
+    await expect(pulse.getByText(/[1-9]\d* quiet ≥2 wk/)).toBeVisible();
 
     // Classifier: every fixture row is source="gmail", and nothing is held.
     await expect(pulse.getByText("14 of 14 auto-filed from mail")).toBeVisible();
@@ -270,12 +270,41 @@ test.describe("live demo (/demo)", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/demo");
     await expect(page.getByText("Beacon Health", { exact: true })).toBeVisible();
-    await expect(page.getByTestId("pipeline-pulse")).toBeVisible();
+
+    // `toBeVisible()` on a bordered, padded <section> passes on an EMPTY strip,
+    // so assert the content itself — the three derived signals and eight drawn
+    // bars — exactly as the motion-on test does. A guard that survives its own
+    // component rendering nothing is the shape this estate keeps producing.
+    const pulse = page.getByTestId("pipeline-pulse");
+    await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
+    await expect(pulse.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
+    // A bar with zero drawn height would satisfy the count above.
+    const barHeights = await pulse.getByTestId("pulse-week").evaluateAll((els) =>
+      els.map((el) => el.getBoundingClientRect().height),
+    );
+    expect(Math.max(...barHeights)).toBeGreaterThan(0);
+
+    // The board's own row-actions menu must keep its accessible name. Branching
+    // element type on `useReducedMotion` desynced the server and client trees,
+    // which shifted every descendant `useId` and left `aria-labelledby` pointing
+    // at an id that no longer existed — for exactly the people this mode serves.
+    const trigger = page.getByRole("button", { name: /^Row actions for / }).first();
+    await trigger.click();
+    const menu = page.getByRole("menu").first();
+    await expect(menu).toBeVisible();
+    const labelledBy = await menu.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    await expect(page.locator(`#${CSS.escape(labelledBy!)}`)).toHaveCount(1);
+    await page.keyboard.press("Escape");
+
     await page
       .getByRole("button", { name: "Show all applications at Northstar Systems" })
       .first()
       .click();
-    await expect(page.getByTestId("company-band")).toBeVisible();
+    const band = page.getByTestId("company-band");
+    await expect(band.getByText("Northstar Systems")).toBeVisible();
+    await expect(band.getByText(/3 applications/)).toBeVisible();
     // The set view keeps only Northstar cards, so open one of those.
     await page
       .getByRole("button", { name: "Open Northstar Systems — ML Engineer, Platform" })

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -208,6 +208,83 @@ test.describe("live demo (/demo)", () => {
     await expect(surface.getByText(/stopped early/)).toHaveCount(0);
   });
 
+  test("the pulse strip renders all three derived signals over the fixtures", async ({ page }) => {
+    await page.goto("/demo");
+    const pulse = page.getByTestId("pipeline-pulse");
+    await expect(pulse).toBeVisible();
+
+    // Momentum: exactly 8 week-bars plus the delta sentence derived from them.
+    await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
+    await expect(pulse.getByText(/last 4 wk/)).toBeVisible();
+
+    // Ageing: the fixture board's open rows are weeks old, so the quiet share
+    // is non-zero (the exact count drifts as real time passes — assert the
+    // signal, not today's number).
+    await expect(pulse.getByText(/\d+ quiet ≥2 wk/)).toBeVisible();
+
+    // Classifier: every fixture row is source="gmail", and nothing is held.
+    await expect(pulse.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
+
+    // The card-level ageing tag agrees with the strip's threshold.
+    await expect(page.getByText(/quiet \d+d/).first()).toBeVisible();
+  });
+
+  test("the pulse strip moves when Sync files fresh mail", async ({ page }) => {
+    await page.goto("/demo");
+    await expect(page.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await page.getByRole("button", { name: "Sync new mail from Gmail" }).click();
+    // Two fixture rows arrive → the classifier fraction re-derives from the
+    // new board. (No assertion on the ageing buckets here: the fixture dates
+    // are static while real time passes, so any exact bucket count would rot.)
+    await expect(page.getByText("16 of 16 auto-filed from mail")).toBeVisible();
+  });
+
+  test("a company opens as a set: band on, chips suppressed, clear restores", async ({ page }) => {
+    await page.goto("/demo");
+    // Three Northstar cards each carry the "+2 at" chip while unfiltered.
+    const chips = page.getByRole("button", { name: "Show all applications at Northstar Systems" });
+    await expect(chips).toHaveCount(3);
+
+    await chips.first().click();
+    // The band names the set…
+    const band = page.getByTestId("company-band");
+    await expect(band).toBeVisible();
+    await expect(band.getByText("Northstar Systems")).toBeVisible();
+    await expect(band.getByText(/3 applications/)).toBeVisible();
+    // …and the chip must NOT render while the active filter already is this
+    // company ("2 more at Northstar" inside Northstar's own set was the bug).
+    await expect(chips).toHaveCount(0);
+    await expect(page.getByText(/at Northstar Systems/)).toHaveCount(0);
+
+    // Clear via the band restores the board and the chips.
+    await page.getByRole("button", { name: "Stop filtering by Northstar Systems" }).click();
+    await expect(page.getByText("Harbor Analytics", { exact: true })).toBeVisible();
+    await expect(chips).toHaveCount(3);
+  });
+
+  test("with reduced motion, every surface is fully present — nothing gated", async ({ page }) => {
+    // The motion layer (board layout glides, band/dialog entrances, pulse bar
+    // draws) must be pure enhancement: under prefers-reduced-motion the same
+    // content renders statically, immediately.
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/demo");
+    await expect(page.getByText("Beacon Health", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("pipeline-pulse")).toBeVisible();
+    await page
+      .getByRole("button", { name: "Show all applications at Northstar Systems" })
+      .first()
+      .click();
+    await expect(page.getByTestId("company-band")).toBeVisible();
+    // The set view keeps only Northstar cards, so open one of those.
+    await page
+      .getByRole("button", { name: "Open Northstar Systems — ML Engineer, Platform" })
+      .click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toBeHidden();
+  });
+
   test("the decision trace rows expand on click (real effect)", async ({ page }) => {
     await page.goto("/demo");
     // The first trace row is open by default; open another and assert its

--- a/apps/web/tests/unit/age.test.mjs
+++ b/apps/web/tests/unit/age.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the dashboard's age/momentum math (`lib/dashboard/age.ts`).
+ *
+ * What these pin down:
+ *
+ *  1. Day counts are a pure function of the two calendar strings — the same
+ *     no-`Date`-construction rule as `dates.ts`, so a card's "quiet 34d" tag
+ *     can never disagree between the UTC server and a local-zone browser.
+ *  2. The week buckets and the delta line derive from ONE pass over the same
+ *     dates, oldest week first, with out-of-window and unparsable dates
+ *     dropped rather than guessed.
+ *  3. The quiet threshold is one shared constant, so the card tag and the
+ *     pulse strip's "N quiet" count use the same boundary.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MOMENTUM_WEEKS,
+  QUIET_AFTER_DAYS,
+  bucketAges,
+  daysBetween,
+  momentumDelta,
+  todayISO,
+  weeklyCounts,
+} from "../../lib/dashboard/age.ts";
+
+test("daysBetween reads calendar prefixes only — timestamps and date-only agree", () => {
+  assert.equal(daysBetween("2026-07-09", "2026-08-11"), 33);
+  assert.equal(daysBetween("2026-07-09T23:59:59", "2026-08-11"), 33);
+  assert.equal(daysBetween("2026-07-09T00:00:01Z", "2026-08-11"), 33);
+});
+
+test("daysBetween is null for absent or malformed input, never a guess", () => {
+  assert.equal(daysBetween(null, "2026-08-11"), null);
+  assert.equal(daysBetween(undefined, "2026-08-11"), null);
+  assert.equal(daysBetween("last Tuesday", "2026-08-11"), null);
+  assert.equal(daysBetween("2026-13-01", "2026-08-11"), null);
+});
+
+test("a future date is negative, and bucketAges drops it", () => {
+  assert.equal(daysBetween("2026-08-20", "2026-08-11"), -9);
+  assert.deepEqual(bucketAges([-9]), { fresh: 0, waiting: 0, quiet: 0 });
+});
+
+test("the quiet boundary is exactly QUIET_AFTER_DAYS, shared with the card tag", () => {
+  const b = bucketAges([0, 6, 7, QUIET_AFTER_DAYS - 1, QUIET_AFTER_DAYS, 60, null]);
+  assert.deepEqual(b, { fresh: 2, waiting: 2, quiet: 2 });
+});
+
+test("weeklyCounts buckets oldest-first with the current week last", () => {
+  const today = "2026-08-11";
+  const counts = weeklyCounts(
+    [
+      "2026-08-11", // 0d  → current week (last bucket)
+      "2026-08-05", // 6d  → current week
+      "2026-08-04", // 7d  → one week back
+      "2026-06-17", // 55d → oldest in-window bucket
+      "2026-06-16", // 56d → outside the 8-week window, dropped
+      "not a date", // dropped
+      null, // dropped
+    ],
+    today,
+  );
+  assert.equal(counts.length, MOMENTUM_WEEKS);
+  assert.deepEqual(counts, [1, 0, 0, 0, 0, 0, 1, 2]);
+});
+
+test("momentumDelta halves the same buckets the bars draw", () => {
+  assert.deepEqual(momentumDelta([1, 0, 0, 0, 0, 0, 1, 2]), { recent: 3, prior: 1 });
+});
+
+test("todayISO is the UTC calendar day of the instant it is handed", () => {
+  assert.equal(todayISO(Date.UTC(2026, 7, 11, 23, 59, 59)), "2026-08-11");
+  assert.equal(todayISO(Date.UTC(2026, 7, 12, 0, 0, 1)), "2026-08-12");
+});


### PR DESCRIPTION
Ayush looked at the live app and said, correctly: it's just text in the dashboard, there's no interactive feel, and it doesn't use shadcn/magic-ui-style components. He was right on all three — before this, `package.json` had **no motion library at all**, shadcn was configured but unused beyond one button, and nothing on any app surface animated.

### Motion, where state changes

`motion@13.1.0`, used for transitions rather than decoration. Board cards are `motion.li` with `layout` + shared `layoutId`: search survivors glide, a card moved **by drag or by select** visibly travels to its new column, clearing a filter gathers the board back. Entrances run only post-hydration (`initial={false}` on the SSR pass, so server HTML is never invisible), and filtering has **no exit animation** — a filter must feel instant in a tool opened twenty times a day. `Dialog` moved to `AnimatePresence` with real enter *and* exit; the detail sheet keeps its last card mounted through close so the exit plays over content.

`useReducedMotion` collapses all of it, and **no IntersectionObserver reveals were added anywhere** — deliberately, given how often visibility-gated content has looked broken here.

### A company is a set

The old affordance was a text link that, absurdly, still read "3 more at Amazon" **while you were already filtered to Amazon**. That's fixed at the board level (`sameCompanyCount()` returns 0 for the active filter) and asserted. In its place: a chip that opens a set view — the employer, its application count, the per-stage spread, the filing span — while the layout animation gathers the cards together.

### The dashboard carries signal, honestly

`PipelinePulse` over pure, unit-tested math in `lib/dashboard/age.ts`: momentum (8 week-bars, 4wk-vs-prior delta from one derivation), ageing of open rows (fresh / waiting / quiet ≥2wk), and the classifier's own auto-filed share with the count held under the gate, deep-linked to the queue. This is not the KPI-tile row that was removed — every number is derived from data that exists, needs-review renders once rather than in two places, a partial board page says "newest N of M", and all date math is calendar-string UTC so it cannot diverge on hydration.

### The classifier looks like the feature it is

`GateMeter` — confidence against the 0.85 gate, in the landing page's `DecisionTrace` vocabulary — now on the inbox verdict rows, the review queue, and the detail sheet's mail trail. `applied 95%` in mono was debug output for the product's headline capability. The review queue also now distinguishes "below the gate" from "cleared the gate, held for a missing employer name", which are different things and were rendered identically.

### Geometry and contrast

One header voice and one column across dashboard/inbox/settings/import; the rail snapshot renders on every tab instead of changing shape as you navigate. Contrast was **measured, not eyeballed**, and it caught a real failure: light-theme `--green` was 3.30:1 on white and is now 5.02:1.

### Verification, stated precisely

`tsc`, `pnpm lint`, `pnpm build` clean. The demo was hand-driven in a real browser — sync, select and drag moves, rebuild receipt → restore, band open/clear, sheet with the gate meter, and a reduced-motion pass — with screenshots at 1440px and 375px reviewed.

**The spec files were not executed** (the suite hook blocks them for that agent), so `demo.spec.ts`'s four new tests and the new `age.test.mjs` are unrun here and go to `labrat`. Saying so explicitly because the last round's commit message overstated exactly this.

One note: the brief asked for the `dataviz` skill before building charts. It isn't installed on this machine, so its discipline was applied by hand — honest scales, labelled windows, no invented axes.
