### PR TITLE
fix(e2e): CSS.escape is a browser global — main is red because of it

### DIFF
--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -295,7 +295,11 @@ test.describe("live demo (/demo)", () => {
     await expect(menu).toBeVisible();
     const labelledBy = await menu.getAttribute("aria-labelledby");
     expect(labelledBy).toBeTruthy();
-    await expect(page.locator(`#${CSS.escape(labelledBy!)}`)).toHaveCount(1);
+    // Attribute selector, not `#${CSS.escape(id)}` — `CSS` is a browser global
+    // and this runs in the Node test context, where referencing it throws
+    // before the assertion can mean anything. React's `useId` values also
+    // contain characters that are not valid bare CSS id selectors.
+    await expect(page.locator(`[id="${labelledBy}"]`)).toHaveCount(1);
     await page.keyboard.press("Escape");
 
     await page


### PR DESCRIPTION
**`main` is red and this is my fault twice over.**

The assertion I added to the reduced-motion test — to prove the row-actions menu's `aria-labelledby` resolves to a real element — used `` `#${CSS.escape(id)}` ``. `CSS` is a **browser** global; that expression evaluates in the Node test context, so it threw `ReferenceError: CSS is not defined` before the assertion could mean anything. It failed on all three CI attempts.

An attribute selector needs no escaping, and React's `useId` values are not valid bare CSS id selectors anyway.

**And I merged #93 while that check was already red.** My command queried the checks and then ran `gh pr merge` unconditionally in the same shell line instead of gating on the result. The product code in #93 is fine and was independently verified by `labrat` — five gates green, 73/73 unit, 67 e2e — this one test line is the only breakage, and it is a line I wrote after that verification ran.

**Verified by running it, not by reasoning about it:** dev server on 3100, `playwright test demo.spec.ts -g "reduced motion" --retries=0` → `1 passed`. The same command before the fix reproduces the `ReferenceError`.

The irony is not lost on me: the assertion existed to stop a guard from passing vacuously, and it shipped in a form that could not execute at all.
