### PR TITLE
fix: the states a user who is not the owner actually lands in

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -47,6 +47,14 @@ import { getCurrentUser } from "@/lib/supabase/auth";
  */
 const BOARD_PAGE_SIZE = 200;
 
+/**
+ * Why the board isn't rendering. The three failures are kept apart because the
+ * user's next step differs for each — the same discrimination
+ * `lib/gmail/server.ts` makes (`classifyBadResponse`), and for the same reason:
+ * collapsing them told everyone their session was the problem. A 500 is not a
+ * sign-in problem, and offering "sign in again" for one sends a user round a
+ * loop that cannot help.
+ */
 type LoadState =
   | {
       kind: "ok";
@@ -55,7 +63,11 @@ type LoadState =
       total: number;
       needsReview: number;
     }
-  | { kind: "unauthorized"; message: string }
+  /** The backend rejected the JWT (401/403) — expired session or JWKS misconfig. */
+  | { kind: "auth"; message: string }
+  /** Any other non-2xx: a backend fault. The session is fine; retrying is the move. */
+  | { kind: "backend"; message: string; status: number }
+  /** The request never completed (network / DNS / timeout). */
   | { kind: "offline"; message: string };
 
 /**
@@ -80,6 +92,18 @@ function failureMessage(error: unknown, status: number): string {
     : `Backend responded ${status}`;
 }
 
+/**
+ * A non-2xx from either dashboard call, labelled by what it actually means.
+ * 401/403 are the only statuses a fresh sign-in can fix; everything else
+ * (500, 502, 503, 429…) is ours to answer for and is said as such.
+ */
+function failureState(error: unknown, status: number): LoadState {
+  const message = failureMessage(error, status);
+  return status === 401 || status === 403
+    ? { kind: "auth", message }
+    : { kind: "backend", message, status };
+}
+
 async function loadDashboard(): Promise<LoadState> {
   try {
     const api = await createServerApiClient();
@@ -91,10 +115,10 @@ async function loadDashboard(): Promise<LoadState> {
     ]);
 
     if (summaryRes.error || !summaryRes.data) {
-      return { kind: "unauthorized", message: failureMessage(summaryRes.error, summaryRes.response.status) };
+      return failureState(summaryRes.error, summaryRes.response.status);
     }
     if (listRes.error || !listRes.data) {
-      return { kind: "unauthorized", message: failureMessage(listRes.error, listRes.response.status) };
+      return failureState(listRes.error, listRes.response.status);
     }
 
     const summary = summarizeCounts(
@@ -150,6 +174,22 @@ export default async function DashboardPage() {
       : null;
   const connected = gmail?.connected === true;
 
+  // Has a scan actually COMPLETED? "No application emails detected yet" is a
+  // verdict about the mailbox, and only a finished scan can deliver it. The
+  // backend holds `last_sync_at` at the last SUCCESSFUL sync and flips
+  // `sync_status` to "error" when one fails, so both facts are needed: a user
+  // whose first sync errored was being told the scan ran and found nothing,
+  // directly above the SyncBar's alert saying it failed.
+  //
+  // The two not-completed cases are kept apart because their next step is not
+  // the same, and because only ONE of them puts a line in the SyncBar: a
+  // failed run renders "last sync failed · try again", while a never-attempted
+  // one leaves that live region empty (the arrival auto-sync is bounded by a
+  // per-tab cooldown), so pointing at a retry line that isn't there would be
+  // the very thing this fix is about.
+  const scanFailed = connected && gmail?.syncStatus === "error";
+  const scanCompleted = connected && gmail?.lastSyncAt != null && !scanFailed;
+
   // --- Honest degradation: unreachable / rejected backend --------------------
   //
   // This branch renders NO sample data, and deliberately does not consult
@@ -158,13 +198,17 @@ export default async function DashboardPage() {
   // failure, a retry, and the routes forward.
   if (state.kind !== "ok") {
     const headline =
-      state.kind === "unauthorized"
-        ? "We couldn't load your pipeline."
-        : "We couldn't reach the server.";
+      state.kind === "offline"
+        ? "We couldn't reach the server."
+        : "We couldn't load your pipeline.";
+    // Only an auth rejection is a session problem. A 500 told through the same
+    // words sent people to sign in again — a loop that could not help them.
     const detail =
-      state.kind === "unauthorized"
+      state.kind === "auth"
         ? `The backend rejected this session: ${state.message}. Signing in again usually clears it.`
-        : `The backend didn't answer: ${state.message}. Nothing is lost — your board renders the moment it responds.`;
+        : state.kind === "backend"
+          ? `The backend answered ${state.status}: ${state.message}. That's a fault on our side, not a problem with your session or your account — try again in a moment.`
+          : `The backend didn't answer: ${state.message}. Nothing is lost — your board renders the moment it responds.`;
     return (
       <section className="space-y-8">
         <SyncBar subtitle="connection issue · your data could not be loaded" gmail={null}>
@@ -186,7 +230,7 @@ export default async function DashboardPage() {
           </p>
           <div className="mt-5 flex flex-wrap items-center gap-3">
             <RetryLoadButton />
-            {state.kind === "unauthorized" ? (
+            {state.kind === "auth" ? (
               <Link
                 href="/login?redirect=/dashboard"
                 className="text-xs text-dim underline-offset-4 hover:text-strong hover:underline"
@@ -216,17 +260,29 @@ export default async function DashboardPage() {
           : "";
       return (
         <section className="space-y-6">
-          <SyncBar subtitle={`connected · no applications detected yet${reviewNote}`} gmail={gmail}>
+          <SyncBar
+            subtitle={`connected · ${
+              scanCompleted ? "no applications detected yet" : "no applications filed yet"
+            }${reviewNote}`}
+            gmail={gmail}
+          >
             <AddApplicationForm compact />
           </SyncBar>
           <div className="rounded-2xl border border-line-soft bg-surface p-6 sm:p-8">
-            <p className="label-caps">connected to gmail</p>
+            <p className="label-caps">
+              {scanCompleted ? "connected to gmail" : "no completed scan yet"}
+            </p>
             <h2 className="mt-3 text-balance text-2xl font-medium tracking-tight text-strong">
-              No application emails detected yet.
+              {scanCompleted
+                ? "No application emails detected yet."
+                : "We haven't completed a scan of your mail yet."}
             </h2>
             <p className="mt-2 max-w-xl text-sm text-muted">
-              We scan your recent mail when you arrive. If your applications are older than 12
-              months, rebuild from a wider window.
+              {scanCompleted
+                ? "We scan your recent mail when you arrive. If your applications are older than 12 months, rebuild from a wider window."
+                : scanFailed
+                  ? "Nothing is filed because nothing has been read successfully — this is not a verdict that your mailbox holds no applications. The line above says how the last attempt failed and offers a retry; you can also rebuild from a wider window."
+                  : "Nothing is filed because your mail hasn't been read yet — this is not a verdict that your mailbox holds no applications. Sync, or choose a window, to run the first scan."}
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <RebuildWindowButton />
@@ -300,7 +356,11 @@ export default async function DashboardPage() {
           Settings toggle describes, kept real. */}
       {notifPrefs.reviewAlerts ? queue : null}
 
-      <PipelineBoard applications={state.applications} />
+      {/* `total` is the account's true count, not the page's: past
+          BOARD_PAGE_SIZE the board says which slice it is showing, so the
+          subtitle's "250 filed" and four columns summing to 200 stop
+          contradicting each other. */}
+      <PipelineBoard applications={state.applications} total={state.total} />
 
       {!notifPrefs.reviewAlerts ? queue : null}
     </section>

--- a/apps/web/app/api/applications/review/[messageId]/classify/route.ts
+++ b/apps/web/app/api/applications/review/[messageId]/classify/route.ts
@@ -10,6 +10,14 @@ import { classifyReviewItem } from "@/lib/applications/server";
  *
  * The optional `company` is forwarded so the client can answer a
  * `needs_employer: true` response with the name the pipeline couldn't extract.
+ * `application_id` is forwarded for the same reason: it is the user's answer to
+ * "which of these is it about?" when an employer holds several applications.
+ * Dropping it here is not a no-op — the backend falls back to picking the
+ * employer's first row, which is exactly the arbitrary-sibling filing that
+ * `_pick_application` was written to stop. This handler REBUILDS the body
+ * rather than forwarding it, so every field it does not name is silently lost;
+ * that is how `confidence` died in the inbox relay and how `applied_date` and
+ * `url` died on create.
  * The backend's body is passed through UNRESHAPED — `needs_employer`,
  * `message_id` and `detail` are what tell the caller whether anything was
  * actually filed, and narrowing them away here would recreate the bug the flag
@@ -23,16 +31,29 @@ export async function POST(req: NextRequest, ctx: Ctx) {
     return NextResponse.json({ detail: "Invalid message id" }, { status: 400 });
   }
 
-  let body: { category?: unknown; company?: unknown } = {};
+  let body: { category?: unknown; company?: unknown; application_id?: unknown } = {};
   try {
-    body = (await req.json()) as { category?: unknown; company?: unknown };
+    body = (await req.json()) as {
+      category?: unknown;
+      company?: unknown;
+      application_id?: unknown;
+    };
   } catch {
     return NextResponse.json({ detail: "Invalid JSON body" }, { status: 400 });
   }
   const category = typeof body.category === "string" ? body.category.trim() : "";
   if (!category) return NextResponse.json({ detail: "category is required" }, { status: 422 });
   const company = typeof body.company === "string" ? body.company.trim() : "";
+  const applicationId =
+    typeof body.application_id === "number" && Number.isInteger(body.application_id)
+      ? body.application_id
+      : undefined;
 
-  const r = await classifyReviewItem(messageId, category, company || undefined);
+  const r = await classifyReviewItem(
+    messageId,
+    category,
+    company || undefined,
+    applicationId,
+  );
   return NextResponse.json(r.data ?? {}, { status: r.status });
 }

--- a/apps/web/app/api/applications/route.ts
+++ b/apps/web/app/api/applications/route.ts
@@ -7,17 +7,51 @@ import { createServerApiClient } from "@/lib/api/server";
  * (from cookies) so the token and `BACKEND_API_URL` never reach the browser,
  * and returns the raw list JSON the client turns into a download.
  */
+/** The backend's own ceiling (`MAX_PAGE_SIZE`); asking for more is a 422. */
+const EXPORT_PAGE_SIZE = 500;
+/** Bounds the loop so a bad `total` can never spin it forever. 50k rows. */
+const EXPORT_MAX_PAGES = 100;
+
 export async function GET() {
   try {
     const api = await createServerApiClient();
-    const { data, error, response } = await api.GET("/applications");
-    if (error || !data) {
+
+    // PAGINATED, because the export claims to be everything.
+    //
+    // This used to make one unparameterised call, which the backend answers with
+    // its DEFAULT_PAGE_SIZE of 100. Settings offers to "export everything Applied
+    // holds for you" and a user with 250 applications silently got 100 of them —
+    // a data-loss-shaped defect in the one feature whose entire job is to hand
+    // the user their data back. It never fired here because this account has 25.
+    const first = await api.GET("/applications", {
+      params: { query: { page: 1, page_size: EXPORT_PAGE_SIZE } },
+    });
+    if (first.error || !first.data) {
       return NextResponse.json(
-        { detail: error ?? "Backend rejected the request" },
-        { status: response.status || 502 },
+        { detail: first.error ?? "Backend rejected the request" },
+        { status: first.response.status || 502 },
       );
     }
-    return NextResponse.json(data, { status: 200 });
+
+    const applications = [...first.data.applications];
+    const total = first.data.total;
+
+    for (let page = 2; applications.length < total && page <= EXPORT_MAX_PAGES; page += 1) {
+      const next = await api.GET("/applications", {
+        params: { query: { page, page_size: EXPORT_PAGE_SIZE } },
+      });
+      // A mid-export failure must not hand back a short file that looks whole.
+      if (next.error || !next.data) {
+        return NextResponse.json(
+          { detail: next.error ?? `Export failed while reading page ${page}` },
+          { status: next.response.status || 502 },
+        );
+      }
+      if (next.data.applications.length === 0) break; // defensive: no progress
+      applications.push(...next.data.applications);
+    }
+
+    return NextResponse.json({ applications, total }, { status: 200 });
   } catch {
     return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
   }

--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -12,6 +12,24 @@ export const metadata: Metadata = {
 };
 
 /**
+ * Rendered per request, because the fixtures are dated RELATIVE to today.
+ *
+ * As a static route this page is prerendered once and the build day's dates are
+ * baked into the HTML on disk, while the client resolves "today" at view time —
+ * so the filed stamps disagree and React throws a hydration error (#418) on
+ * every day after the build. Measured: clean at +0d, mismatching at +3d, +30d
+ * and +180d, and clean again at +365d, where the stamp string happens to
+ * repeat. That last one is the proof it is the date and nothing else.
+ *
+ * Resolving the date on the server and passing it down does NOT fix this on a
+ * static route — there, "server render time" IS build time, so the demo would
+ * simply resume ageing, which is the defect the relative dates removed. Only
+ * per-request rendering collapses the window to the UTC-midnight boundary that
+ * `lib/dashboard/age.ts` already documents as accepted.
+ */
+export const dynamic = "force-dynamic";
+
+/**
  * The product, auth-free: the exact dashboard a signed-in user sees, running
  * its real components — SyncBar, the board, drag, the detail sheet — over an
  * in-memory fixture store (`DemoDashboard`). Only the transport is simulated;

--- a/apps/web/components/applications/AddApplicationForm.tsx
+++ b/apps/web/components/applications/AddApplicationForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Plus } from "lucide-react";
 
 import { Dialog } from "@/components/ui/Dialog";
@@ -24,6 +24,9 @@ const STATUS_OPTIONS = [
 ] as const;
 
 type Mode = "live" | "demo";
+
+/** How long the "Filed …" receipt stays on screen. */
+const CONFIRMATION_MS = 8000;
 
 function normalizeUrl(raw: string): string {
   const trimmed = raw.trim();
@@ -74,6 +77,26 @@ export function AddApplicationForm({
   const dateId = useId();
   const linkId = useId();
   const notesId = useId();
+
+  /**
+   * The confirmation is a receipt, not a status: it says what just happened
+   * and then gets out of the way. It used to be set and never cleared, so
+   * "Filed 'X' — role." sat under the `+` button for the life of the mount,
+   * outliving the filing it described and (after a `router.refresh()`) the
+   * board state it was about. It clears on a timer, and again when the form is
+   * reopened — nobody should be reading a stale receipt while filing the next
+   * one. Ample margin over any assertion that reads it right after a submit.
+   */
+  useEffect(() => {
+    if (confirmation === null) return;
+    const id = window.setTimeout(() => setConfirmation(null), CONFIRMATION_MS);
+    return () => window.clearTimeout(id);
+  }, [confirmation]);
+
+  function openForm() {
+    setConfirmation(null);
+    setOpen(true);
+  }
 
   function close() {
     setOpen(false);
@@ -148,7 +171,7 @@ export function AddApplicationForm({
       {compact ? (
         <button
           type="button"
-          onClick={() => setOpen(true)}
+          onClick={openForm}
           title="File an application by hand"
           aria-label="File an application by hand"
           className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-line text-dim transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
@@ -156,7 +179,7 @@ export function AddApplicationForm({
           <Plus className="h-4 w-4" aria-hidden="true" />
         </button>
       ) : (
-        <button type="button" onClick={() => setOpen(true)} className={primaryBtnClass}>
+        <button type="button" onClick={openForm} className={primaryBtnClass}>
           <Plus className="h-4 w-4" aria-hidden="true" />
           File an application
         </button>

--- a/apps/web/components/dashboard/CompanyBand.tsx
+++ b/apps/web/components/dashboard/CompanyBand.tsx
@@ -14,23 +14,29 @@ import { STAGES, stageOf, type Application } from "@/lib/dashboard/summary";
  * gathers them (the cards glide together via the shared layout animation) and
  * this band states what the set is.
  *
- * Facts are computed from the company's FULL row set (never the search-
- * narrowed one), so the band describes the employer even while a search
- * narrows what is visible. The clear control carries the same accessible name
- * the old filter chip did ("Stop filtering by …"), so the affordance's
- * contract is unchanged.
+ * Facts are computed from the company's rows ON THE BOARD, never the
+ * search-narrowed subset — so the band keeps describing the employer while a
+ * search narrows what is visible. It does NOT claim to describe the employer's
+ * whole history: the signed-in board is one bounded page, and when that page
+ * is a slice of a larger account `partial` makes the band say which rows it
+ * counted rather than implying an older application never existed. The clear
+ * control carries the same accessible name the old filter chip did ("Stop
+ * filtering by …"), so the affordance's contract is unchanged.
  */
 export function CompanyBand({
   company,
   apps,
   statusOf,
+  partial = false,
   onClear,
 }: {
   company: string;
-  /** Every board row at this company, unfiltered. */
+  /** This company's rows as loaded on the board — not narrowed by search. */
   apps: Application[];
   /** Status resolver — the board passes its optimistic-overlay-aware one. */
   statusOf: (app: Application) => string;
+  /** The board itself is truncated, so these facts cover the loaded rows only. */
+  partial?: boolean;
   onClear: () => void;
 }) {
   const reduceMotion = useReducedMotion();
@@ -62,6 +68,7 @@ export function CompanyBand({
         <p className="truncate text-base font-medium leading-tight text-strong">{company}</p>
         <p className="tabular text-xs text-dim">
           {apps.length} application{apps.length === 1 ? "" : "s"} · {span}
+          {partial ? " · counted from the rows loaded on this board" : ""}
         </p>
       </div>
       <ul className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1">

--- a/apps/web/components/dashboard/DashboardEmptyState.tsx
+++ b/apps/web/components/dashboard/DashboardEmptyState.tsx
@@ -3,7 +3,7 @@ import { Inbox, Mail, Upload, type LucideIcon } from "lucide-react";
 
 import { AddApplicationForm } from "@/components/applications/AddApplicationForm";
 import { PipelineBoard } from "@/components/dashboard/PipelineBoard";
-import { DEMO_APPLICATIONS_AS_API } from "@/lib/demo/asApplications";
+import { demoApplicationsAsApi } from "@/lib/demo/asApplications";
 import { summarize } from "@/lib/dashboard/summary";
 
 const ROUTES: { href: string; title: string; body: string; icon: LucideIcon }[] = [
@@ -62,9 +62,16 @@ export function ForwardRoutes() {
  * A labelled preview built from sample data. Clearly tagged "not yours" and
  * inert, it lets any no-board state still demonstrate exactly what a populated
  * dashboard looks like.
+ *
+ * The fixtures are dated relative to now (see `lib/demo/demoData.ts`) and
+ * resolved HERE, at render, on the server: this is a server component, so the
+ * rows travel to the client as props and the browser never re-derives them.
+ * What the preview must show is a healthy board — it used to show one where
+ * every card had gone quiet, because the fixture dates were frozen in July.
  */
 export function SamplePreview() {
-  const summary = summarize(DEMO_APPLICATIONS_AS_API);
+  const applications = demoApplicationsAsApi();
+  const summary = summarize(applications);
 
   return (
     <section aria-label="Sample dashboard preview" className="space-y-4">
@@ -88,7 +95,7 @@ export function SamplePreview() {
           {summary.total} filed · {summary.inMotion} in motion · {summary.offers} offer
           {summary.offers === 1 ? "" : "s"}
         </p>
-        <PipelineBoard applications={DEMO_APPLICATIONS_AS_API} interactive={false} />
+        <PipelineBoard applications={applications} interactive={false} />
       </div>
     </section>
   );

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -107,9 +107,19 @@ function StaticApplicationCard({
  * `rejected`/`withdrawn`/`ghosted`, so it is headed `closed` and every card in
  * it states its own status (see `lib/dashboard/board.ts`).
  *
- * The public demo and sample previews pass `interactive={false}` for read-only
- * cards whose mutations never fire — search and filters still work there,
- * because `/demo` renders this same component on fixtures.
+ * `interactive={false}` is the INERT board: the sample preview inside the
+ * dashboard's empty state, which sits under `pointer-events-none`. It renders
+ * read-only cards (mutations there would 401 without a session) and no search
+ * field — a search input a user cannot focus is chrome that invites typing and
+ * eats nothing. `/demo` is NOT that board: it renders this component fully
+ * interactive over fixtures, and only the transport is simulated, which is
+ * what gives the session-gated surfaces their executing e2e coverage.
+ *
+ * Scope honesty: the signed-in board is ONE bounded page of a possibly larger
+ * account, so it takes the account's true `total` and says which slice it is
+ * showing when the two differ — the same rule and phrasing as the pulse strip.
+ * Everything derived from the loaded rows (the "+N at" chip, the company band)
+ * is then explicitly counted from that slice, never claimed as the whole.
  */
 const COLLAPSED_COUNT = 8;
 
@@ -161,10 +171,15 @@ function BoardCell({
 
 export function PipelineBoard({
   applications,
+  total,
   interactive = true,
   transport = liveBoardTransport,
 }: {
   applications: Application[];
+  /** The account's true row count, when the caller knows it and it can exceed
+   *  what was loaded. Omitted where the given rows ARE everything (the demo
+   *  store, the sample fixtures) — then there is no slice to disclose. */
+  total?: number;
   interactive?: boolean;
   /** How mutations reach data — the live proxy by default, fixtures on /demo. */
   transport?: BoardTransport;
@@ -204,7 +219,18 @@ export function PipelineBoard({
     setPendingMoves(next);
   }
 
-  /** How many OTHER cards share each company — drives the "+N at" chip. */
+  /**
+   * True when these rows are one page of a bigger account. Everything the
+   * board derives — the column counts, the "+N at" chip, the company band —
+   * then describes the LOADED rows only, and says so rather than passing
+   * itself off as the account.
+   */
+  const truncated = total !== undefined && applications.length < total;
+  const scopeNote = truncated ? `newest ${applications.length} of ${total}` : null;
+
+  /** How many OTHER cards share each company ON THIS BOARD — drives the "+N
+   *  at" chip. Under truncation an employer can hold rows that never loaded,
+   *  so the chip is a floor, not a census; the band states the same scope. */
   const companyCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const app of applications) {
@@ -223,7 +249,7 @@ export function PipelineBoard({
     return true;
   });
 
-  /** The active employer's FULL set — what the band describes. */
+  /** The active employer's rows ON THIS BOARD — what the band describes. */
   const companySet =
     companyFilter !== null
       ? applications.filter((app) => app.company === companyFilter)
@@ -263,7 +289,11 @@ export function PipelineBoard({
     router.refresh();
   }
 
-  const showSearch = applications.length > SEARCH_AFTER;
+  // Never on the inert preview: `interactive={false}` renders inside
+  // `pointer-events-none`, where 14 fixtures cleared this threshold and put a
+  // search box on a brand-new user's first dashboard that they could not type
+  // into.
+  const showSearch = interactive && applications.length > SEARCH_AFTER;
 
   // --- Column widths: space follows content --------------------------------
   // A real search's board is one heavy column and three near-empty ones, and
@@ -287,7 +317,7 @@ export function PipelineBoard({
   return (
     <div className="space-y-3">
       {/* --- Board filters ------------------------------------------------- */}
-      {showSearch || filterActive ? (
+      {showSearch || filterActive || scopeNote ? (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           {showSearch ? (
             <div className="relative flex-1 basis-56">
@@ -310,6 +340,14 @@ export function PipelineBoard({
               {filtered.length} of {applications.length} shown
             </span>
           ) : null}
+          {/* The subtitle counts the whole account; these four columns can
+              only count what loaded. Without this line "250 filed" sat above
+              columns summing to 200 and neither number explained the other. */}
+          {scopeNote ? (
+            <span className="tabular text-xs text-dim">
+              board shows the {scopeNote} · older rows aren&apos;t loaded
+            </span>
+          ) : null}
         </div>
       ) : null}
 
@@ -319,6 +357,7 @@ export function PipelineBoard({
           company={companyFilter}
           apps={companySet}
           statusOf={shownStatus}
+          partial={truncated}
           onClear={() => setCompanyFilter(null)}
         />
       ) : null}

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -177,9 +177,15 @@ export function PipelinePulse({
             />
           ) : null}
         </div>
+        {/* The scope note is not optional here just because the denominator is
+            the loaded count: "120 of 200" reads as the whole account to anyone
+            who hasn't done the arithmetic, and this cell's own aria-label has
+            always said "of 200 LOADED rows". The visible line now agrees with
+            the label, and with the other two cells. */}
         <p className="tabular mt-2 text-xs text-muted">
           <span className="tabular text-strong">{autoFiled}</span> of {applications.length}{" "}
           auto-filed from mail
+          {scopeNote ? <span className="text-dim"> · {scopeNote}</span> : null}
         </p>
         {needsReview > 0 ? (
           <Link

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -6,9 +6,10 @@ import { AddApplicationForm } from "@/components/applications/AddApplicationForm
 import { PipelineBoard } from "@/components/dashboard/PipelineBoard";
 import { PipelinePulse } from "@/components/dashboard/PipelinePulse";
 import { SyncBar, type SyncGmailState } from "@/components/dashboard/SyncBar";
+import { todayISO } from "@/lib/dashboard/age";
 import { summarize, type Application } from "@/lib/dashboard/summary";
 import type { BoardTransport, SyncTransport } from "@/lib/dashboard/transport";
-import { DEMO_APPLICATIONS_AS_API, DEMO_UNSYNCED_AS_API } from "@/lib/demo/asApplications";
+import { demoApplicationsAsApi, demoUnsyncedAsApi } from "@/lib/demo/asApplications";
 import { demoDetailBody } from "@/lib/demo/demoDetail";
 
 /**
@@ -74,11 +75,18 @@ function delay(ms: number): Promise<void> {
 }
 
 export function DemoDashboard() {
-  const [snapshot, setSnapshot] = useState<DemoBoard>(() => ({
-    apps: DEMO_APPLICATIONS_AS_API,
-    pool: DEMO_UNSYNCED_AS_API,
-    touched: [],
-  }));
+  // ONE clock read for the whole mount: the fixture dates are relative, so
+  // every row in this store — board and unsynced pool alike — is aged against
+  // the same "today" the board renders with. Resolving them here rather than
+  // at module load is what keeps a long-lived server's HTML and the browser's
+  // hydration agreeing on what "16 days ago" means.
+  const [snapshot, setSnapshot] = useState<DemoBoard>(() => {
+    const today = todayISO();
+    return { apps: demoApplicationsAsApi(today), pool: demoUnsyncedAsApi(today), touched: [] };
+  });
+  /** The pristine fixtures, kept for `restore` — the rows this board began
+   *  with, before any drag, dismissal or rebuild touched them. */
+  const original = useRef<Application[]>([...snapshot.apps, ...snapshot.pool]);
   const store = useRef(snapshot);
   const commit = useCallback((next: DemoBoard) => {
     store.current = next;
@@ -185,13 +193,12 @@ export function DemoDashboard() {
         await delay(300);
         const s = store.current;
         // The removed row is not in `apps` anymore; recover it from the
-        // fixtures (its edits died with the removal, as a real dismissal's
-        // board row does — restore brings back the row, not the session).
-        const original =
-          DEMO_APPLICATIONS_AS_API.find((app) => app.id === id) ??
-          DEMO_UNSYNCED_AS_API.find((app) => app.id === id);
-        if (!original) return false;
-        commit({ ...s, apps: [...s.apps, original] });
+        // fixtures this mount started with (its edits died with the removal,
+        // as a real dismissal's board row does — restore brings back the row,
+        // not the session).
+        const row = original.current.find((app) => app.id === id);
+        if (!row) return false;
+        commit({ ...s, apps: [...s.apps, row] });
         return true;
       },
     }),
@@ -208,15 +215,18 @@ export function DemoDashboard() {
       <SyncBar subtitle={subtitle} gmail={DEMO_GMAIL} transport={syncTransport}>
         <AddApplicationForm mode="demo" />
       </SyncBar>
-      {/* Same strip as the signed-in dashboard, over the fixture store: the
-          fixtures are the full board, so total is exact and the momentum /
-          ageing / classifier cells derive from what is actually on screen —
-          press Sync and the fresh rows move the bars. */}
-      <PipelinePulse
-        applications={snapshot.apps}
-        total={snapshot.apps.length}
-        needsReview={0}
-      />
+      {/* Same strip as the signed-in dashboard, over the fixture store.
+          `total` is the store's own length because on this board it IS the
+          whole account — the strip's scope note ("newest N of M") therefore
+          never fires here by construction, not by omission; the live
+          dashboard is where a bounded page makes it real.
+          `needsReview` is 0 deliberately, not a stub: /demo mounts no review
+          queue for a held verdict to point at, and the cell's non-zero branch
+          deep-links to /dashboard#needs-classification — an auth-gated route
+          that would dead-end an anonymous visitor. The fixture queue
+          (DEMO_REVIEW_QUEUE) does hold one sub-gate message; the DecisionTrace
+          lower down this page is where it is shown and explained. */}
+      <PipelinePulse applications={snapshot.apps} total={snapshot.apps.length} needsReview={0} />
       <PipelineBoard applications={snapshot.apps} transport={boardTransport} />
     </section>
   );

--- a/apps/web/components/gmail/InboxWorkbench.tsx
+++ b/apps/web/components/gmail/InboxWorkbench.tsx
@@ -184,6 +184,10 @@ interface InboxSnapshot {
   savedAt: number;
   verdicts: InboxVerdict[];
   analysis: PipelineAnalysis | null;
+  /** The analysis call failed for this mine — a null `analysis` alone cannot
+   *  say whether it failed or was simply never reached, and the follow-up
+   *  panel must not vanish silently on a rehydrated mine either. */
+  analysisFailed?: boolean;
   fetched: number;
   target: number;
 }
@@ -220,6 +224,10 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
   const [filters, setFilters] = useState<InboxFilters>(DEFAULT_FILTERS);
   const [verdicts, setVerdicts] = useState<InboxVerdict[]>([]);
   const [analysis, setAnalysis] = useState<PipelineAnalysis | null>(null);
+  /** The whole-set analysis failed for the current mine — the ghosting panel
+   *  says so instead of not rendering (an absent panel reads as "nobody has
+   *  ghosted you", which is a claim we cannot make without the analysis). */
+  const [analysisFailed, setAnalysisFailed] = useState(false);
   const [state, setState] = useState<FetchState>({
     phase: "loading",
     fetched: 0,
@@ -247,6 +255,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
 
     setVerdicts([]);
     setAnalysis(null);
+    setAnalysisFailed(false);
     setState({ phase: "loading", fetched: 0, target });
     // A new mine invalidates the last filing report — it described a different set.
     setFiling({ phase: "idle", note: null });
@@ -286,20 +295,36 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
 
       const pipelineItems = toPipelineItems(acc);
 
-      // Whole-set analysis (category summary + follow-up flags).
-      const analysisRes = await fetch("/api/gmail/pipeline", {
-        method: "POST",
-        cache: "no-store",
-        signal: ac.signal,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: pipelineItems }),
-      });
-      if (runId !== runIdRef.current) return;
+      // Whole-set analysis (category summary + follow-up flags) — in its OWN
+      // try/catch. The mine has already succeeded by this point, so a thrown
+      // analysis fetch must not fall into the outer catch and mark the whole
+      // mine failed: that would put a "we couldn't read your mail" banner over
+      // a complete, correct verdict list (and skip the snapshot, re-mining
+      // Gmail on the next visit). A failure here degrades to the per-verdict
+      // category tally, with the follow-up panel saying it is unavailable.
       let analysisData: PipelineAnalysis | null = null;
-      if (analysisRes.ok) {
-        analysisData = (await analysisRes.json()) as PipelineAnalysis;
-        setAnalysis(analysisData);
+      let analysisBroke = false;
+      try {
+        const analysisRes = await fetch("/api/gmail/pipeline", {
+          method: "POST",
+          cache: "no-store",
+          signal: ac.signal,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ items: pipelineItems }),
+        });
+        if (runId !== runIdRef.current) return;
+        if (analysisRes.ok) {
+          analysisData = (await analysisRes.json()) as PipelineAnalysis;
+          setAnalysis(analysisData);
+        } else {
+          analysisBroke = true;
+        }
+      } catch {
+        // An abort is a newer mine taking over, not a failure.
+        if (ac.signal.aborted || runId !== runIdRef.current) return;
+        analysisBroke = true;
       }
+      setAnalysisFailed(analysisBroke);
       setState({ phase: "ready", fetched: acc.length, target });
 
       // Persist this mine so a remount with the same filters (e.g. navigating
@@ -309,6 +334,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
         savedAt: Date.now(),
         verdicts: acc,
         analysis: analysisData,
+        analysisFailed: analysisBroke,
         fetched: acc.length,
         target,
       });
@@ -341,6 +367,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
           if (snap) {
             setVerdicts(snap.verdicts);
             setAnalysis(snap.analysis);
+            setAnalysisFailed(snap.analysisFailed === true);
             setState({ phase: "ready", fetched: snap.fetched, target: snap.target });
             return;
           }
@@ -427,6 +454,9 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
   }, [router, verdicts]);
 
   const loading = state.phase === "loading";
+  /** The MINE broke (Gmail/proxy). Distinct from `analysisFailed`, which is a
+   *  successful mine whose whole-set analysis didn't answer. */
+  const mineFailed = state.phase === "error";
   const progressPct =
     state.target > 0 ? Math.min(100, Math.round((state.fetched / state.target) * 100)) : 0;
 
@@ -549,6 +579,33 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
         )}
       </div>
 
+      {/* --- A failed mine, led with --------------------------------------
+          The failure used to be a small dim line at the very BOTTOM of the
+          page, under a success-shaped empty box reading "No messages matched
+          this range" — a completed-scan verdict about a mailbox we never
+          finished reading. It now sits first, directly under the scan
+          controls, and the empty box does not render at all when nothing was
+          read. */}
+      {mineFailed ? (
+        <div role="alert" className="rounded-xl border border-reject/40 bg-surface p-6">
+          <p className="label-caps text-reject">scan failed</p>
+          <h2 className="mt-2 text-base font-medium text-strong">
+            We couldn&apos;t finish reading your mail.
+          </h2>
+          <p className="mt-1.5 text-sm text-muted">
+            {state.fetched > 0
+              ? `The scan stopped after ${state.fetched.toLocaleString()} of ${state.target.toLocaleString()} messages, so what's below is partial — not a picture of your whole mailbox.`
+              : "Nothing was read, so nothing here says anything about what your mailbox holds."}{" "}
+            Press Refresh to try again.
+          </p>
+          {state.errorStatus ? (
+            <p className="tabular mt-1 font-mono text-[11px] text-dim">
+              mail backend responded {state.errorStatus}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
       {/* --- File the mine into the pipeline ------------------------------ */}
       {state.phase === "ready" && jobRelatedTotal > 0 ? (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-line-soft bg-surface px-4 py-3">
@@ -604,8 +661,23 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
         </div>
       ) : null}
 
-      {/* --- Needs follow-up (ghosting) ----------------------------------- */}
-      {followUps.length > 0 ? (
+      {/* --- Needs follow-up (ghosting) -----------------------------------
+          A missing answer is not an empty one. When the analysis call fails
+          this panel used to simply not render, and "no ghosting panel" reads
+          as "nobody has ghosted you" — a claim only the analysis can make. */}
+      {analysisFailed ? (
+        <div role="status" className="rounded-xl border border-line-soft bg-surface p-5">
+          <h2 className="flex items-center gap-2 text-base font-medium text-strong">
+            <Bell className="h-4 w-4 text-dim" aria-hidden />
+            Needs follow-up — unavailable
+          </h2>
+          <p className="mt-1 text-sm text-muted">
+            The follow-up analysis didn&apos;t answer for this mine, so we can&apos;t say who has
+            gone silent on you. This is a missing answer, not an empty one — the messages below
+            are unaffected, and Refresh runs it again.
+          </p>
+        </div>
+      ) : followUps.length > 0 ? (
         <div className="rounded-xl border border-review/40 bg-surface p-5">
           <h2 className="flex items-center gap-2 text-base font-medium text-strong">
             <Bell className="h-4 w-4 text-review" aria-hidden />
@@ -708,26 +780,19 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
             <SkeletonRow key={i} />
           ))}
         </ul>
-      ) : filtered.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-line-soft bg-surface p-8 text-center text-sm text-muted">
-          {verdicts.length === 0
-            ? "No messages matched this range. Widen the age window or switch to All mail."
-            : "No messages match these view filters."}
-        </div>
-      ) : (
+      ) : filtered.length > 0 ? (
         <ul className="rounded-xl border border-line-soft bg-surface px-3">
           {filtered.map((v) => (
             <VerdictRow key={v.message_id} v={v} />
           ))}
         </ul>
+      ) : mineFailed && verdicts.length === 0 ? null : (
+        <div className="rounded-xl border border-dashed border-line-soft bg-surface p-8 text-center text-sm text-muted">
+          {verdicts.length === 0
+            ? "No messages matched this range. Widen the age window or switch to All mail."
+            : "No messages match these view filters."}
+        </div>
       )}
-
-      {state.phase === "error" ? (
-        <p className="text-xs text-review">
-          The mail backend hiccuped{state.errorStatus ? ` (${state.errorStatus})` : ""} — press
-          Refresh to try again.
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -124,10 +124,18 @@ export function classifyReviewItem(
   messageId: string,
   category: string,
   company?: string,
+  applicationId?: number,
 ): Promise<ApiCallResult> {
   const named = company?.trim();
   return call(`/applications/review/${encodeURIComponent(messageId)}/classify`, {
     method: "POST",
-    body: named ? { category, company: named } : { category },
+    body: {
+      category,
+      ...(named ? { company: named } : {}),
+      // The user's own answer to "which application is this about?". Omitted
+      // rather than sent as null when absent, so the backend's "no choice was
+      // made" path stays distinguishable from "the choice was empty".
+      ...(applicationId !== undefined ? { application_id: applicationId } : {}),
+    },
   });
 }

--- a/apps/web/lib/demo/asApplications.ts
+++ b/apps/web/lib/demo/asApplications.ts
@@ -4,9 +4,19 @@
  * the signed-in dashboard's sample preview. One component tree, two data
  * sources — verifying the public demo therefore verifies the real dashboard's
  * building blocks.
+ *
+ * These are functions, not constants, because the fixture dates are relative
+ * (see `demoData.ts`): they must be resolved during a render, against the same
+ * clock read that render ages them with, not frozen at module load.
  */
+import { todayISO } from "@/lib/dashboard/age";
 import type { Application } from "@/lib/dashboard/summary";
-import { DEMO_APPLICATIONS, DEMO_UNSYNCED, type DemoApplication } from "@/lib/demo/demoData";
+import {
+  DEMO_APPLICATION_COUNT,
+  demoApplications,
+  demoUnsynced,
+  type DemoApplication,
+} from "@/lib/demo/demoData";
 
 function toApi(app: DemoApplication, id: number): Application {
   return {
@@ -25,11 +35,11 @@ function toApi(app: DemoApplication, id: number): Application {
 }
 
 /** The demo applications, projected onto the API `Application` type. */
-export const DEMO_APPLICATIONS_AS_API: Application[] = DEMO_APPLICATIONS.map((app, index) =>
-  toApi(app, index + 1),
-);
+export function demoApplicationsAsApi(today: string = todayISO()): Application[] {
+  return demoApplications(today).map((app, index) => toApi(app, index + 1));
+}
 
 /** The not-yet-synced fixture rows, ids continuing after the board's. */
-export const DEMO_UNSYNCED_AS_API: Application[] = DEMO_UNSYNCED.map((app, index) =>
-  toApi(app, DEMO_APPLICATIONS.length + index + 1),
-);
+export function demoUnsyncedAsApi(today: string = todayISO()): Application[] {
+  return demoUnsynced(today).map((app, index) => toApi(app, DEMO_APPLICATION_COUNT + index + 1));
+}

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -3,7 +3,23 @@
  * companies and roles reuse the vocabulary of the backend's mock
  * training generator. No inbox is read; nothing here touches Supabase
  * or the API.
+ *
+ * Dates are RELATIVE, and that is load-bearing. They used to be absolute
+ * (`2026-07-15`), so the fixtures aged a day per day against a clock that kept
+ * moving: by August every applied card in the dashboard's sample preview — the
+ * one screen whose whole job is to show a healthy board — carried an amber
+ * "· quiet 27d" tag, and the momentum strip was two months from eight flat
+ * bars. Each seed carries `filedDaysAgo` instead, resolved against a single
+ * "now" per render, so the demo's SHAPE is fixed while its dates stay current.
+ *
+ * The offsets encode a deliberate ageing spread across the 11 open rows — 4
+ * under a week, 4 waiting, 3 past the quiet line (`QUIET_AFTER_DAYS`) — so all
+ * three pulse buckets draw, the quiet signal is demonstrated without the board
+ * looking abandoned, and every row lands inside the 8-week momentum window.
+ * Changing an offset changes what the e2e sees: the counts and the "quiet Nd"
+ * tag asserted in tests/e2e/demo.spec.ts are the contract.
  */
+import { todayISO } from "@/lib/dashboard/age";
 
 export type DemoStatus = "applied" | "interviewing" | "offered" | "rejected";
 
@@ -12,9 +28,16 @@ export interface DemoApplication {
   company: string;
   position: string;
   status: DemoStatus;
+  /** Calendar day filed — resolved from the seed against the render's "today". */
   appliedAt: string;
   lastSignal: string; // the most recent classified email, one line
 }
+
+/** A fixture row before its date is resolved: an age, not a calendar day. */
+type DemoSeed = Omit<DemoApplication, "appliedAt"> & {
+  /** Whole days before "today" this application was filed. */
+  filedDaysAgo: number;
+};
 
 export interface DemoReviewItem {
   subject: string;
@@ -25,6 +48,22 @@ export interface DemoReviewItem {
   needsReview: boolean;
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * `today` minus n whole days, as a plain calendar-day string. UTC arithmetic —
+ * exactly what `daysBetween` inverts — so a row seeded at 16 reads back as "16
+ * days old" on the server and in the browser alike, in any timezone.
+ */
+function daysBefore(today: string, days: number): string {
+  return new Date(Date.parse(`${today}T00:00:00Z`) - days * DAY_MS).toISOString().slice(0, 10);
+}
+
+function resolve(seed: DemoSeed, today: string): DemoApplication {
+  const { filedDaysAgo, ...row } = seed;
+  return { ...row, appliedAt: daysBefore(today, filedDaysAgo) };
+}
+
 /**
  * Shaped like a REAL early-search board, not a brochure: the applied column is
  * heavy (10 of 14), offered is empty, and one employer holds several
@@ -33,39 +72,66 @@ export interface DemoReviewItem {
  * does: company+role as the card identity, the "N more at …" affordance,
  * cross-column same-company cards, an applied column past the collapse
  * threshold, and an honestly empty column.
+ *
+ * Order matters as much as the dates: the applied column renders in this
+ * order, and the collapse expander test depends on Copperline and Waypoint
+ * being the two that wait behind "show all 10".
  */
-export const DEMO_APPLICATIONS: DemoApplication[] = [
+const APPLICATION_SEEDS: DemoSeed[] = [
   // Northstar Systems ×3 — one advanced, two still applied. Three cards, three
   // distinct roles, two different columns: an application is not a company.
-  { id: "a1", company: "Northstar Systems", position: "ML Engineer", status: "interviewing", appliedAt: "2026-06-28", lastSignal: "Interview availability — technical round" },
-  { id: "a2", company: "Northstar Systems", position: "ML Engineer, Platform", status: "applied", appliedAt: "2026-07-09", lastSignal: "Your application was received" },
-  { id: "a3", company: "Northstar Systems", position: "Research Engineer, Applied ML", status: "applied", appliedAt: "2026-07-09", lastSignal: "Thanks for applying" },
+  { id: "a1", company: "Northstar Systems", position: "ML Engineer", status: "interviewing", filedDaysAgo: 18, lastSignal: "Interview availability — technical round" },
+  { id: "a2", company: "Northstar Systems", position: "ML Engineer, Platform", status: "applied", filedDaysAgo: 16, lastSignal: "Your application was received" },
+  { id: "a3", company: "Northstar Systems", position: "Research Engineer, Applied ML", status: "applied", filedDaysAgo: 15, lastSignal: "Thanks for applying" },
   // Cedar Labs ×2 — one open, one already closed.
-  { id: "a4", company: "Cedar Labs", position: "Software Engineer, Platform", status: "applied", appliedAt: "2026-07-08", lastSignal: "Your application was received" },
-  { id: "a5", company: "Cedar Labs", position: "Site Reliability Engineer", status: "rejected", appliedAt: "2026-06-14", lastSignal: "Moving forward with other candidates" },
+  { id: "a4", company: "Cedar Labs", position: "Software Engineer, Platform", status: "applied", filedDaysAgo: 12, lastSignal: "Your application was received" },
+  { id: "a5", company: "Cedar Labs", position: "Site Reliability Engineer", status: "rejected", filedDaysAgo: 34, lastSignal: "Moving forward with other candidates" },
   // Single-application employers — the common case, which stays untaxed.
-  { id: "a6", company: "Harbor Analytics", position: "Backend Engineer", status: "applied", appliedAt: "2026-07-02", lastSignal: "Application under review" },
-  { id: "a7", company: "Summit Platform", position: "Full-Stack Engineer", status: "applied", appliedAt: "2026-07-10", lastSignal: "Application under review" },
-  { id: "a8", company: "Quarry Data", position: "Data Engineer", status: "applied", appliedAt: "2026-07-11", lastSignal: "Thanks for applying" },
-  { id: "a9", company: "Beacon Health", position: "ML Engineer, Risk", status: "applied", appliedAt: "2026-07-12", lastSignal: "We received your application" },
-  { id: "a10", company: "Fernworks", position: "Systems Engineer", status: "rejected", appliedAt: "2026-06-05", lastSignal: "Update on your application" },
-  { id: "a11", company: "Atlas Freight", position: "Software Engineer II", status: "rejected", appliedAt: "2026-06-12", lastSignal: "Moving forward with other candidates" },
-  { id: "a12", company: "Juniper Cloud", position: "Infrastructure Engineer", status: "applied", appliedAt: "2026-07-13", lastSignal: "We received your application" },
-  { id: "a13", company: "Copperline", position: "Backend Engineer, Payments", status: "applied", appliedAt: "2026-07-14", lastSignal: "We received your application" },
-  { id: "a14", company: "Waypoint Robotics", position: "Software Engineer, Controls", status: "applied", appliedAt: "2026-07-15", lastSignal: "Thanks for applying" },
+  { id: "a6", company: "Harbor Analytics", position: "Backend Engineer", status: "applied", filedDaysAgo: 11, lastSignal: "Application under review" },
+  { id: "a7", company: "Summit Platform", position: "Full-Stack Engineer", status: "applied", filedDaysAgo: 9, lastSignal: "Application under review" },
+  { id: "a8", company: "Quarry Data", position: "Data Engineer", status: "applied", filedDaysAgo: 8, lastSignal: "Thanks for applying" },
+  { id: "a9", company: "Beacon Health", position: "ML Engineer, Risk", status: "applied", filedDaysAgo: 6, lastSignal: "We received your application" },
+  { id: "a10", company: "Fernworks", position: "Systems Engineer", status: "rejected", filedDaysAgo: 45, lastSignal: "Update on your application" },
+  { id: "a11", company: "Atlas Freight", position: "Software Engineer II", status: "rejected", filedDaysAgo: 38, lastSignal: "Moving forward with other candidates" },
+  { id: "a12", company: "Juniper Cloud", position: "Infrastructure Engineer", status: "applied", filedDaysAgo: 5, lastSignal: "We received your application" },
+  { id: "a13", company: "Copperline", position: "Backend Engineer, Payments", status: "applied", filedDaysAgo: 3, lastSignal: "We received your application" },
+  { id: "a14", company: "Waypoint Robotics", position: "Software Engineer, Controls", status: "applied", filedDaysAgo: 2, lastSignal: "Thanks for applying" },
 ];
 
 /**
  * Fixture mail the demo account has NOT synced yet. Pressing `Sync` on /demo
  * files these into the board through the real SyncBar state machine, so the
  * demo demonstrates the product's actual loop (sync → new cards appear) on
- * data that is still entirely synthetic. Kept out of DEMO_APPLICATIONS so the
- * board's initial counts stay the honest 14.
+ * data that is still entirely synthetic. Kept out of the board seeds so the
+ * initial counts stay the honest 14, and dated as the newest mail there is —
+ * they are what "new since your last sync" means.
  */
-export const DEMO_UNSYNCED: DemoApplication[] = [
-  { id: "u1", company: "Twitch", position: "Software Engineer, Creator Tools", status: "applied", appliedAt: "2026-08-08", lastSignal: "Your application was received" },
-  { id: "u2", company: "DoorDash", position: "Backend Engineer, Logistics", status: "applied", appliedAt: "2026-08-09", lastSignal: "Thanks for applying" },
+const UNSYNCED_SEEDS: DemoSeed[] = [
+  { id: "u1", company: "Twitch", position: "Software Engineer, Creator Tools", status: "applied", filedDaysAgo: 1, lastSignal: "Your application was received" },
+  { id: "u2", company: "DoorDash", position: "Backend Engineer, Logistics", status: "applied", filedDaysAgo: 0, lastSignal: "Thanks for applying" },
 ];
+
+/** How many rows the demo board starts with — ids continue after these. */
+export const DEMO_APPLICATION_COUNT = APPLICATION_SEEDS.length;
+
+/**
+ * The demo board's applications, dated against one `today`.
+ *
+ * Callers pass the SAME clock read they render with (`todayISO()`), and call
+ * this during render rather than at module load: a module-level resolution
+ * freezes at process start, which on a long-lived dev server or a warm lambda
+ * means the server renders yesterday's dates into HTML the browser then
+ * hydrates with today's — a mismatch that repairs itself loudly, in the
+ * console.
+ */
+export function demoApplications(today: string = todayISO()): DemoApplication[] {
+  return APPLICATION_SEEDS.map((seed) => resolve(seed, today));
+}
+
+/** The not-yet-synced fixture mail, dated against the same `today`. */
+export function demoUnsynced(today: string = todayISO()): DemoApplication[] {
+  return UNSYNCED_SEEDS.map((seed) => resolve(seed, today));
+}
 
 export const DEMO_REVIEW_QUEUE: DemoReviewItem[] = [
   { subject: "Interview availability — technical round", from: "recruiting@northstar.dev", category: "interview", confidence: 0.991, method: "setfit", needsReview: false },

--- a/apps/web/lib/demo/demoDetail.ts
+++ b/apps/web/lib/demo/demoDetail.ts
@@ -16,10 +16,17 @@ function slug(company: string): string {
   return company.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-/** `2026-07-08` + n days, kept as a plain calendar string. */
+/**
+ * The filed date + n days — never in the future, and never before the mail it
+ * follows. The clamp is load-bearing since the fixture dates went relative
+ * (`demoData.ts`): the newest board rows are now days old, not weeks, so a
+ * visitor dragging one to interviewing would otherwise open its detail sheet
+ * onto a follow-up email "received" next week.
+ */
 function daysAfter(isoDate: string, days: number): string {
-  const ms = Date.parse(`${isoDate.slice(0, 10)}T12:00:00Z`) + days * 24 * 60 * 60 * 1000;
-  return new Date(ms).toISOString();
+  const filed = Date.parse(`${isoDate.slice(0, 10)}T12:00:00Z`);
+  const shifted = filed + days * 24 * 60 * 60 * 1000;
+  return new Date(Math.max(filed, Math.min(shifted, Date.now()))).toISOString();
 }
 
 const LATEST_CATEGORY: Record<string, { category: string; confidence: number }> = {

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -2056,7 +2056,14 @@ async def list_applications_cloud(
         stmt = (
             select(Application)
             .where(*filters)
-            .order_by(Application.created_at.desc())
+            # `id` breaks the tie, and it has to. A first Gmail rebuild writes
+            # hundreds of rows inside the same second, so ordering on
+            # `created_at` alone leaves them tied en masse and Postgres is free
+            # to return them in a different order per request. Paging through a
+            # non-deterministic order silently drops and repeats rows across
+            # pages — which the export now walks, and which the board's "newest
+            # 200 of 250" claim depends on being true.
+            .order_by(Application.created_at.desc(), Application.id.desc())
             .offset(offset)
             .limit(page_size)
         )


### PR DESCRIPTION
An audit of the paths nobody had stood in. This account has 25 applications, a connected Gmail and a happy board, and essentially all live testing has been against it — so every state that isn't that one was unexercised.

Eleven findings, ordered by what a new user hits on a bad first day.

## Breaks

**The review queue's answer died in transit.** When an employer holds several applications, the queue asks which one a message belongs to. The client sent `application_id`; the backend accepted and validated it; the Next.js proxy in between rebuilt the request body and dropped it — so the backend fell back to picking the employer's first row, which is precisely the arbitrary-sibling filing `_pick_application` was written to stop. **Third time** a rebuilt body has silently lost a field on this path (`confidence` in the inbox relay, `applied_date`/`url` on create); the comment now says so.

**"Export everything Applied holds for you" returned 100 rows.** One unparameterised call, and the backend defaults to a page size of 100. A user with 250 applications got 100 — data loss in the one feature whose entire job is handing their data back. Now paginated to the backend's own 500 ceiling, and a mid-export failure refuses to return a short file that looks complete.

**Listing ordered on `created_at` alone.** A first Gmail rebuild writes hundreds of rows inside one second, so the ties broke arbitrarily and paging could drop and repeat rows. `id` now breaks the tie — which the export's new loop and the board's "newest 200 of 250" both depend on.

## Misleads

**Every backend failure read as a session problem.** A 500 rendered *"The backend rejected this session… Signing in again usually clears it"* with a sign-in link. A new user during an incident was sent to re-authenticate for something authentication cannot fix. 401/403 are now separated from faults.

**`/inbox` rendered "No messages matched this range" over a FAILED mine** — asserting the scan ran and the mailbox is empty, with the honest error in small dim text below it. The failure now leads; partial results say they're partial. (Bonus found in review: a *thrown* analysis call marked the whole mine failed and skipped the snapshot write, re-mining Gmail on every visit.)

**A failed follow-up analysis made the ghosting panel vanish**, so the user concluded nobody had ghosted them. It now says it's unavailable.

**"No application emails detected yet" was asserted even when the arrival sync errored** — two contradicting claims on one screen for someone whose very first sync failed.

**The board silently truncated at 200** while the header quoted the true total. It now names what's loaded, as the pulse strip already did; the classifier cell gained the scope note its own `aria-label` already carried; the company band stopped claiming a "full row set" it only had a page of.

**The sample board a brand-new user first sees had aged into showing every card as "quiet 27d"** — the one screen meant to demonstrate a healthy pipeline showed a neglected one, degrading a day per day, and heading for eight flat momentum bars within two months. Fixtures are now offsets resolved against a single `today` per render, verified time-invariant at five simulated dates including 2028.

## Verification

456 backend tests pass. `tsc` and `lint` clean and positive-controlled — the compiled file list confirms every edited file is actually in the program rather than skipped, which is the failure shape this repo keeps producing.

The demo-fixture change is the highest-risk item and is going to `labrat` for the full suite: every `/demo` assertion depends on those dates, and the claim to check is that each asserted string stays byte-identical because `scopeNote` and `partial` are inert when `total === length`.

Two things stated rather than papered over: `/inbox`'s failure paths have **no e2e coverage at all**, so the two inbox items are verified by reading and typecheck only; and `demo.spec.ts:279` now carries a comment that is no longer true ("the fixture dates are static… any exact bucket count would rot") — the buckets are now permanently assertable, and that spec was left alone deliberately.
