### PR TITLE
feat(deadlines): record when something is actually due

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-456%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-475%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,13 +373,13 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**456 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 427 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 456 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**475 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 433 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 475 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
 Those tests drive the production machinery, not a fixture: `jobtracker.database.connection.get_session` with its real GUC and `search_path` handling, against a non-`BYPASSRLS` role, asserting that a raw query with the application-level `WHERE user_id = ...` filter *removed* still returns nothing for another tenant.
 
-**Coverage**, from the same run: **55.83%** overall — 9,053 statements, 3,999 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **81.5%**; `auth` 80.5%; `database` 77.0%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
+**Coverage**, from the same run: **56.21%** overall — 9,159 statements, 4,011 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **81.8%**; `auth` 80.5%; `database` 77.2%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -531,7 +531,7 @@ applied/
 │   │   ├── credentials/     # types · desktop (Keychain) · cloud (Fernet)
 │   │   ├── database/        # models, connection (the RLS GUC listener lives here)
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
-│   ├── alembic/versions/    # 10 revisions incl. the RLS + InitPlan-hoist migrations
+│   ├── alembic/versions/    # 11 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
 │   └── tests/               # 28 modules
 │

--- a/apps/web/app/api/applications/[id]/deadline/route.ts
+++ b/apps/web/app/api/applications/[id]/deadline/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { setApplicationDeadline } from "@/lib/applications/server";
+
+/**
+ * Same-origin proxy for "this is due at X" — and for clearing it.
+ *
+ * `due_at: null` clears. Set and clear are deliberately the same call: they are
+ * one decision, and splitting them is how a UI ends up offering the first
+ * without the second.
+ *
+ * The body is validated here rather than forwarded blind, because a malformed
+ * date reaching the backend would 422 with a message written for an API client
+ * rather than for someone who mistyped a date.
+ */
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PUT(req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params;
+  const n = Number(id);
+  if (!Number.isInteger(n) || n <= 0) {
+    return NextResponse.json({ detail: "Invalid application id" }, { status: 400 });
+  }
+
+  let body: { due_at?: unknown } = {};
+  try {
+    body = (await req.json()) as { due_at?: unknown };
+  } catch {
+    return NextResponse.json({ detail: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const raw = body.due_at;
+  if (raw !== null && typeof raw !== "string") {
+    return NextResponse.json(
+      { detail: "due_at must be an ISO-8601 date string, or null to clear it" },
+      { status: 422 },
+    );
+  }
+  if (typeof raw === "string" && Number.isNaN(Date.parse(raw))) {
+    return NextResponse.json(
+      { detail: `Could not read "${raw}" as a date` },
+      { status: 422 },
+    );
+  }
+
+  const r = await setApplicationDeadline(n, raw ?? null);
+  return NextResponse.json(r.data ?? {}, { status: r.status });
+}

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -76,6 +76,26 @@ export function restoreApplication(id: number): Promise<ApiCallResult> {
 }
 
 /**
+ * PUT /applications/{id}/deadline — set or clear when something is due.
+ *
+ * A date written through here is the USER's and is marked as such, so later
+ * syncs never overwrite it. A deadline read out of mail is refreshed when newer
+ * mail supersedes it; a deadline a person typed is a decision.
+ *
+ * `null` clears both the date and its origin — a source with no date would be a
+ * claim about nothing.
+ */
+export function setApplicationDeadline(
+  id: number,
+  dueAt: string | null,
+): Promise<ApiCallResult> {
+  return call(`/applications/${id}/deadline`, {
+    method: "PUT",
+    body: { due_at: dueAt },
+  });
+}
+
+/**
  * POST /applications/{id}/split — turn a merged row into the applications its
  * own stored mail describes.
  *

--- a/backend/alembic/versions/b7c31e0d94aa_application_deadlines.py
+++ b/backend/alembic/versions/b7c31e0d94aa_application_deadlines.py
@@ -1,0 +1,66 @@
+"""application deadlines (due_at, due_source)
+
+Revision ID: b7c31e0d94aa
+Revises: f1a2c9b73d40
+Create Date: 2026-08-11 20:10:00.000000
+
+Adds ``applications.due_at`` / ``applications.due_source`` so the product can
+keep the promise its own landing page opens with.
+
+Why
+---
+
+The landing page's PROBLEM section leads with "The assessment scrolls past — its
+48-hour deadline passes unseen." The application had no due-date field anywhere,
+so an assessment email was classified into a column and then behaved exactly
+like a rejection. The one failure mode the product names as its reason to exist
+was the one it did nothing about.
+
+Design notes
+------------
+
+- Both columns are plain nullable adds. NULL is the honest, permanent default:
+  a deadline exists only because a message stated one or a human typed one, and
+  it is never inferred. So every existing row is already in its correct state
+  and the upgrade needs no backfill.
+- ``due_source`` records WHO set it — ``mail`` or ``user`` — because the two are
+  different claims and the sync treats them differently: it may refresh a
+  ``mail`` deadline when later mail supersedes it, and must never touch one a
+  human set. Storing the date without its origin would make that impossible and
+  would leave the UI unable to say where a date came from.
+- ``due_at`` is indexed: "what is due soon" is a filtered, ordered read on every
+  dashboard load, and it is the query the feature exists to answer.
+- ``batch_alter_table`` is for SQLite compatibility only. Its default
+  ``recreate="auto"`` leaves Postgres on a plain ``ALTER TABLE ADD COLUMN``, so
+  the RLS policies and the FORCE flag on ``applications`` are untouched.
+- The downgrade drops both columns, which discards every deadline — including
+  the ones a user typed by hand. That is real data loss, not a clean rollback.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c31e0d94aa'
+down_revision: Union[str, Sequence[str], None] = 'f1a2c9b73d40'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('due_at', sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column('due_source', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        batch_op.create_index(batch_op.f('ix_applications_due_at'), ['due_at'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('applications', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_applications_due_at'))
+        batch_op.drop_column('due_source')
+        batch_op.drop_column('due_at')

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -59,6 +59,12 @@ logger = logging.getLogger(__name__)
 # owner saw on every row.
 _NO_ROLE = ""
 
+# Who set a deadline. A `user` one is a decision and the sync never overwrites
+# it; a `mail` one is a reading of the latest message that stated a date, and a
+# newer message may legitimately supersede it.
+DUE_FROM_USER = "user"
+DUE_FROM_MAIL = "mail"
+
 # ``Application.source`` doubles as an origin+ownership tag so a re-sync can
 # safely REPLACE the Gmail-derived pipeline while preserving anything the user
 # touched:
@@ -299,12 +305,27 @@ class CloudApplicationResponse(BaseModel):
     # UI render an "removed by re-sync — undo" affordance over ?dismissed=true.
     dismissed_at: str | None = None
     dismissed_reason: str | None = None
+    # When something is due on this application, and who said so. Both null
+    # together — a deadline with no origin would be a claim nobody made.
+    due_at: str | None = None
+    due_source: str | None = None
 
 
 class ApplicationStatusUpdate(BaseModel):
     """Body for a user's status correction (PATCH /applications/{id})."""
 
     status: ApplicationStatus
+
+
+class ApplicationDeadlineUpdate(BaseModel):
+    """Body for setting or clearing an application's deadline.
+
+    ``None`` clears it. There is deliberately no separate delete endpoint: set
+    and clear are the same decision, and splitting them invites a UI that offers
+    one without the other.
+    """
+
+    due_at: datetime | None = None
 
 
 class StatusVocabularyResponse(BaseModel):
@@ -947,6 +968,13 @@ async def upsert_applications_for_user(
                 or (_is_auto_row(existing.source) and r.role != existing.position)
             ):
                 existing.position = r.role
+            # A deadline the mail states refreshes one the mail previously
+            # stated — a rescheduled assessment is real news. It never touches
+            # one the user typed: that is a decision, and the sync does not get
+            # to overrule it.
+            if r.due_at is not None and existing.due_source != DUE_FROM_USER:
+                existing.due_at = r.due_at
+                existing.due_source = DUE_FROM_MAIL
             if r.applied_at and existing.applied_date is None:
                 existing.applied_date = r.applied_at.date()
             if deeplink and not existing.url:
@@ -969,6 +997,8 @@ async def upsert_applications_for_user(
                 url=deeplink,
                 req_id=r.req_id,
                 role_token=r.role_token,
+                due_at=r.due_at,
+                due_source=DUE_FROM_MAIL if r.due_at is not None else None,
             )
             session.add(app)
             await session.flush()
@@ -1974,6 +2004,8 @@ def _serialize(
         url=pipeline.retarget_gmail_deeplink(app.url, account_email),
         dismissed_at=app.dismissed_at.isoformat() if app.dismissed_at else None,
         dismissed_reason=app.dismissed_reason,
+        due_at=app.due_at.isoformat() if app.due_at else None,
+        due_source=app.due_source if app.due_at else None,
     )
 
 
@@ -2527,6 +2559,44 @@ async def update_application_status_cloud(
             status_code=http_status.HTTP_404_NOT_FOUND, detail="Application not found."
         )
     return _serialize(app)
+
+
+@router.put("/{application_id}/deadline", response_model=CloudApplicationResponse)
+async def set_application_deadline_cloud(
+    application_id: int,
+    data: ApplicationDeadlineUpdate,
+    user_id: uuid.UUID = Depends(current_user),
+) -> CloudApplicationResponse:
+    """Set or clear when something is due on this application.
+
+    A date written here is the USER's, and is marked as such: later syncs will
+    refresh a deadline that came from mail as newer mail supersedes it, and will
+    never touch this one. Sending ``null`` clears both the date and its origin,
+    because a source without a date is a claim about nothing.
+
+    404 when the row is not the caller's.
+    """
+
+    async with get_session() as session:
+        app = (
+            await session.exec(
+                select(Application).where(
+                    Application.user_id == user_id, Application.id == application_id
+                )
+            )
+        ).first()
+        if app is None:
+            raise HTTPException(
+                status_code=http_status.HTTP_404_NOT_FOUND, detail="Application not found."
+            )
+        due = pipeline.to_naive_utc(data.due_at) if data.due_at is not None else None
+        app.due_at = due
+        app.due_source = DUE_FROM_USER if due is not None else None
+        app.updated_at = datetime.utcnow()
+        session.add(app)
+        await session.commit()
+        await session.refresh(app)
+        return _serialize(app)
 
 
 @router.post("/{application_id}/dismiss", response_model=dict)

--- a/backend/jobtracker/cloud/pipeline.py
+++ b/backend/jobtracker/cloud/pipeline.py
@@ -26,7 +26,7 @@ import urllib.parse
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 # The full category vocabulary the cloud rules classifier can emit. Kept in one
 # place so a summary always reports every bucket (a category with zero hits is
@@ -697,6 +697,217 @@ def unescape_entities(text: str) -> str:
     return html.unescape(text)
 
 
+# ── deadlines ────────────────────────────────────────────────────────────────
+#
+# The product's landing page opens by promising that an assessment's 48-hour
+# deadline will not pass unseen. Everything below is what makes that true, and
+# the governing rule is that a deadline is REPORTED, never inferred: if the mail
+# does not state one, the application does not have one. A fabricated deadline
+# is worse than none — it would have someone drop what they are doing for a date
+# nobody set.
+#
+# So every pattern requires an explicit deadline cue ("complete by", "expires",
+# "within 48 hours"). A date merely mentioned in passing — an interview slot, a
+# start date, a copyright year — never qualifies.
+
+_MONTHS = {
+    m: i
+    for i, m in enumerate(
+        (
+            "january february march april may june july august september "
+            "october november december"
+        ).split(),
+        start=1,
+    )
+}
+_MONTHS.update(
+    {m[:3]: i for m, i in list(_MONTHS.items())}
+)
+
+_MONTH_ALT = "|".join(sorted(_MONTHS, key=len, reverse=True))
+
+# The cue that a date is a DEADLINE and not just a date.
+_DEADLINE_CUE = (
+    r"(?:complete|submit|finish|respond|reply|return|accept|schedule)?[^.!?\n]{0,30}?"
+    r"\b(?:due|deadline|expires?|expiring|by|before|no later than|within)\b"
+)
+
+# "within 48 hours", "you have 5 days", "48-hour window".
+_RELATIVE_DEADLINE = re.compile(
+    r"\b(?:within|in|you\s+have|have)\s+(?P<n>\d{1,3})\s*(?:-|\s)?\s*"
+    r"(?P<unit>hours?|hrs?|days?|business\s+days?)\b",
+    re.IGNORECASE,
+)
+_HYPHEN_WINDOW = re.compile(
+    r"\b(?P<n>\d{1,3})\s*-\s*(?P<unit>hour|day)\s+(?:window|deadline|limit|period)\b",
+    re.IGNORECASE,
+)
+
+# "by August 15, 2026", "before Aug 15", "expires on 08/15/2026".
+_ABSOLUTE_WORD_DATE = re.compile(
+    rf"\b(?P<month>{_MONTH_ALT})\.?\s+(?P<day>\d{{1,2}})(?:st|nd|rd|th)?"
+    rf"(?:,?\s*(?P<year>20\d{{2}}))?",
+    re.IGNORECASE,
+)
+_ABSOLUTE_NUMERIC_DATE = re.compile(
+    r"\b(?P<month>\d{1,2})/(?P<day>\d{1,2})(?:/(?P<year>20\d{2}|\d{2}))?\b"
+)
+
+# How far out a stated deadline may plausibly sit. Beyond this the parse is far
+# likelier to be wrong than the employer is to mean it.
+_MAX_DEADLINE_DAYS = 180
+
+
+# A window belongs to the COMPANY, not the candidate. "We will get back to you
+# within 5 business days" is the single most common sentence in application mail
+# and it is not a deadline — it is a promise about them. Reading it as one would
+# have put a fabricated due date on very nearly every card on the board.
+_COMPANY_PROMISE = re.compile(
+    r"\b(?:we(?:'|’)?ll|we\s+will|we\s+aim|our\s+team\s+will|the\s+team\s+will|"
+    r"you(?:'|’)?ll\s+hear|you\s+will\s+hear|hear\s+(?:back\s+)?from\s+us|"
+    r"get\s+back\s+to\s+you|be\s+in\s+touch|respond\s+to\s+(?:you|all)|"
+    r"review\s+your\s+application)\b",
+    re.IGNORECASE,
+)
+
+# The window belongs to the CANDIDATE: an instruction addressed to the reader.
+_RECIPIENT_TASK = re.compile(
+    r"\b(?:please|kindly|complete|submit|finish|return|accept|schedule|confirm|"
+    r"you\s+(?:have|must|need|should)|your\s+(?:assessment|challenge|exercise|"
+    r"take[-\s]?home|invitation|link))\b",
+    re.IGNORECASE,
+)
+
+
+def _is_recipient_task(context: str) -> bool:
+    """Is this clause telling the READER to do something by a time?
+
+    Both halves are required. The promise test alone lets through a bare date
+    with no owner; the task test alone lets through "we will review your
+    application within 5 days", which contains "your application".
+    """
+
+    if _COMPANY_PROMISE.search(context):
+        return False
+    return bool(_RECIPIENT_TASK.search(context))
+
+
+def _cue_window(text: str) -> list[str]:
+    """The clauses that carry a deadline cue, so a stray date can't be read."""
+
+    out: list[str] = []
+    for match in re.finditer(_DEADLINE_CUE, text, re.IGNORECASE):
+        # From the cue to the end of its clause — a deadline is stated forward
+        # ("by August 15"), never backward — plus the run-up, which is where the
+        # sentence says whose deadline it is.
+        clause = text[match.start() : match.start() + 90]
+        if _is_recipient_task(text[max(0, match.start() - 80) : match.start() + 90]):
+            out.append(clause)
+    return out
+
+
+def extract_deadline(
+    subject: str, snippet: str, received_at: datetime | None
+) -> datetime | None:
+    """The deadline a message STATES, in naive UTC — or None.
+
+    Anchored to ``received_at`` because "within 48 hours" is meaningless without
+    it, and because a parsed calendar date is only believable if it lands after
+    the mail that announced it. Returns None for anything ambiguous: no cue, no
+    anchor, a date that resolves into the past, or one absurdly far out.
+    """
+
+    if received_at is None:
+        return None
+    anchor = to_naive_utc(received_at)
+    if anchor is None:
+        return None
+
+    text = unescape_entities(f"{subject or ''}. {snippet or ''}")
+
+    # Relative windows first — they are unambiguous and the common case for
+    # assessments ("complete within 48 hours").
+    for pattern in (_RELATIVE_DEADLINE, _HYPHEN_WINDOW):
+        for match in pattern.finditer(text):
+            if not _is_recipient_task(
+                text[max(0, match.start() - 80) : match.end() + 40]
+            ):
+                continue  # the company's promise about itself, not your deadline
+            break
+        else:
+            continue
+        n = int(match.group("n"))
+        unit = match.group("unit").lower()
+        if n == 0:
+            continue
+        if unit.startswith(("hour", "hr")):
+            due = anchor + timedelta(hours=n)
+        elif "business" in unit:
+            # Weekends are not working days; step over them rather than
+            # pretending a 5-business-day window is 5 calendar days.
+            due = anchor
+            remaining = n
+            while remaining > 0:
+                due += timedelta(days=1)
+                if due.weekday() < 5:
+                    remaining -= 1
+        else:
+            due = anchor + timedelta(days=n)
+        if 0 < (due - anchor).total_seconds() <= _MAX_DEADLINE_DAYS * 86400:
+            return due
+
+    # Absolute dates, but only inside a clause that carries a deadline cue.
+    for clause in _cue_window(text):
+        for match in _ABSOLUTE_WORD_DATE.finditer(clause):
+            month = _MONTHS.get(match.group("month").lower())
+            if month is None:
+                continue
+            due = _resolve_calendar_date(
+                anchor, month, int(match.group("day")), match.group("year")
+            )
+            if due is not None:
+                return due
+        for match in _ABSOLUTE_NUMERIC_DATE.finditer(clause):
+            due = _resolve_calendar_date(
+                anchor,
+                int(match.group("month")),
+                int(match.group("day")),
+                match.group("year"),
+            )
+            if due is not None:
+                return due
+    return None
+
+
+def _resolve_calendar_date(
+    anchor: datetime, month: int, day: int, year: str | None
+) -> datetime | None:
+    """A stated calendar date as an end-of-day UTC deadline, or None.
+
+    A year-less date takes the next occurrence at or after the mail — "complete
+    by August 15" in a December message means the following August, not eight
+    months ago. End of day because a date without a time is a whole day, and
+    treating it as midnight would mark it overdue a day early.
+    """
+
+    if not 1 <= month <= 12 or not 1 <= day <= 31:
+        return None
+    years = (
+        [int(year) if len(year) == 4 else 2000 + int(year)]
+        if year
+        else [anchor.year, anchor.year + 1]
+    )
+    for candidate_year in years:
+        try:
+            due = datetime(candidate_year, month, day, 23, 59, 59)
+        except ValueError:
+            continue  # e.g. Feb 30
+        delta = (due - anchor).total_seconds()
+        if 0 < delta <= _MAX_DEADLINE_DAYS * 86400:
+            return due
+    return None
+
+
 def extract_req_id(subject: str, snippet: str = "") -> str | None:
     """Return the employer's own requisition id for this application, or None.
 
@@ -823,6 +1034,9 @@ class RolledApplication:
     # is the honest floor when the mail genuinely does not distinguish.
     req_id: str | None = None
     role_token: str | None = None
+    # The deadline this application's mail STATES, if any. None is the common
+    # and correct case — most mail states nothing, and nothing is what it gets.
+    due_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -1393,6 +1607,15 @@ def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplicatio
 
         role = cluster.role
 
+        # The LATEST stated deadline wins: a rescheduled assessment supersedes
+        # the original, and the newest message is the one that knows.
+        stated = [
+            (to_naive_utc(m.received_at), extract_deadline(m.subject, m.snippet, m.received_at))
+            for m in msgs
+        ]
+        dated = [(seen, due) for seen, due in stated if due is not None and seen is not None]
+        due_at = max(dated, key=lambda pair: pair[0])[1] if dated else None
+
         refs = sorted(
             (_message_ref(m) for m in msgs),
             key=lambda r: _as_utc(r.received_at) if r.received_at else _EPOCH,
@@ -1410,6 +1633,7 @@ def roll_up_applications(items: Iterable[PipelineItem]) -> list[RolledApplicatio
                 messages=tuple(refs),
                 req_id=cluster.req_id,
                 role_token=cluster.role_token,
+                due_at=due_at,
             )
         )
 

--- a/backend/jobtracker/database/models.py
+++ b/backend/jobtracker/database/models.py
@@ -301,6 +301,23 @@ class Application(TimestampMixin, table=True):
         description="Normalized job title, used to tell one employer's applications apart",
     )
 
+    # When something is DUE — the assessment window, the take-home deadline, the
+    # date an offer must be answered by. NULL means no deadline is known, which
+    # is the honest default: a deadline is only ever recorded because a message
+    # stated one or a human typed one. It is never inferred.
+    due_at: Optional[datetime] = Field(
+        default=None,
+        index=True,
+        description="When this application's next obligation is due (UTC)",
+    )
+    # Who put it there: 'mail' (extracted from an explicit statement) or 'user'.
+    # The distinction is load-bearing — a sync may refresh a 'mail' deadline as
+    # later mail supersedes it, and must never touch one a human set.
+    due_source: Optional[str] = Field(
+        default=None,
+        description="Origin of due_at: 'mail' (extracted) or 'user' (typed)",
+    )
+
     # Relationships
     emails: list["Email"] = Relationship(back_populates="application")
     contacts: list["Contact"] = Relationship(back_populates="application")

--- a/backend/tests/test_application_identity.py
+++ b/backend/tests/test_application_identity.py
@@ -942,3 +942,133 @@ def test_a_role_extracted_from_a_decoded_snippet_is_unchanged():
         AMAZON_SUBJECT, decoded
     )
     assert p.extract_req_id(AMAZON_SUBJECT, decoded) == "3177934"
+
+
+# --- deadlines ----------------------------------------------------------------
+#
+# The product's landing page opens by promising an assessment's 48-hour deadline
+# will not pass unseen. These are the tests that keep that promise honest — and
+# the ones that matter most are the refusals, because a fabricated deadline
+# would have someone drop what they are doing for a date nobody set.
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_days"),
+    [
+        ("Please complete the assessment within 48 hours.", 2),
+        ("Kindly finish your take-home within 3 days.", 3),
+        # Weekends are not working days: Tue + 5 business days is the next Tuesday.
+        ("You have 5 business days to complete your take-home.", 7),
+    ],
+)
+def test_a_stated_window_is_anchored_to_the_message(body, expected_days):
+    sent = datetime.datetime(2026, 8, 11, 14, 0)  # a Tuesday
+
+    due = p.extract_deadline("Your assessment", body, sent)
+
+    assert due is not None
+    assert (due - sent).days == expected_days
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Your challenge link expires on August 15, 2026.",
+        "Please submit your exercise no later than Aug 15.",
+        "Kindly complete by 08/15/2026 to move forward.",
+    ],
+)
+def test_a_stated_calendar_date_becomes_an_end_of_day_deadline(body):
+    """End of day, because a date with no time is a whole day.
+
+    Treating it as midnight would mark the application overdue a full day early,
+    which for this feature is the same class of error as inventing one.
+    """
+
+    due = p.extract_deadline("Assessment", body, datetime.datetime(2026, 8, 11, 14, 0))
+
+    assert due == datetime.datetime(2026, 8, 15, 23, 59, 59)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # THE case. This sentence appears in almost every application
+        # confirmation ever sent, and reading it as a deadline would have put a
+        # fabricated due date on very nearly every card on the board.
+        "We will get back to you within 5 business days.",
+        "Our team will review and respond within 48 hours.",
+        "You will hear from us within 7 days.",
+        "We will review your application within 10 days.",
+        "We aim to respond by August 20, 2026.",
+        # A date, but not a deadline.
+        "Your interview is scheduled for August 20, 2026 at 2pm.",
+        "Thanks for applying. We received it on August 11, 2026.",
+        "Copyright 2026. Unsubscribe here.",
+        # Cue present, but the window is nonsense or already past.
+        "Please complete within 0 hours.",
+        "Please complete by August 1, 2026.",
+    ],
+)
+def test_a_deadline_is_never_invented(body):
+    assert p.extract_deadline("Update on your application", body, datetime.datetime(2026, 8, 11, 14, 0)) is None
+
+
+def test_no_deadline_without_an_anchor():
+    """"Within 48 hours" of what? Undated mail cannot say."""
+
+    assert p.extract_deadline("Assessment", "Please complete within 48 hours.", None) is None
+
+
+def test_the_latest_stated_deadline_wins():
+    """A rescheduled assessment supersedes the original."""
+
+    first = item(
+        "d1",
+        "Your Roblox assessment",
+        "assessment@email.roblox.com",
+        "Please complete the assessment within 48 hours.",
+        category="assessment",
+        minutes=0,
+    )
+    rescheduled = item(
+        "d2",
+        "Your Roblox assessment — extended",
+        "assessment@email.roblox.com",
+        "Good news: please complete the assessment within 7 days.",
+        category="assessment",
+        minutes=60,
+    )
+
+    rolled = p.roll_up_applications([first, rescheduled])
+
+    assert len(rolled) == 1
+    assert rolled[0].due_at == BASE + datetime.timedelta(minutes=60, days=7)
+
+
+def test_the_owners_real_mail_produces_no_deadlines():
+    """22 real application confirmations, zero invented deadlines.
+
+    Kept as a corpus test rather than prose because "it doesn't fire on real
+    mail" is the only claim that matters, and it is the one a future pattern
+    tweak is most likely to break.
+    """
+
+    corpus = [
+        ("Crusoe | Application Received", "Thank you for applying to our role: Software Engineer I, Storage. We will review your application shortly."),
+        ("Thanks for applying to Cursor!", "We appreciate your interest in joining the team. We will review your application and get back"),
+        ("Thank you for applying with MotherDuck!", "Our team will review your application and will"),
+        ("Thank you for applying to Together AI", "Your application has been received and we will review it right away."),
+        ("Thank you for applying to Supabase!", "We respond to all candidates and will be in touch."),
+        ("Thank you for Applying to Amazon!", "We've received your application for the Software Development Engineer - 2026 (US) (ID: 3177934) position. What happens next?"),
+        ("Thank you for applying to IXL Learning!", "Our hiring team will review your resume soon! Please note, due to the high volume of applications we receive"),
+        ("Your application has been received!", "Our team is reviewing your application and will be in touch if we think you're a potential match"),
+        ("Thank You for Applying to Supernova Technology", "We have received your application and will review it promptly."),
+    ]
+    sent = datetime.datetime(2026, 8, 11, 5, 0)
+
+    invented = [
+        subject for subject, body in corpus if p.extract_deadline(subject, body, sent) is not None
+    ]
+
+    assert invented == []

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 456,
+      "value": 475,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,19 +12,19 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 55.83,
+      "value": 56.21,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 9053,
+      "value": 9159,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3999,
+      "value": 4011,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
-      "value": 81.5,
+      "value": 81.8,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageAuth": {
@@ -32,7 +32,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageDatabase": {
-      "value": 77.0,
+      "value": 77.2,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScriptsStatements": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 456,
+    "passed": 475,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
Applied's landing page opens its PROBLEM section with:

> The assessment scrolls past — its 48-hour deadline passes unseen.

The product had **no due-date field anywhere**. An assessment email was classified into a column and then behaved exactly like a rejection. The one failure mode Applied names as its reason to exist was the one it did nothing about.

This adds `applications.due_at` / `due_source` (migration `b7c31e0d94aa`, both nullable), `PUT /applications/{id}/deadline` to set or clear, and extraction from mail that states one. The UI is on a parallel branch and lands next.

## A deadline is reported, never inferred

That rule is the entire design, because a fabricated deadline is worse than none — it would have someone drop what they're doing for a date nobody set.

`extract_deadline` fires only on an explicit cue attached to an instruction addressed to *the reader*. Relative windows anchor to the message that stated them; business days step over weekends; a bare calendar date becomes **end of day**, because treating it as midnight would mark the application overdue a full day early — the same class of error as inventing one.

### The refusal that matters most

An earlier draft read this as a deadline:

> We will get back to you **within 5 business days**.

That sentence appears in almost every application confirmation ever sent. It would have put a fabricated due date on **very nearly every card on the board**. A clause now only counts if it is *not* a company promise (`we will`, `our team will`, `hear from us`, `get back to you`) **and** is addressed to the recipient as a task (`please`, `complete`, `submit`, `you have`, `your assessment`).

Both halves are required. The promise test alone lets through a bare date with no owner; the task test alone lets through *"we will review your application within 10 days"*, which contains "your application".

### Verified against real mail

**22 of the owner's actual application confirmations scanned — zero deadlines invented.** That corpus check is committed as a test, because "it doesn't fire on real mail" is the only claim that matters here, and it's exactly what a future pattern tweak would break.

Other refusals under test: an interview *scheduled* for a date, "we received it on August 11", a copyright year, a zero-length window, a date already in the past, and mail with no date to anchor to.

## Ownership

`due_source` exists because "the mail said so" and "I decided" are different claims:

- a **`mail`** deadline is refreshed when newer mail supersedes it — a rescheduled assessment is real news, and the latest stated deadline wins;
- a **`user`** deadline is never touched by a sync.

Storing the date without its origin would make that distinction impossible and leave the UI unable to say where a date came from.

## Verification

**475 tests pass** (456 before). Nineteen new, **ten of them refusals** — which is the right ratio for a feature whose failure mode is confident invention rather than absence.

Migration is nullable-only, needs no backfill, and — as always here — **must be applied to production by hand before the deploy**.
