### PR TITLE
feat(web): assessment deadlines — card tag, sheet control, pulse cell

### DIFF
--- a/apps/web/components/dashboard/ApplicationCard.tsx
+++ b/apps/web/components/dashboard/ApplicationCard.tsx
@@ -4,7 +4,7 @@ import { ExternalLink, Loader2, TriangleAlert, Undo2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 
-import { FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
+import { DeadlineTag, FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { RowActionsMenu, type RowMenuItem } from "@/components/dashboard/RowActionsMenu";
 import { cardQualifier } from "@/lib/dashboard/board";
 import { todayISO } from "@/lib/dashboard/age";
@@ -349,6 +349,10 @@ export function ApplicationCard({
       {sameCompanyCount > 0 && onFilterCompany ? (
         <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
       ) : null}
+
+      {/* Renders nothing unless the row carries a due_at — the tag never
+          prompts, and never guesses (see DeadlineTag). */}
+      <DeadlineTag dueAt={app.due_at} today={today} />
 
       <div className="mt-2 flex items-center justify-between gap-2">
         <label className="sr-only" htmlFor={`status-${app.id}`}>

--- a/apps/web/components/dashboard/ApplicationDetail.tsx
+++ b/apps/web/components/dashboard/ApplicationDetail.tsx
@@ -1,18 +1,34 @@
 "use client";
 
-import { ExternalLink, Loader2, TriangleAlert } from "lucide-react";
+import { CalendarClock, ExternalLink, Loader2, TriangleAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Dialog } from "@/components/ui/Dialog";
 import { AUTO_FILE_GATE, GateMeter } from "@/components/viz/GateMeter";
+import { todayISO } from "@/lib/dashboard/age";
 import { filedAt, longDate, shortDate } from "@/lib/dashboard/dates";
+import {
+  DEADLINE_ADD_LABEL,
+  DEADLINE_CHANGE_LABEL,
+  DEADLINE_CLEAR_FAILED,
+  DEADLINE_CLEAR_HINT,
+  DEADLINE_CLEAR_LABEL,
+  DEADLINE_PICK_FIRST,
+  DEADLINE_SAVE_FAILED,
+  DEADLINE_SAVE_LABEL,
+  dueDayISO,
+  dueInfo,
+  duePhrase,
+  dueSourceLabel,
+  type DueState,
+} from "@/lib/dashboard/deadline";
 import {
   readApplicationDetail,
   type ApplicationDetail as DetailData,
   type SplitCandidate,
 } from "@/lib/dashboard/detail";
-import { statusChangeFailure } from "@/lib/dashboard/rowActions";
+import { CANCEL_LABEL, statusChangeFailure } from "@/lib/dashboard/rowActions";
 import { statusOptions, statusSelectValue } from "@/lib/dashboard/status";
 import { STAGES, stageOf, type Application } from "@/lib/dashboard/summary";
 import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transport";
@@ -41,6 +57,14 @@ type LoadState =
 function pct(n: number): string {
   return `${Math.round(n * 100)}%`;
 }
+
+/** The sheet's deadline phrase ink, by state — measured in both themes (red
+ * 6.89:1 dark / 6.47:1 light on the sheet surface; amber 8.87:1 / 5.02:1). */
+const DUE_TEXT_CLASS: Record<DueState, string> = {
+  overdue: "text-reject",
+  soon: "text-review",
+  ahead: "text-muted",
+};
 
 function TrailMessage({ message, isLast }: { message: DetailData["messages"][number]; isLast: boolean }) {
   const meta = message.category
@@ -203,6 +227,17 @@ export function ApplicationDetail({
   const [stageError, setStageError] = useState<string | null>(null);
   /** The stage the user just picked here, shown before the server confirms. */
   const [optimistic, setOptimistic] = useState<string | null>(null);
+  /** The deadline a write here just committed, shown until the row prop
+   *  catches up (`app` is the board's snapshot and survives `router.refresh`). */
+  const [dueOverride, setDueOverride] = useState<{
+    at: string | null;
+    source: string | null;
+  } | null>(null);
+  const [dueEditing, setDueEditing] = useState(false);
+  /** The date input's draft, `YYYY-MM-DD`. */
+  const [dueDraft, setDueDraft] = useState("");
+  const [dueBusy, setDueBusy] = useState<null | "save" | "clear">(null);
+  const [dueError, setDueError] = useState<string | null>(null);
 
   const load = useCallback(
     async (id: number) => {
@@ -224,6 +259,10 @@ export function ApplicationDetail({
     const id = window.setTimeout(() => {
       setOptimistic(null);
       setStageError(null);
+      setDueOverride(null);
+      setDueEditing(false);
+      setDueError(null);
+      setDueBusy(null);
       void load(app.id);
     }, 0);
     return () => window.clearTimeout(id);
@@ -241,6 +280,11 @@ export function ApplicationDetail({
   const shownStatus = optimistic ?? active.status;
   const stage = STAGES.find((s) => s.key === stageOf(shownStatus))!;
   const role = active.position.trim();
+  // The deadline the sheet asserts: the row's own, unless a write here already
+  // moved it. UTC calendar-day math, same clock rule as the board.
+  const due = dueOverride ?? { at: active.due_at ?? null, source: active.due_source ?? null };
+  const dueState = dueInfo(due.at, todayISO());
+  const dueSource = dueSourceLabel(due.source);
 
   async function onStageChange(next: string) {
     if (next === shownStatus) return;
@@ -254,6 +298,44 @@ export function ApplicationDetail({
       setStageError(statusChangeFailure(next, active.status, result.detail));
       return;
     }
+    router.refresh();
+  }
+
+  // NOT optimistic, unlike the stage control: the sheet stays on the old value
+  // with a busy state until the server answers, so the date it asserts is never
+  // one the backend may still refuse. Cheap here — the sheet is already open
+  // and the row is not travelling between columns.
+  async function onDeadlineSave() {
+    const iso = dueDayISO(dueDraft);
+    if (!iso) {
+      setDueError(DEADLINE_PICK_FIRST);
+      return;
+    }
+    setDueError(null);
+    setDueBusy("save");
+    const result = await transport.setDeadline(active.id, iso);
+    setDueBusy(null);
+    if (!result.ok) {
+      setDueError(result.detail ? `${DEADLINE_SAVE_FAILED} ${result.detail}` : DEADLINE_SAVE_FAILED);
+      return;
+    }
+    // Any write through the deadline endpoint is the user's word — the
+    // backend marks it "user" and sync keeps its hands off it.
+    setDueOverride({ at: iso, source: "user" });
+    setDueEditing(false);
+    router.refresh();
+  }
+
+  async function onDeadlineClear() {
+    setDueError(null);
+    setDueBusy("clear");
+    const result = await transport.setDeadline(active.id, null);
+    setDueBusy(null);
+    if (!result.ok) {
+      setDueError(result.detail ? `${DEADLINE_CLEAR_FAILED} ${result.detail}` : DEADLINE_CLEAR_FAILED);
+      return;
+    }
+    setDueOverride({ at: null, source: null });
     router.refresh();
   }
 
@@ -311,6 +393,110 @@ export function ApplicationDetail({
           >
             <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject" aria-hidden />
             <span>{stageError}</span>
+          </p>
+        ) : null}
+
+        {/* --- The deadline: set, change, clear — and whose claim it is ----- */}
+        {/* Quick on purpose: one native date input (the OS picker on a phone),
+            an explicit Save so a half-typed date is never PUT, and a Clear that
+            is visibly reversible — the Add control it returns to sits in the
+            same slot. The date is data (mono, state ink); the words around it
+            are not (Atkinson, dim). */}
+        <div data-testid="detail-deadline" className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <CalendarClock className="h-3.5 w-3.5 shrink-0 text-dim" aria-hidden />
+          {dueEditing ? (
+            <>
+              <label className="sr-only" htmlFor={`deadline-date-${active.id}`}>
+                Deadline date for {active.company}
+              </label>
+              <input
+                id={`deadline-date-${active.id}`}
+                type="date"
+                value={dueDraft}
+                onChange={(e) => setDueDraft(e.target.value)}
+                disabled={dueBusy !== null}
+                className="rounded border border-line bg-surface-2 px-2 py-1 font-mono text-xs text-strong outline-none transition-colors hover:border-line-strong focus:border-line-strong disabled:opacity-50"
+              />
+              <button
+                type="button"
+                onClick={() => void onDeadlineSave()}
+                disabled={dueBusy !== null}
+                className="rounded border border-line px-2 py-1 text-xs font-medium text-foreground transition-colors hover:border-line-strong hover:text-strong disabled:opacity-50"
+              >
+                {dueBusy === "save" ? "saving…" : DEADLINE_SAVE_LABEL}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setDueEditing(false);
+                  setDueError(null);
+                }}
+                disabled={dueBusy !== null}
+                className="text-xs text-dim underline-offset-2 hover:text-strong hover:underline disabled:opacity-50"
+              >
+                {CANCEL_LABEL}
+              </button>
+            </>
+          ) : due.at && dueState ? (
+            <>
+              <span className={`tabular font-mono text-[11px] ${DUE_TEXT_CLASS[dueState.state]}`}>
+                {duePhrase(dueState.daysLeft)} ·{" "}
+                {dueState.state === "overdue" ? `was due ${shortDate(due.at)}` : shortDate(due.at)}
+              </span>
+              {/* Who set it — two different claims, stated quietly, never guessed. */}
+              {dueSource ? <span className="text-[11px] text-dim">{dueSource}</span> : null}
+              <button
+                type="button"
+                aria-label={`Change the deadline for ${active.company}`}
+                onClick={() => {
+                  setDueDraft(due.at ? due.at.slice(0, 10) : "");
+                  setDueError(null);
+                  setDueEditing(true);
+                }}
+                disabled={dueBusy !== null}
+                className="rounded border border-line px-2 py-1 text-xs text-foreground transition-colors hover:border-line-strong hover:text-strong disabled:opacity-50"
+              >
+                {DEADLINE_CHANGE_LABEL}
+              </button>
+              <button
+                type="button"
+                aria-label={`Clear the deadline for ${active.company}`}
+                title={DEADLINE_CLEAR_HINT}
+                onClick={() => void onDeadlineClear()}
+                disabled={dueBusy !== null}
+                className="rounded border border-line px-2 py-1 text-xs text-foreground transition-colors hover:border-line-strong hover:text-strong disabled:opacity-50"
+              >
+                {dueBusy === "clear" ? "clearing…" : DEADLINE_CLEAR_LABEL}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  setDueDraft("");
+                  setDueError(null);
+                  setDueEditing(true);
+                }}
+                className="rounded border border-line px-2 py-1 text-xs font-medium text-foreground transition-colors hover:border-line-strong hover:text-strong"
+              >
+                {DEADLINE_ADD_LABEL}
+              </button>
+              <span className="text-[11px] text-dim">for assessment and take-home windows</span>
+            </>
+          )}
+          {dueBusy !== null ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-dim motion-reduce:animate-none" aria-hidden />
+          ) : null}
+        </div>
+
+        {dueError ? (
+          <p
+            role="alert"
+            className="flex items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
+          >
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject" aria-hidden />
+            <span>{dueError}</span>
           </p>
         ) : null}
 

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Layers } from "lucide-react";
+import { CalendarClock, Layers } from "lucide-react";
 
 import { QUIET_AFTER_DAYS, daysBetween } from "@/lib/dashboard/age";
-import { shortDate } from "@/lib/dashboard/dates";
+import { longDate, shortDate } from "@/lib/dashboard/dates";
+import { dueInfo, duePhrase, type DueState } from "@/lib/dashboard/deadline";
 import { stageOf } from "@/lib/dashboard/summary";
 
 /**
@@ -43,6 +44,63 @@ export function FiledStamp({
         </span>
       ) : null}
     </span>
+  );
+}
+
+/**
+ * One chip anatomy — clock glyph · distance phrase · calendar day — with the
+ * ink escalating by state, so the three states read apart at a glance while
+ * occupying the same slot (a tag never jumps position as its day approaches):
+ *
+ *   - **ahead** — dim mono, no frame: present, calm, and honest about it;
+ *   - **soon** (≤ {@link DUE_SOON_DAYS} days) — amber ink + border, the same
+ *     needs-attention amber as the review queue;
+ *   - **overdue** — the red wash, with the phrase in `text-strong`: the only
+ *     wash a live card can carry, the same stop-vocabulary as the delete
+ *     confirm. Measured (both themes) rather than eyeballed: strong-on-wash
+ *     15.06:1 dark / 13.67:1 light; amber 8.51:1 dark / 4.57:1 light — the
+ *     10% amber wash was DROPPED from the soon state because amber-on-wash
+ *     measured 4.01:1 in light, under AA.
+ */
+const DUE_TAG_CLASS: Record<DueState, string> = {
+  overdue: "border-reject/50 bg-reject/10 text-strong",
+  soon: "border-review/50 text-review",
+  ahead: "border-transparent text-dim",
+};
+
+/**
+ * The card's deadline — rendered ONLY when the row carries a `due_at`. A row
+ * without one shows nothing at all: no placeholder, no prompt, no inferred
+ * urgency (`dueInfo` returning `null` is the whole gate). The words are the
+ * CVD-safe channel — "overdue" / "due in Nd" carry the state without the hue.
+ */
+export function DeadlineTag({
+  dueAt,
+  today,
+}: {
+  /** The row's `due_at` — ISO datetime, or null/undefined for "no deadline". */
+  dueAt: string | null | undefined;
+  /** `todayISO()` — the board's one clock read, threaded down. */
+  today: string;
+}) {
+  const due = dueInfo(dueAt, today);
+  if (!due) return null;
+  const day = shortDate(dueAt);
+  return (
+    <p
+      data-testid="deadline-tag"
+      data-due-state={due.state}
+      title={`deadline ${longDate(dueAt)}`}
+      className={`tabular mt-2 inline-flex items-center gap-1.5 rounded border px-1.5 py-0.5 font-mono text-[10px] leading-snug ${DUE_TAG_CLASS[due.state]}`}
+    >
+      <CalendarClock
+        className={`h-3 w-3 shrink-0 ${due.state === "overdue" ? "text-reject" : ""}`}
+        aria-hidden
+      />
+      <span>
+        {duePhrase(due.daysLeft)} · {due.state === "overdue" ? `was due ${day}` : day}
+      </span>
+    </p>
   );
 }
 

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { ApplicationCard } from "@/components/dashboard/ApplicationCard";
 import { ApplicationDetail } from "@/components/dashboard/ApplicationDetail";
-import { FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
+import { DeadlineTag, FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { CompanyBand } from "@/components/dashboard/CompanyBand";
 import { todayISO } from "@/lib/dashboard/age";
 import { boardColumns, cardQualifier } from "@/lib/dashboard/board";
@@ -62,6 +62,8 @@ function StaticApplicationCard({
       {sameCompanyCount > 0 && onFilterCompany ? (
         <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
       ) : null}
+      {/* Same rule as the interactive card: nothing unless the row has a due_at. */}
+      <DeadlineTag dueAt={app.due_at} today={today} />
       {app.notes && <p className="mt-1.5 line-clamp-2 text-[11px] leading-snug text-dim">{app.notes}</p>}
       <p className="mt-2">
         <FiledStamp filed={filed} status={app.status} today={today} />

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -9,10 +9,11 @@ import {
   weeklyCounts,
 } from "@/lib/dashboard/age";
 import { filedAt } from "@/lib/dashboard/dates";
+import { DUE_SOON_DAYS, deadlinePulse, duePhrase } from "@/lib/dashboard/deadline";
 import { stageOf, type Application } from "@/lib/dashboard/summary";
 
 /**
- * The pulse strip — the three signals the rows actually carry, drawn instead
+ * The pulse strip — the four signals the rows actually carry, drawn instead
  * of restated. Sits under the SyncBar; everything on it is NEW information the
  * subtitle and the board don't already say:
  *
@@ -22,6 +23,13 @@ import { stageOf, type Application } from "@/lib/dashboard/summary";
  *   - **ageing** — the open (applied + interviewing) rows bucketed by days
  *     since filed; the ≥{@link QUIET_AFTER_DAYS}-day share is the amber
  *     "quiet" signal, the same threshold that tags individual cards;
+ *   - **deadlines** — the rows carrying a `due_at`, bucketed
+ *     overdue / due ≤{@link DUE_SOON_DAYS}d / later by the same derivation
+ *     that inks the card tags (`lib/dashboard/deadline.ts`), plus the single
+ *     most urgent row BY NAME — the one thing on this strip a user should act
+ *     on today. When nothing carries a deadline the cell says so and says
+ *     where deadlines come from, instead of drawing an empty bar or inventing
+ *     urgency: most boards, most of the time, honestly have nothing due;
  *   - **classifier** — how much of this pipeline the classifier built
  *     (source = "gmail" rows) and what it is holding under the 0.85 gate,
  *     deep-linked to the review queue.
@@ -70,6 +78,9 @@ export function PipelinePulse({
   const ages = bucketAges(openAges);
   const openTotal = ages.fresh + ages.waiting + ages.quiet;
 
+  // --- deadlines (rows carrying a due_at; no due date, no claim) -------------
+  const due = deadlinePulse(applications, today);
+
   // --- classifier -----------------------------------------------------------
   const autoFiled = applications.filter((app) => app.source === "gmail").length;
 
@@ -79,10 +90,10 @@ export function PipelinePulse({
     <section
       aria-label="Pipeline pulse"
       data-testid="pipeline-pulse"
-      className="grid overflow-hidden rounded-xl border border-line-soft bg-surface sm:grid-cols-3"
+      className="grid overflow-hidden rounded-xl border border-line-soft bg-surface sm:grid-cols-2 lg:grid-cols-4"
     >
       {/* --- momentum -------------------------------------------------------- */}
-      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+      <div className="border-b border-line-soft p-4 sm:border-r lg:border-b-0">
         <h2 className="label-caps">momentum · filed per wk</h2>
         <div
           role="img"
@@ -115,7 +126,7 @@ export function PipelinePulse({
       </div>
 
       {/* --- ageing ---------------------------------------------------------- */}
-      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+      <div className="border-b border-line-soft p-4 lg:border-b-0 lg:border-r">
         <h2 className="label-caps">open · age since filed</h2>
         {openTotal === 0 ? (
           <p className="mt-3 text-xs text-dim">no open applications</p>
@@ -154,6 +165,77 @@ export function PipelinePulse({
               </span>
               {scopeNote ? <span className="text-dim"> · {scopeNote}</span> : null}
             </p>
+          </>
+        )}
+      </div>
+
+      {/* --- deadlines ------------------------------------------------------- */}
+      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+        <h2 className="label-caps">deadlines · time left</h2>
+        {due.total === 0 ? (
+          <>
+            {/* The state most users see most of the time, so it earns real
+                copy: what the cell measures, and where a deadline comes from —
+                never a nag, never a bar drawn at zero. */}
+            <p className="mt-3 text-xs text-dim">nothing due — no loaded row carries a deadline</p>
+            <p className="mt-1 text-[11px] leading-snug text-dim">
+              filed from mail when one is stated · or set one in a card&apos;s detail
+            </p>
+          </>
+        ) : (
+          <>
+            <div
+              role="img"
+              aria-label={`Deadlines on loaded rows: ${due.overdue} overdue, ${due.soon} due within ${DUE_SOON_DAYS} days, ${due.later} later`}
+              className="mt-3 flex h-1.5 overflow-hidden rounded-full bg-surface-2"
+            >
+              {(
+                [
+                  [due.overdue, "var(--red)"],
+                  [due.soon, "var(--amber)"],
+                  [due.later, "var(--stage-applied)"],
+                ] as const
+              )
+                .filter(([count]) => count > 0)
+                .map(([count, color], i) => (
+                  <span
+                    key={color}
+                    className="pulse-seg-x h-full"
+                    style={{
+                      width: `${(count / due.total) * 100}%`,
+                      background: color,
+                      ["--i" as string]: i,
+                    }}
+                  />
+                ))}
+            </div>
+            <p className="tabular mt-2 text-xs text-muted">
+              {/* "N overdue" turns red as a unit — a red word beside a white
+                  digit would put the emphasis on the wrong half. */}
+              <span className={due.overdue > 0 ? "font-medium text-reject" : ""}>
+                <span className={due.overdue > 0 ? "tabular" : "tabular text-strong"}>
+                  {due.overdue}
+                </span>{" "}
+                overdue
+              </span>{" "}
+              · <span className="tabular">{due.soon}</span> due ≤{DUE_SOON_DAYS}d ·{" "}
+              <span className="tabular">{due.later}</span> later
+              {scopeNote ? <span className="text-dim"> · {scopeNote}</span> : null}
+            </p>
+            {/* The one to act on today, by name — smallest days-left wins, so an
+                overdue row outranks everything until it is dealt with. */}
+            {due.urgent ? (
+              <p className="mt-1 text-xs text-muted">
+                most urgent · {due.urgent.company}{" "}
+                <span
+                  className={`tabular font-mono text-[10px] ${
+                    due.urgent.daysLeft < 0 ? "text-reject" : "text-review"
+                  }`}
+                >
+                  {duePhrase(due.urgent.daysLeft)}
+                </span>
+              </p>
+            ) : null}
           </>
         )}
       </div>

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -105,6 +105,24 @@ export function DemoDashboard() {
         });
         return { ok: true, status };
       },
+      async setDeadline(id, dueAt) {
+        await delay(300);
+        const s = store.current;
+        commit({
+          ...s,
+          apps: s.apps.map((app) =>
+            app.id === id
+              ? // The live backend's exact semantics: any write through the
+                // deadline endpoint is the user's word (`due_source: "user"`),
+                // and null clears both fields together.
+                { ...app, due_at: dueAt, due_source: dueAt === null ? null : ("user" as const) }
+              : app,
+          ),
+          // A hand-set deadline is a correction — a rebuild keeps the row.
+          touched: s.touched.includes(id) ? s.touched : [...s.touched, id],
+        });
+        return { ok: true };
+      },
       async dismiss(id) {
         await delay(300);
         const s = store.current;

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -60,6 +60,11 @@ export interface components {
       source?: string | null;
       /** Gmail deep link to the underlying conversation (click-through). */
       url?: string | null;
+      /** Assessment/take-home deadline, ISO-8601 UTC. null = no deadline known. */
+      due_at?: string | null;
+      /** Who set it: "user" (sticky — sync never overwrites) or "mail"
+       * (extracted from an explicit statement). null iff due_at is null. */
+      due_source?: "user" | "mail" | null;
     };
     ApplicationListResponse: {
       applications: components["schemas"]["Application"][];

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -58,6 +58,16 @@ export function updateApplicationStatus(id: number, status: string): Promise<Api
   return call(`/applications/${id}`, { method: "PATCH", body: { status } });
 }
 
+/**
+ * PUT /applications/{id}/deadline — set or clear the row's due date. `null`
+ * clears it. Every write through here becomes `due_source: "user"`, which a
+ * later sync never overwrites — only mail-extracted dates are the sync's to
+ * move.
+ */
+export function updateApplicationDeadline(id: number, dueAt: string | null): Promise<ApiCallResult> {
+  return call(`/applications/${id}/deadline`, { method: "PUT", body: { due_at: dueAt } });
+}
+
 /** POST /applications/{id}/dismiss — "not an application"; removes + trains "other". */
 export function dismissApplication(id: number): Promise<ApiCallResult> {
   return call(`/applications/${id}/dismiss`, { method: "POST", body: {} });

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -58,16 +58,6 @@ export function updateApplicationStatus(id: number, status: string): Promise<Api
   return call(`/applications/${id}`, { method: "PATCH", body: { status } });
 }
 
-/**
- * PUT /applications/{id}/deadline — set or clear the row's due date. `null`
- * clears it. Every write through here becomes `due_source: "user"`, which a
- * later sync never overwrites — only mail-extracted dates are the sync's to
- * move.
- */
-export function updateApplicationDeadline(id: number, dueAt: string | null): Promise<ApiCallResult> {
-  return call(`/applications/${id}/deadline`, { method: "PUT", body: { due_at: dueAt } });
-}
-
 /** POST /applications/{id}/dismiss — "not an application"; removes + trains "other". */
 export function dismissApplication(id: number): Promise<ApiCallResult> {
   return call(`/applications/${id}/dismiss`, { method: "POST", body: {} });

--- a/apps/web/lib/dashboard/deadline.ts
+++ b/apps/web/lib/dashboard/deadline.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure deadline math + copy for `due_at` — the assessment/take-home due dates
+ * the backend carries on every application (`null` = no deadline known).
+ *
+ * Same discipline as `age.ts`: everything is a function of calendar-day
+ * strings, never a locally-constructed `Date`, so the server and the browser
+ * cannot disagree about how far away a deadline is (the hydration bug class
+ * `dates.ts` documents). Kept import-free (`CALENDAR_PREFIX` and the day math
+ * are duplicated from `age.ts` on purpose) so `node --test` can load it under
+ * type stripping, same as `board.ts` and `rowActions.ts`.
+ *
+ * Honesty rules, shared by the card tag, the detail sheet and the pulse cell:
+ *
+ *  - a row without `due_at` produces NOTHING — no state, no placeholder, no
+ *    inferred urgency. The absence of a date is itself the honest answer;
+ *  - the granularity is the calendar day. `due_at` may carry a real instant,
+ *    but every surface renders and buckets the day it STATES ("due today"
+ *    until UTC midnight, overdue after) — the one reading that is identical
+ *    on server and client in every timezone, and the same rule every other
+ *    date on the board already follows;
+ *  - the words are arithmetic, never inference: "due in 2d" is a subtraction,
+ *    and no phrasing here claims more than the mail or the user stated.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Leading `YYYY-MM-DD` of an ISO date or timestamp; anything after it is ignored. */
+const CALENDAR_PREFIX = /^(\d{4})-(\d{2})-(\d{2})(?:[T ]|$)/;
+
+/**
+ * Due within this many days (today included) = the amber "soon" state. Two
+ * days because the product's founding failure is the 48-hour assessment
+ * window ("its 48-hour deadline passes unseen" — the landing's own PROBLEM
+ * line): inside that window the deadline is a today-or-tomorrow task, not a
+ * calendar entry. The pulse cell's "due ≤2d" copy derives from this constant
+ * so the two can never drift.
+ */
+export const DUE_SOON_DAYS = 2;
+
+export type DueState = "overdue" | "soon" | "ahead";
+
+export interface DueInfo {
+  state: DueState;
+  /** Whole calendar days until the due day; 0 = due today, negative = overdue. */
+  daysLeft: number;
+}
+
+/** UTC-midnight epoch of a calendar-day prefix, or `null` if unparsable. */
+function utcDay(value: string | null | undefined): number | null {
+  if (typeof value !== "string") return null;
+  const match = CALENDAR_PREFIX.exec(value.trim());
+  if (!match) return null;
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return Date.UTC(Number(match[1]), month - 1, day);
+}
+
+/**
+ * The row's deadline state, or `null` when there is no usable deadline —
+ * absent, malformed, whatever. `null` means render nothing, and every caller
+ * honours that instead of substituting a guess.
+ */
+export function dueInfo(dueAt: string | null | undefined, today: string): DueInfo | null {
+  const due = utcDay(dueAt);
+  const now = utcDay(today);
+  if (due === null || now === null) return null;
+  const daysLeft = Math.round((due - now) / DAY_MS);
+  const state: DueState = daysLeft < 0 ? "overdue" : daysLeft <= DUE_SOON_DAYS ? "soon" : "ahead";
+  return { state, daysLeft };
+}
+
+/**
+ * What the deadline control PUTs for a picked calendar day: the END of that
+ * day, UTC. "Due Aug 15" means "by the end of Aug 15" — start-of-day would
+ * read as overdue for the whole day it is due — and the calendar prefix
+ * round-trips exactly, so the card renders back the day the user picked.
+ * `null` for anything that is not a real calendar day.
+ */
+export function dueDayISO(day: string): string | null {
+  const match = CALENDAR_PREFIX.exec(day.trim());
+  if (!match) return null;
+  const month = Number(match[2]);
+  const dayOfMonth = Number(match[3]);
+  if (month < 1 || month > 12 || dayOfMonth < 1 || dayOfMonth > 31) return null;
+  return `${match[1]}-${match[2]}-${match[3]}T23:59:59Z`;
+}
+
+/**
+ * The one phrase every surface uses for a deadline's distance: "overdue 3d",
+ * "due today", "due in 2d". Arithmetic in the data voice — the calendar day
+ * itself is rendered beside it by the caller (`shortDate`).
+ */
+export function duePhrase(daysLeft: number): string {
+  if (daysLeft < 0) return `overdue ${-daysLeft}d`;
+  if (daysLeft === 0) return "due today";
+  return `due in ${daysLeft}d`;
+}
+
+/**
+ * The provenance qualifier — two different claims, never interchangeable:
+ * "from your mail" is an extraction from an explicit statement in a message,
+ * "set by you" is the user's own word (and sync never overwrites it). `null`
+ * for anything else, so no unknown source is ever dressed up as either.
+ */
+export function dueSourceLabel(source: string | null | undefined): string | null {
+  if (source === "user") return "set by you";
+  if (source === "mail") return "from your mail";
+  return null;
+}
+
+// --- Copy (kept here so the component can never drift from what is tested) --
+
+export const DEADLINE_ADD_LABEL = "Add a deadline";
+export const DEADLINE_SAVE_LABEL = "Save deadline";
+export const DEADLINE_CHANGE_LABEL = "Change";
+export const DEADLINE_CLEAR_LABEL = "Clear";
+/** Clearing is not a delete and must never read like one. */
+export const DEADLINE_CLEAR_HINT = "removes the date only — nothing else about the row changes";
+export const DEADLINE_SAVE_FAILED = "Couldn't save the deadline — nothing changed.";
+export const DEADLINE_CLEAR_FAILED = "Couldn't clear the deadline — it is still set.";
+export const DEADLINE_PICK_FIRST = "Pick a date first — the deadline is unchanged.";
+
+// --- The pulse strip's derivation --------------------------------------------
+
+export interface DeadlinePulse {
+  overdue: number;
+  /** Due within {@link DUE_SOON_DAYS} days, today included. */
+  soon: number;
+  /** Due further out than the soon window. */
+  later: number;
+  /** Rows carrying any usable deadline at all. */
+  total: number;
+  /** The single most urgent tracked row (smallest days-left), or `null`. */
+  urgent: { company: string; daysLeft: number } | null;
+}
+
+/**
+ * Bucket the loaded rows' deadlines for the pulse cell. Rows without a usable
+ * `due_at` simply don't count — the cell describes tracked deadlines only and
+ * says "nothing due" when there are none, never a guess. Structurally typed so
+ * this module stays free of the generated API schema.
+ */
+export function deadlinePulse(
+  rows: { company: string; due_at?: string | null }[],
+  today: string,
+): DeadlinePulse {
+  const pulse: DeadlinePulse = { overdue: 0, soon: 0, later: 0, total: 0, urgent: null };
+  for (const row of rows) {
+    const due = dueInfo(row.due_at, today);
+    if (due === null) continue;
+    pulse.total += 1;
+    if (due.state === "overdue") pulse.overdue += 1;
+    else if (due.state === "soon") pulse.soon += 1;
+    else pulse.later += 1;
+    if (pulse.urgent === null || due.daysLeft < pulse.urgent.daysLeft) {
+      pulse.urgent = { company: row.company, daysLeft: due.daysLeft };
+    }
+  }
+  return pulse;
+}

--- a/apps/web/lib/dashboard/rowActions.ts
+++ b/apps/web/lib/dashboard/rowActions.ts
@@ -27,13 +27,22 @@
 export interface ProxyRequest {
   /** Same-origin proxy path; the Supabase JWT is attached server-side. */
   path: string;
-  method: "PATCH" | "POST" | "DELETE";
+  method: "PATCH" | "PUT" | "POST" | "DELETE";
   body?: Record<string, unknown>;
 }
 
 /** PATCH the row's stage. Sticky + trains; also restores a dismissed row. */
 export function statusChangeRequest(id: number, status: string): ProxyRequest {
   return { path: `/api/applications/${id}`, method: "PATCH", body: { status } };
+}
+
+/**
+ * PUT the row's deadline; `null` clears it. Any write through this endpoint
+ * makes `due_source` `"user"`, which a later sync never overwrites — only
+ * mail-extracted dates are the sync's to move.
+ */
+export function deadlineChangeRequest(id: number, dueAt: string | null): ProxyRequest {
+  return { path: `/api/applications/${id}/deadline`, method: "PUT", body: { due_at: dueAt } };
 }
 
 /**

--- a/apps/web/lib/dashboard/transport.ts
+++ b/apps/web/lib/dashboard/transport.ts
@@ -17,6 +17,7 @@
  * asserted in `tests/unit/row-actions.test.mjs` keep holding here.
  */
 import {
+  deadlineChangeRequest,
   permanentDeleteRequest,
   removeFromBoardRequest,
   statusChangeRequest,
@@ -35,6 +36,10 @@ export interface SendResult {
 /** Row-level operations the board's cards and detail sheet perform. */
 export interface BoardTransport {
   changeStatus(id: number, status: string): Promise<SendResult>;
+  /** Set (`ISO datetime`) or clear (`null`) the row's deadline — always a
+   *  user write, so the backend marks it `due_source: "user"` and sync
+   *  never overwrites it. */
+  setDeadline(id: number, dueAt: string | null): Promise<SendResult>;
   /** The RECOVERABLE removal ("Not an application") — never the hard delete. */
   dismiss(id: number): Promise<SendResult>;
   /** The hard delete — the one behind a confirmation. */
@@ -86,6 +91,7 @@ async function send(req: ProxyRequest): Promise<SendResult> {
 /** The default: the same-origin proxy routes (JWT stays server-side). */
 export const liveBoardTransport: BoardTransport = {
   changeStatus: (id, status) => send(statusChangeRequest(id, status)),
+  setDeadline: (id, dueAt) => send(deadlineChangeRequest(id, dueAt)),
   dismiss: (id) => send(removeFromBoardRequest(id)),
   deleteRow: (id) => send(permanentDeleteRequest(id)),
   async detail(id) {

--- a/apps/web/lib/demo/asApplications.ts
+++ b/apps/web/lib/demo/asApplications.ts
@@ -31,6 +31,11 @@ function toApi(app: DemoApplication, id: number): Application {
     // Every fixture row is "from Gmail" in the simulation, so the rebuild's
     // stale-row semantics apply to them the way they would on a real board.
     source: "gmail",
+    // Fixture deadlines are all mail-extracted — `due_source: "user"` only
+    // ever appears here after a visitor writes one through the sheet, exactly
+    // as on a live board. null iff due_at is null, matching the API contract.
+    due_at: app.dueAt ?? null,
+    due_source: app.dueAt ? "mail" : null,
   };
 }
 

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -12,14 +12,19 @@
  * bars. Each seed carries `filedDaysAgo` instead, resolved against a single
  * "now" per render, so the demo's SHAPE is fixed while its dates stay current.
  *
- * The offsets encode a deliberate ageing spread across the 11 open rows — 4
- * under a week, 4 waiting, 3 past the quiet line (`QUIET_AFTER_DAYS`) — so all
+ * The offsets encode a deliberate ageing spread across the 14 open rows — 6
+ * under a week, 5 waiting, 3 past the quiet line (`QUIET_AFTER_DAYS`) — so all
  * three pulse buckets draw, the quiet signal is demonstrated without the board
  * looking abandoned, and every row lands inside the 8-week momentum window.
- * Changing an offset changes what the e2e sees: the counts and the "quiet Nd"
- * tag asserted in tests/e2e/demo.spec.ts are the contract.
+ * Deadlines (`dueInDays`) are relative for the same reason the filed dates
+ * are: an absolute due date is "comfortably ahead" for exactly as long as the
+ * calendar allows and then silently becomes a fourth overdue row, changing
+ * every count the e2e asserts. Changing an offset changes what the e2e sees:
+ * the counts, the "quiet Nd" tag and the deadline phrases asserted in
+ * tests/e2e/demo.spec.ts are the contract.
  */
 import { todayISO } from "@/lib/dashboard/age";
+import { dueDayISO } from "@/lib/dashboard/deadline";
 
 export type DemoStatus = "applied" | "interviewing" | "offered" | "rejected";
 
@@ -31,12 +36,18 @@ export interface DemoApplication {
   /** Calendar day filed — resolved from the seed against the render's "today". */
   appliedAt: string;
   lastSignal: string; // the most recent classified email, one line
+  /** ISO instant the row is due by (end of its calendar day, UTC — the same
+   *  shape the deadline control writes), when its mail stated one. */
+  dueAt?: string;
 }
 
 /** A fixture row before its date is resolved: an age, not a calendar day. */
-type DemoSeed = Omit<DemoApplication, "appliedAt"> & {
+type DemoSeed = Omit<DemoApplication, "appliedAt" | "dueAt"> & {
   /** Whole days before "today" this application was filed. */
   filedDaysAgo: number;
+  /** Whole days after "today" this row's assessment is due (negative =
+   *  already missed). Only rows whose mail states a deadline carry one. */
+  dueInDays?: number;
 };
 
 export interface DemoReviewItem {
@@ -60,13 +71,22 @@ function daysBefore(today: string, days: number): string {
 }
 
 function resolve(seed: DemoSeed, today: string): DemoApplication {
-  const { filedDaysAgo, ...row } = seed;
-  return { ...row, appliedAt: daysBefore(today, filedDaysAgo) };
+  const { filedDaysAgo, dueInDays, ...row } = seed;
+  return {
+    ...row,
+    appliedAt: daysBefore(today, filedDaysAgo),
+    // `dueDayISO` is what the deadline control PUTs, so fixture deadlines and
+    // user-set ones are byte-identical in shape. `?? undefined` can't fire —
+    // `daysBefore` always yields a valid day — it just keeps the type honest.
+    ...(dueInDays !== undefined
+      ? { dueAt: dueDayISO(daysBefore(today, -dueInDays)) ?? undefined }
+      : {}),
+  };
 }
 
 /**
  * Shaped like a REAL early-search board, not a brochure: the applied column is
- * heavy (10 of 14), offered is empty, and one employer holds several
+ * heavy (10 of 17), offered is empty, and one employer holds several
  * applications in different stages — the owner's own board has four Amazon
  * requisitions, so the fixtures must exercise the same truths the live board
  * does: company+role as the card identity, the "N more at …" affordance,
@@ -96,6 +116,19 @@ const APPLICATION_SEEDS: DemoSeed[] = [
   { id: "a12", company: "Juniper Cloud", position: "Infrastructure Engineer", status: "applied", filedDaysAgo: 5, lastSignal: "We received your application" },
   { id: "a13", company: "Copperline", position: "Backend Engineer, Payments", status: "applied", filedDaysAgo: 3, lastSignal: "We received your application" },
   { id: "a14", company: "Waypoint Robotics", position: "Software Engineer, Controls", status: "applied", filedDaysAgo: 2, lastSignal: "Thanks for applying" },
+  // Assessments with deadlines ×3 — the landing's own opening problem ("its
+  // 48-hour deadline passes unseen") demonstrated in all three states: one
+  // comfortably ahead, one inside the DUE_SOON_DAYS window, one already
+  // missed. Status is `interviewing` (an assessment mail advances the row;
+  // `assessment` is a classifier category, not an API status — see
+  // lib/dashboard/status.ts), and every deadline here is mail-extracted
+  // (`due_source: "mail"` via the adapter): this account is auto-filed, and
+  // the e2e sets/clears the one "user" deadline through the sheet instead.
+  // The offsets are the contract demo.spec.ts asserts (due in 9d / due in 2d /
+  // overdue 2d) — change them and the spec's phrases change with them.
+  { id: "a15", company: "Meridian Grid", position: "Software Engineer, Energy", status: "interviewing", filedDaysAgo: 1, dueInDays: 9, lastSignal: "Online assessment — complete within two weeks" },
+  { id: "a16", company: "Kestrel Dynamics", position: "Software Engineer, Simulation", status: "interviewing", filedDaysAgo: 3, dueInDays: 2, lastSignal: "Next step: online assessment (90 min)" },
+  { id: "a17", company: "Tidewater Labs", position: "Platform Engineer", status: "interviewing", filedDaysAgo: 7, dueInDays: -2, lastSignal: "Take-home exercise — 72 hour window" },
 ];
 
 /**

--- a/apps/web/lib/demo/demoDetail.ts
+++ b/apps/web/lib/demo/demoDetail.ts
@@ -9,6 +9,7 @@
  * Gmail deep links are invented — the sheet simply renders no link, exactly as
  * it does for a hand-filed row.
  */
+import { longDate } from "@/lib/dashboard/dates";
 import type { Application } from "@/lib/dashboard/summary";
 
 /** `Beacon Health` → `beaconhealth`. */
@@ -40,7 +41,13 @@ const LATEST_CATEGORY: Record<string, { category: string; confidence: number }> 
 export function demoDetailBody(app: Application): Record<string, unknown> {
   const sender_email = `talent@${slug(app.company)}.example`;
   const filed = app.created_at;
-  const latest = LATEST_CATEGORY[app.status] ?? LATEST_CATEGORY.applied;
+  // A mail-extracted deadline exists because a message STATED it, so the row's
+  // latest signal is that assessment mail — and its snippet spells the date
+  // out, demonstrating the extraction rule: the claim is in the mail, read it.
+  const assessment = app.due_at != null && app.due_source === "mail";
+  const latest = assessment
+    ? { category: "assessment", confidence: 0.97 }
+    : (LATEST_CATEGORY[app.status] ?? LATEST_CATEGORY.applied);
 
   const messages: Record<string, unknown>[] = [];
   // Advanced or closed rows carry their latest signal ABOVE the original
@@ -52,7 +59,9 @@ export function demoDetailBody(app: Application): Record<string, unknown> {
       sender_name: `${app.company} Talent`,
       sender_email,
       received_at: daysAfter(filed, 9),
-      snippet: `Regarding your application for ${app.position}.`,
+      snippet: assessment
+        ? `Complete your ${app.position} assessment by ${longDate(app.due_at)}.`
+        : `Regarding your application for ${app.position}.`,
       category: latest.category,
       confidence: latest.confidence,
       gmail_link: null,

--- a/apps/web/tests/e2e/dashboard.spec.ts
+++ b/apps/web/tests/e2e/dashboard.spec.ts
@@ -33,14 +33,14 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await page.goto("/demo");
 
     await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
-    // The one prose data line — 14 fixtures, 11 in motion (10 applied + 1
+    // The one prose data line — 17 fixtures, 14 in motion (10 applied + 4
     // interviewing), 0 offers. The page's only rendering of the totals.
-    await expect(page.getByText("14 filed · 11 in motion · 0 offers")).toBeVisible();
+    await expect(page.getByText("17 filed · 14 in motion · 0 offers")).toBeVisible();
 
     // Board columns carry the per-stage counts (the fixtures are shaped like a
     // real early search: applied-heavy, offered honestly empty).
     await expect(page.getByRole("region", { name: /applied — 10/i })).toBeVisible();
-    await expect(page.getByRole("region", { name: /interviewing — 1/i })).toBeVisible();
+    await expect(page.getByRole("region", { name: /interviewing — 4/i })).toBeVisible();
     await expect(page.getByRole("region", { name: /offered — 0/i })).toBeVisible();
     await expect(page.getByRole("region", { name: /closed — 3/i })).toBeVisible();
     await expect(page.getByText("none yet")).toBeVisible();
@@ -80,7 +80,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
       .getByRole("button", { name: /show all applications at Northstar Systems/i })
       .first()
       .click();
-    await expect(page.getByText("3 of 14 shown")).toBeVisible();
+    await expect(page.getByText("3 of 17 shown")).toBeVisible();
     await expect(page.getByText("Harbor Analytics")).toHaveCount(0);
     // …and the filter chip clears it.
     await page.getByRole("button", { name: /stop filtering by Northstar Systems/i }).click();
@@ -94,7 +94,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
 
     const search = page.getByRole("searchbox", { name: /search the board/i });
     await search.fill("engineer, payments");
-    await expect(page.getByText("1 of 14 shown")).toBeVisible();
+    await expect(page.getByText("1 of 17 shown")).toBeVisible();
     await expect(page.getByText("Copperline", { exact: true })).toBeVisible();
     await expect(page.getByText("Quarry Data")).toHaveCount(0);
 

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -151,7 +151,17 @@ test.describe("live demo (/demo)", () => {
       .locator("li")
       .filter({ has: page.getByText("Harbor Analytics", { exact: true }) })
       .first();
-    await card.dragTo(page.getByRole("region", { name: /interviewing/i }));
+    // Drop near the TOP of the column, not its centre. Hovering the centre of a
+    // 2249px-tall board scrolls the page ~147px between mouse-down and the first
+    // move, so the HTML5 `dragstart` fires on whichever card has slid under the
+    // cursor — Summit Platform moved while Harbor stayed put, and the count
+    // assertion above was satisfied by the wrong card. A real drag has no
+    // programmatic scroll between press and move; this is the harness, not the
+    // product. The assertion below must keep naming Harbor: asserting whichever
+    // card actually moved would restore green by deleting the coverage.
+    await card.dragTo(page.getByRole("region", { name: /interviewing/i }), {
+      targetPosition: { x: 140, y: 20 },
+    });
     await expect(page.getByRole("region", { name: /interviewing — 6/i })).toBeVisible();
     await expect(
       page

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -105,7 +105,7 @@ test.describe("live demo (/demo)", () => {
     // …and the board actually gained the two filed fixture rows.
     await expect(page.getByRole("region", { name: /applied — 12/i })).toBeVisible();
     await expect(page.getByText("Twitch", { exact: true })).toBeVisible();
-    await expect(page.getByText("16 filed · 13 in motion · 0 offers")).toBeVisible();
+    await expect(page.getByText("19 filed · 16 in motion · 0 offers")).toBeVisible();
 
     // A second sync has nothing new, and the cursored zero case says exactly
     // that — never a claim about a window it did not check.
@@ -135,13 +135,13 @@ test.describe("live demo (/demo)", () => {
 
   test("a card moves between stages by drag, and by its select", async ({ page }) => {
     await page.goto("/demo");
-    await expect(page.getByRole("region", { name: /interviewing — 1/i })).toBeVisible();
+    await expect(page.getByRole("region", { name: /interviewing — 4/i })).toBeVisible();
 
     // The accessible path: the per-card stage select.
     await page
       .getByLabel("Change stage for Quarry Data")
       .selectOption("interviewing");
-    await expect(page.getByRole("region", { name: /interviewing — 2/i })).toBeVisible();
+    await expect(page.getByRole("region", { name: /interviewing — 5/i })).toBeVisible();
     await expect(
       page.getByRole("region", { name: /interviewing/i }).getByText("Quarry Data", { exact: true }),
     ).toBeVisible();
@@ -152,7 +152,7 @@ test.describe("live demo (/demo)", () => {
       .filter({ has: page.getByText("Harbor Analytics", { exact: true }) })
       .first();
     await card.dragTo(page.getByRole("region", { name: /interviewing/i }));
-    await expect(page.getByRole("region", { name: /interviewing — 3/i })).toBeVisible();
+    await expect(page.getByRole("region", { name: /interviewing — 6/i })).toBeVisible();
     await expect(
       page
         .getByRole("region", { name: /interviewing/i })
@@ -248,7 +248,7 @@ test.describe("live demo (/demo)", () => {
     await expect(surface.getByText(/stopped early/)).toHaveCount(0);
   });
 
-  test("the pulse strip renders all three derived signals over the fixtures", async ({ page }) => {
+  test("the pulse strip renders all four derived signals over the fixtures", async ({ page }) => {
     await page.goto("/demo");
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse).toBeVisible();
@@ -262,8 +262,14 @@ test.describe("live demo (/demo)", () => {
     // is here to make — so require a non-zero leading digit.
     await expect(pulse.getByText(/[1-9]\d* quiet ≥2 wk/)).toBeVisible();
 
+    // Deadlines: the three fixture states, counted, and the most urgent row
+    // named. The counts derive from the same `dueInfo` that inks the cards.
+    await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
+    await expect(pulse.getByText(/most urgent · Tidewater Labs/)).toBeVisible();
+    await expect(pulse.getByText("overdue 2d", { exact: true })).toBeVisible();
+
     // Classifier: every fixture row is source="gmail", and nothing is held.
-    await expect(pulse.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await expect(pulse.getByText("17 of 17 auto-filed from mail")).toBeVisible();
     await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
 
     // The card-level ageing tag agrees with the strip's threshold.
@@ -272,12 +278,104 @@ test.describe("live demo (/demo)", () => {
 
   test("the pulse strip moves when Sync files fresh mail", async ({ page }) => {
     await page.goto("/demo");
-    await expect(page.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await expect(page.getByText("17 of 17 auto-filed from mail")).toBeVisible();
     await page.getByRole("button", { name: "Sync new mail from Gmail" }).click();
     // Two fixture rows arrive → the classifier fraction re-derives from the
     // new board. (No assertion on the ageing buckets here: the fixture dates
     // are static while real time passes, so any exact bucket count would rot.)
-    await expect(page.getByText("16 of 16 auto-filed from mail")).toBeVisible();
+    await expect(page.getByText("19 of 19 auto-filed from mail")).toBeVisible();
+  });
+
+  test("assessment deadlines render in all three states — and only where a date exists", async ({
+    page,
+  }) => {
+    await page.goto("/demo");
+    const tag = (state: string) =>
+      page.locator(`[data-testid="deadline-tag"][data-due-state="${state}"]`);
+
+    // One fixture per state, phrase + calendar day, derived from the relative
+    // offsets in demoData.ts (dueInDays 9 / 2 / -2).
+    await expect(tag("ahead")).toHaveCount(1);
+    await expect(tag("ahead")).toContainText("due in 9d");
+    await expect(tag("soon")).toHaveCount(1);
+    await expect(tag("soon")).toContainText("due in 2d");
+    await expect(tag("overdue")).toHaveCount(1);
+    await expect(tag("overdue")).toContainText("overdue 2d");
+    await expect(tag("overdue")).toContainText("was due");
+
+    // A deadline is data: the tag speaks mono, like every date stamp.
+    await expect(tag("overdue")).toHaveCSS("font-family", /Geist Mono/);
+
+    // The tags sit on the rows that own them…
+    const kestrel = page
+      .locator("li")
+      .filter({ has: page.getByText("Kestrel Dynamics", { exact: true }) });
+    await expect(kestrel.locator('[data-testid="deadline-tag"]')).toContainText("due in 2d");
+    // …and a row without a due_at renders NOTHING — no placeholder, no prompt.
+    const harbor = page
+      .locator("li")
+      .filter({ has: page.getByText("Harbor Analytics", { exact: true }) });
+    await expect(harbor.locator('[data-testid="deadline-tag"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="deadline-tag"]')).toHaveCount(3);
+
+    // The sheet states the deadline's provenance: this one was extracted from
+    // mail — and the mail it came from, right below, spells the date out.
+    await page
+      .getByRole("button", { name: "Open Kestrel Dynamics — Software Engineer, Simulation" })
+      .click();
+    const sheet = page.getByRole("dialog");
+    await expect(sheet.getByText("from your mail")).toBeVisible();
+    await expect(sheet.getByText(/Complete your .* assessment by/)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+  });
+
+  test("setting a deadline updates the card and the pulse; clearing removes both", async ({
+    page,
+  }) => {
+    await page.goto("/demo");
+    const pulse = page.getByTestId("pipeline-pulse");
+    await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
+
+    // Cedar Labs (applied) has no deadline; give it one 5 days out. The date
+    // is computed the way the app computes everything: UTC calendar days.
+    const dayISO = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const cedar = page
+      .locator("li")
+      .filter({ has: page.getByText("Software Engineer, Platform", { exact: true }) });
+    await expect(cedar.locator('[data-testid="deadline-tag"]')).toHaveCount(0);
+
+    await page
+      .getByRole("button", { name: "Open Cedar Labs — Software Engineer, Platform" })
+      .click();
+    const sheet = page.getByRole("dialog");
+    const deadline = sheet.getByTestId("detail-deadline");
+    await deadline.getByRole("button", { name: "Add a deadline" }).click();
+    await deadline.getByLabel(/Deadline date/).fill(dayISO);
+    await deadline.getByRole("button", { name: "Save deadline" }).click();
+
+    // The sheet shows the new claim and WHOSE claim it is.
+    await expect(deadline.getByText("due in 5d", { exact: false })).toBeVisible();
+    await expect(deadline.getByText("set by you")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+
+    // The card gained the tag; the pulse cell re-derived.
+    await expect(cedar.locator('[data-testid="deadline-tag"]')).toContainText("due in 5d");
+    await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 2 later/)).toBeVisible();
+
+    // Clearing is one click, obviously reversible — the Add control returns —
+    // and both surfaces drop the date.
+    await page
+      .getByRole("button", { name: "Open Cedar Labs — Software Engineer, Platform" })
+      .click();
+    await deadline.getByRole("button", { name: /Clear the deadline/ }).click();
+    await expect(deadline.getByRole("button", { name: "Add a deadline" })).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(sheet).toBeHidden();
+
+    await expect(cedar.locator('[data-testid="deadline-tag"]')).toHaveCount(0);
+    await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
   });
 
   test("a company opens as a set: band on, chips suppressed, clear restores", async ({ page }) => {
@@ -317,8 +415,12 @@ test.describe("live demo (/demo)", () => {
     // component rendering nothing is the shape this estate keeps producing.
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
-    await expect(pulse.getByText("14 of 14 auto-filed from mail")).toBeVisible();
+    await expect(pulse.getByText("17 of 17 auto-filed from mail")).toBeVisible();
     await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
+    // The deadline surfaces are content, not motion: all three tags and the
+    // pulse counts render statically too.
+    await expect(page.locator('[data-testid="deadline-tag"]')).toHaveCount(3);
+    await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
     // A bar with zero drawn height would satisfy the count above.
     const barHeights = await pulse.getByTestId("pulse-week").evaluateAll((els) =>
       els.map((el) => el.getBoundingClientRect().height),

--- a/apps/web/tests/unit/deadline.test.mjs
+++ b/apps/web/tests/unit/deadline.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * The deadline derivation every surface shares (`lib/dashboard/deadline.ts`):
+ * the card tag, the detail sheet and the pulse cell all read `dueInfo` /
+ * `duePhrase` / `deadlinePulse`, so what is asserted here is asserted for all
+ * three at once.
+ *
+ * The properties that matter:
+ *  - no `due_at`, no claim: absent/malformed input yields null, never a guess;
+ *  - the state boundaries sit exactly on DUE_SOON_DAYS and on "yesterday";
+ *  - `dueDayISO` writes the END of the picked day (a deadline is "by then",
+ *    not "at midnight before it") and round-trips its calendar prefix;
+ *  - the pulse buckets count only rows with usable deadlines and name the
+ *    smallest-days-left row as most urgent (overdue outranks everything).
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DUE_SOON_DAYS,
+  deadlinePulse,
+  dueDayISO,
+  dueInfo,
+  duePhrase,
+  dueSourceLabel,
+} from "../../lib/dashboard/deadline.ts";
+
+const TODAY = "2026-08-11";
+
+test("dueInfo: no date, no claim", () => {
+  assert.equal(dueInfo(null, TODAY), null);
+  assert.equal(dueInfo(undefined, TODAY), null);
+  assert.equal(dueInfo("", TODAY), null);
+  assert.equal(dueInfo("not-a-date", TODAY), null);
+  assert.equal(dueInfo("2026-13-40T00:00:00Z", TODAY), null);
+});
+
+test("dueInfo: the three states and their exact boundaries", () => {
+  assert.deepEqual(dueInfo("2026-08-10T23:59:59Z", TODAY), { state: "overdue", daysLeft: -1 });
+  assert.deepEqual(dueInfo("2026-08-11T23:59:59Z", TODAY), { state: "soon", daysLeft: 0 });
+  // The last "soon" day is exactly DUE_SOON_DAYS out…
+  assert.deepEqual(dueInfo("2026-08-13T23:59:59Z", TODAY), {
+    state: "soon",
+    daysLeft: DUE_SOON_DAYS,
+  });
+  // …and one more day is "ahead".
+  assert.deepEqual(dueInfo("2026-08-14T23:59:59Z", TODAY), { state: "ahead", daysLeft: 3 });
+});
+
+test("dueInfo reads the calendar day the string states, time and zone ignored", () => {
+  // Same rule as dates.ts: the claim is the stated day, identically on server
+  // and client — a time component must not shift the bucket.
+  assert.deepEqual(dueInfo("2026-08-13", TODAY), dueInfo("2026-08-13T01:00:00Z", TODAY));
+});
+
+test("dueDayISO: end of the picked day, calendar prefix intact", () => {
+  assert.equal(dueDayISO("2026-08-15"), "2026-08-15T23:59:59Z");
+  assert.equal(dueDayISO(" 2026-08-15 "), "2026-08-15T23:59:59Z");
+  assert.equal(dueDayISO(""), null);
+  assert.equal(dueDayISO("08/15/2026"), null);
+  assert.equal(dueDayISO("2026-99-15"), null);
+});
+
+test("duePhrase: arithmetic, not urgency inference", () => {
+  assert.equal(duePhrase(-3), "overdue 3d");
+  assert.equal(duePhrase(0), "due today");
+  assert.equal(duePhrase(1), "due in 1d");
+  assert.equal(duePhrase(9), "due in 9d");
+});
+
+test("dueSourceLabel: two claims, nothing else dressed up as either", () => {
+  assert.equal(dueSourceLabel("user"), "set by you");
+  assert.equal(dueSourceLabel("mail"), "from your mail");
+  assert.equal(dueSourceLabel(null), null);
+  assert.equal(dueSourceLabel("sync"), null);
+});
+
+test("deadlinePulse: buckets tracked rows only, most urgent named by smallest days-left", () => {
+  const rows = [
+    { company: "No Deadline Co" },
+    { company: "Broken Co", due_at: "soon-ish" },
+    { company: "Later Co", due_at: "2026-08-20T23:59:59Z" },
+    { company: "Soon Co", due_at: "2026-08-13T23:59:59Z" },
+    { company: "Overdue Co", due_at: "2026-08-09T23:59:59Z" },
+    { company: "More Overdue Co", due_at: "2026-08-05T23:59:59Z" },
+  ];
+  const pulse = deadlinePulse(rows, TODAY);
+  assert.deepEqual(pulse, {
+    overdue: 2,
+    soon: 1,
+    later: 1,
+    total: 4,
+    urgent: { company: "More Overdue Co", daysLeft: -6 },
+  });
+});
+
+test("deadlinePulse: an empty board is honestly empty", () => {
+  assert.deepEqual(deadlinePulse([], TODAY), {
+    overdue: 0,
+    soon: 0,
+    later: 0,
+    total: 0,
+    urgent: null,
+  });
+});


### PR DESCRIPTION
The UI half of #97. Together they make the product keep the promise its landing page opens with — *"The assessment scrolls past — its 48-hour deadline passes unseen."*

## One derivation, four surfaces

`lib/dashboard/deadline.ts` is a new pure, import-free module in the `age.ts` discipline: state and days-left from **calendar-day UTC math**, never `Date`-from-local, so there is no hydration mismatch. `DUE_SOON_DAYS = 2`, because the founding failure this feature names is a 48-hour window. The card, the sheet and the pulse all read this one module, so they cannot disagree.

**Card tag** — one anatomy (clock · phrase · calendar day, the date in mono because a date is data), with ink escalating: dim (ahead) → amber outline (soon) → **red wash** (overdue, the only wash a live card carries). `dueInfo === null` renders literally nothing — no placeholder, no prompt. The words carry the state too, so it isn't colour-only.

**Sheet control** — native date input (so it's the OS picker on a phone), an explicit **Save** so a half-typed date is never sent, **Change**, and a one-click **Clear** whose reversibility is visible because the Add control returns to the same slot. Deliberately **not** optimistic: the sheet never asserts a date the backend might refuse.

**Provenance** — a quiet qualifier beside the date: *"from your mail"* or *"set by you"*. Two different claims, and the user shouldn't have to guess which one they're looking at.

**Pulse cell** — a fourth cell placed between ageing and the classifier, so the two time-pressure signals sit together. Populated: a proportional bar, `N overdue · N due ≤2d · N later`, and **the single most urgent row by name**. Empty: *"nothing due — no loaded row carries a deadline"* and where deadlines come from. No zero bar, no nag — most users will see the empty state most of the time, so it got the same care as the populated one.

## Contrast, measured — and one failure caught before shipping

Light-theme amber-on-amber-wash measured **4.01:1**, under AA. The "due soon" chip therefore ships as outline + ink with no wash. Everything else clears AA in both themes: strong-on-red-wash 15.06:1 dark / 13.67:1 light, amber 8.51:1 / 4.57:1, red text 6.89:1 / 6.47:1.

## Verification, stated precisely

`tsc`, `lint` and `build` clean after rebasing onto the merged backend. The **built** app was walked with screenshots read back: all three tag states render with correct arithmetic against the real clock (`due in 9d · Aug 20`, `due in 2d · Aug 13`, `overdue 2d · was due Aug 9`), and the pulse cell shows `1 overdue · 1 due ≤2d · 1 later` with `most urgent · Tidewater Labs overdue 2d`.

**Not walked:** the set/change/clear interaction and the sheet itself — no browser automation was available to that agent, so the new e2e tests are unproven until `labrat` runs them. Saying so explicitly rather than implying coverage.

A 375px clipping artifact appeared in headless screenshots; it reproduces identically against **deployed production**, so it is a plain-headless-Chrome artifact rather than a regression. Worth confirming under Playwright's mobile emulation.

## Housekeeping in this PR

Both branches added a client for the same endpoint, since they were built in parallel. The rebase kept the proxy route from `main`, leaving the second helper exported and called by nothing — removed, because an unused export that duplicates a live one is the seed of a future call site wired to the wrong half.
