### PR TITLE
fix(split): the split prompt could never render — it read a field nobody sends

### DIFF
--- a/apps/web/components/dashboard/ApplicationDetail.tsx
+++ b/apps/web/components/dashboard/ApplicationDetail.tsx
@@ -133,12 +133,14 @@ function TrailMessage({ message, isLast }: { message: DetailData["messages"][num
 /**
  * "This looks like N applications — split?" for a merged row.
  *
- * TODO(backend): renders ONLY when the detail response carries
- * `split_candidates` (see `lib/dashboard/detail.ts`) and posts to
- * `POST /api/applications/{id}/split` — neither exists until the entity-model
- * branch lands, so today this component never mounts and no decorative
- * control ships. The wiring is here so the surface lights up the moment the
- * backend starts sending candidates.
+ * Renders only when the detail response carries two or more `split_candidates`
+ * (see `lib/dashboard/detail.ts`), which the backend derives by re-clustering
+ * this row's own stored mail. Empty is the normal case and offers nothing.
+ *
+ * The split itself takes NO request body: `POST /applications/{id}/split`
+ * recomputes the clusters server-side from the same stored mail, so the client
+ * cannot propose a division the server did not derive. The candidates here are
+ * for display and consent only — they tell the user what they are agreeing to.
  */
 function SplitPrompt({
   applicationId,
@@ -159,10 +161,10 @@ function SplitPrompt({
     setBusy(true);
     setError(null);
     try {
+      // No body on purpose — the endpoint re-derives the clusters from stored
+      // mail. Sending `candidates` would imply the server honours them.
       const res = await fetch(`/api/applications/${applicationId}/split`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ candidates }),
       });
       if (!res.ok) {
         setError("Couldn't split this row — it is unchanged.");
@@ -182,9 +184,12 @@ function SplitPrompt({
         This looks like {candidates.length} applications at {company} — split them?
       </p>
       <ul className="mt-2 space-y-1">
-        {candidates.map((c) => (
-          <li key={c.position} className="text-xs text-muted">
-            {company} · {c.position}
+        {candidates.map((c, i) => (
+          // Keyed on the first message id, not the role: a role is nullable on
+          // the wire and two clusters at one employer can share one.
+          <li key={c.message_ids[0] ?? `candidate-${i}`} className="text-xs text-muted">
+            {company} · {c.role ?? "no role named in this mail"}
+            {c.retains_row ? " · keeps your edits" : null}
           </li>
         ))}
       </ul>

--- a/apps/web/lib/dashboard/detail.ts
+++ b/apps/web/lib/dashboard/detail.ts
@@ -40,18 +40,26 @@ export interface DetailApplication {
 }
 
 /**
- * One proposed half of a merged row.
+ * One application hiding inside a merged row — the signal behind the "this
+ * looks like N applications — split?" surface. The backend derives these by
+ * re-clustering the row's OWN stored mail, so a non-empty list means this row's
+ * messages describe more than one requisition.
  *
- * TODO(backend): `split_candidates` is NOT in `ApplicationDetailResponse` yet.
- * It is the signal for the "this looks like N applications — split?" surface:
- * the entity-model branch will populate it when one row's mail spans several
- * requisitions (four Amazon roles filed as one card is the proven case). Until
- * the field exists this parses to `[]` and the split prompt renders nothing —
- * deliberately, so no fake candidates are ever shown.
+ * These field names are the wire contract (`SplitCandidateResponse` in
+ * `backend/jobtracker/cloud/applications.py`) and must not drift from it. They
+ * already did once: this interface said `position` while the backend has only
+ * ever sent `role`, so every candidate failed the reader's guard, the list was
+ * always empty, and the prompt — which needs two — could not mount for anyone.
+ * A stale TODO in this spot claiming the backend field did not exist is how
+ * that survived review.
  */
 export interface SplitCandidate {
-  position: string;
+  /** Nullable on the wire: the retained cluster is where role-less mail lands. */
+  role: string | null;
+  req_id: string | null;
   message_ids: string[];
+  /** True for the cluster that keeps this row's id. Exactly one candidate has it. */
+  retains_row: boolean;
 }
 
 export interface ApplicationDetail {
@@ -84,13 +92,29 @@ function readMessage(entry: unknown): DetailMessage | null {
   };
 }
 
+/**
+ * Read one candidate, degrading each field rather than discarding the entry.
+ *
+ * Only a non-object is rejected. That asymmetry is deliberate and is the whole
+ * lesson of this file: the previous reader dropped any candidate missing a
+ * field it wanted, which turned a single field-name mismatch into a feature
+ * that was simply absent — no error, no empty state, nothing to notice. A
+ * candidate whose `role` is null is not malformed, it is the ordinary retained
+ * cluster; dropping those would also shrink a genuine two-application row back
+ * under the prompt's threshold and hide the split exactly where it is needed.
+ */
 function readSplitCandidate(entry: unknown): SplitCandidate | null {
-  const c = asRecord(entry);
-  if (typeof c.position !== "string" || c.position.trim() === "") return null;
+  if (typeof entry !== "object" || entry === null) return null;
+  const c = entry as Record<string, unknown>;
   const ids = Array.isArray(c.message_ids)
     ? c.message_ids.filter((id): id is string => typeof id === "string")
     : [];
-  return { position: c.position, message_ids: ids };
+  return {
+    role: str(c.role),
+    req_id: str(c.req_id),
+    message_ids: ids,
+    retains_row: c.retains_row === true,
+  };
 }
 
 /** Read a detail response body into what the sheet renders. */

--- a/apps/web/tests/unit/detail.test.mjs
+++ b/apps/web/tests/unit/detail.test.mjs
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for `lib/dashboard/detail.ts` — the reader that turns a detail
+ * response into what the sheet renders.
+ *
+ * These exist because the split surface shipped unreachable. The backend has
+ * sent `split_candidates` since the entity-model work landed, and every field
+ * in the fixtures below is copied from the live contract
+ * (`SplitCandidateResponse` in `backend/jobtracker/cloud/applications.py`):
+ *
+ *     role: str | None
+ *     req_id: str | None
+ *     message_ids: list[str]
+ *     retains_row: bool
+ *
+ * The reader was looking for `position`, which the backend has never sent. Every
+ * candidate failed the guard and was filtered out, so `splitCandidates` was
+ * always `[]`, `SplitPrompt` returns null below a length of 2, and the whole
+ * "this looks like N applications — split them?" surface could not mount for
+ * anyone. Two stale TODO comments — one in each file — asserted that the
+ * backend field did not exist yet, which is how it survived review.
+ *
+ * The lesson these tests encode: a reader that silently drops what it cannot
+ * parse turns a field-name typo into a feature that is simply absent, with no
+ * error anywhere. So they assert against the real wire shape, not against the
+ * shape the reader happens to want.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readApplicationDetail } from "../../lib/dashboard/detail.ts";
+
+/** A response body in exactly the shape FastAPI serialises. */
+function detailBody(candidates) {
+  return {
+    application: {
+      id: 42,
+      company: "Amazon",
+      position: "Software Development Engineer - 2026 (US)",
+      status: "applied",
+      notes: null,
+      created_at: "2026-08-11T00:00:00",
+      applied_date: "2026-08-11",
+      source: "gmail",
+      url: null,
+    },
+    messages: [],
+    split_candidates: candidates,
+  };
+}
+
+test("a merged row's split candidates survive the read", () => {
+  const detail = readApplicationDetail(
+    detailBody([
+      {
+        role: "Software Development Engineer - 2026 (US)",
+        req_id: "3177934",
+        message_ids: ["m1", "m2"],
+        retains_row: true,
+      },
+      {
+        role: "Software Development Engineer – Database 2026 (US)",
+        req_id: "3130865",
+        message_ids: ["m3"],
+        retains_row: false,
+      },
+    ]),
+  );
+
+  // The whole point: two candidates in, two candidates out. Before the fix this
+  // was [] and the prompt could never reach its `length >= 2` gate.
+  assert.equal(detail.splitCandidates.length, 2);
+  assert.equal(
+    detail.splitCandidates[0].role,
+    "Software Development Engineer - 2026 (US)",
+  );
+  assert.equal(detail.splitCandidates[0].req_id, "3177934");
+  assert.deepEqual(detail.splitCandidates[0].message_ids, ["m1", "m2"]);
+  assert.equal(detail.splitCandidates[0].retains_row, true);
+  assert.equal(detail.splitCandidates[1].retains_row, false);
+});
+
+test("a role-less cluster is kept, because the backend really does send one", () => {
+  // `role` is `str | None` on the wire and the retained cluster is exactly where
+  // role-less mail collects — a verification email that names no requisition.
+  // Dropping it would under-count the clusters and could pull a genuine
+  // two-application row back below the prompt's threshold, hiding the split
+  // for the rows that most need it.
+  const detail = readApplicationDetail(
+    detailBody([
+      { role: null, req_id: null, message_ids: ["m1"], retains_row: true },
+      { role: "TPU Kernel Engineer", req_id: null, message_ids: ["m2"], retains_row: false },
+    ]),
+  );
+
+  assert.equal(detail.splitCandidates.length, 2);
+  assert.equal(detail.splitCandidates[0].role, null);
+});
+
+test("the ordinary row offers nothing to split", () => {
+  // Empty is the normal case and must stay empty — a prompt on a row with one
+  // application would be an invitation to break it.
+  assert.deepEqual(readApplicationDetail(detailBody([])).splitCandidates, []);
+});
+
+test("junk in the candidates array cannot crash the sheet", () => {
+  const detail = readApplicationDetail(
+    detailBody([
+      null,
+      "nonsense",
+      { role: "Real Role", req_id: null, message_ids: ["m1"], retains_row: false },
+      { role: "No ids", message_ids: "not-an-array", retains_row: false },
+    ]),
+  );
+
+  // Two survive: the well-formed one, and the one whose only fault is a bad
+  // message_ids — which degrades to [] rather than discarding the candidate.
+  assert.equal(detail.splitCandidates.length, 2);
+  assert.deepEqual(detail.splitCandidates[1].message_ids, []);
+});
+
+test("a missing split_candidates key reads as nothing to offer", () => {
+  const body = detailBody([]);
+  delete body.split_candidates;
+  assert.deepEqual(readApplicationDetail(body).splitCandidates, []);
+});


### PR DESCRIPTION
fix(split): the split prompt could never render — it read a field nobody sends

`SplitCandidate` declared `position`; the backend has only ever sent `role`
(`SplitCandidateResponse`: role, req_id, message_ids, retains_row).
`readSplitCandidate` required `position` to be a non-empty string and returned
null otherwise, so every candidate was filtered out, `splitCandidates` was
always `[]`, and `SplitPrompt` — which returns null below a length of 2 — could
not mount for anyone. The "this looks like N applications at X — split them?"
surface, its POST route and `splitApplication` were all unreachable in the
product while the backend computed candidates correctly on every detail read.

Two stale TODO comments are why this survived review. Both asserted the backend
field did not exist yet ("neither exists until the entity-model branch lands"),
so a reader checking whether the surface was dead found a comment confirming it
and stopped. The field had landed; only the comments hadn't. Both are corrected
here rather than deleted, because the reason the mismatch was invisible is worth
keeping next to the code.

The reader now degrades each field instead of discarding the entry. That
asymmetry is the actual lesson: dropping a candidate that misses one field turns
a field-name typo into a feature that is merely absent — no error, no empty
state, nothing to notice. It also mattered semantically, because `role` is
nullable on the wire: the retained cluster is exactly where role-less mail
collects, and dropping those would shrink a genuine two-application row back
under the prompt's threshold, hiding the split precisely where it is needed.

Also drops the request body from the split POST. The endpoint takes no body —
it re-derives the clusters from stored mail so a client cannot propose a
division the server did not compute — and sending `candidates` implied the
server honoured them.

Verified: the new tests fail on the parent commit (0 candidates read where 2
were sent) and pass here. Fixtures are copied from the live wire contract, not
from the shape the reader wanted. 5 new tests, typecheck clean.
