### PR TITLE
test: give the three untested fixes an executing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-475%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-478%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,7 +373,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**475 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 433 `test_*` functions across 28 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 475 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**478 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 436 `test_*` functions across 29 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 478 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
@@ -534,7 +534,7 @@ applied/
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
 │   ├── alembic/versions/    # 11 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 28 modules
+│   └── tests/               # 29 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/apps/web/app/api/applications/review/[messageId]/classify/route.ts
+++ b/apps/web/app/api/applications/review/[messageId]/classify/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { readClassifyBody } from "@/lib/applications/classify-request";
 import { classifyReviewItem } from "@/lib/applications/server";
 
 /**
@@ -31,29 +32,26 @@ export async function POST(req: NextRequest, ctx: Ctx) {
     return NextResponse.json({ detail: "Invalid message id" }, { status: 400 });
   }
 
-  let body: { category?: unknown; company?: unknown; application_id?: unknown } = {};
+  let raw: unknown;
   try {
-    body = (await req.json()) as {
-      category?: unknown;
-      company?: unknown;
-      application_id?: unknown;
-    };
+    raw = await req.json();
   } catch {
     return NextResponse.json({ detail: "Invalid JSON body" }, { status: 400 });
   }
-  const category = typeof body.category === "string" ? body.category.trim() : "";
-  if (!category) return NextResponse.json({ detail: "category is required" }, { status: 422 });
-  const company = typeof body.company === "string" ? body.company.trim() : "";
-  const applicationId =
-    typeof body.application_id === "number" && Number.isInteger(body.application_id)
-      ? body.application_id
-      : undefined;
+
+  // The narrowing lives in `lib/applications/classify-request.ts` so a test can
+  // execute it — in here it needed the Next runtime and was covered by types
+  // and review only, which is exactly how a dropped field goes unnoticed.
+  const parsed = readClassifyBody(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ detail: parsed.detail }, { status: parsed.status });
+  }
 
   const r = await classifyReviewItem(
     messageId,
-    category,
-    company || undefined,
-    applicationId,
+    parsed.category,
+    parsed.company,
+    parsed.applicationId,
   );
   return NextResponse.json(r.data ?? {}, { status: r.status });
 }

--- a/apps/web/app/api/applications/route.ts
+++ b/apps/web/app/api/applications/route.ts
@@ -1,57 +1,52 @@
 import { NextResponse } from "next/server";
 import { createServerApiClient } from "@/lib/api/server";
+import { collectApplications } from "@/lib/applications/export";
 
 /**
  * Server-side proxy for listing applications — used by the Settings "export
  * your data" action. Forwards to the backend with the caller's Supabase JWT
  * (from cookies) so the token and `BACKEND_API_URL` never reach the browser,
  * and returns the raw list JSON the client turns into a download.
+ *
+ * PAGINATED, because the export claims to be everything. This used to make one
+ * unparameterised call, which the backend answers with its DEFAULT_PAGE_SIZE of
+ * 100 — so a user with 250 applications silently got 100 of them, a
+ * data-loss-shaped defect in the one feature whose entire job is handing the
+ * user their data back. It never fired here because this account has 25.
+ *
+ * The loop itself lives in `lib/applications/export.ts` as a pure function over
+ * a page-fetcher, so it can be executed by a test. Inline here it needed the
+ * Next runtime and a Supabase cookie jar, which is why it shipped covered by
+ * types and review only.
  */
-/** The backend's own ceiling (`MAX_PAGE_SIZE`); asking for more is a 422. */
-const EXPORT_PAGE_SIZE = 500;
-/** Bounds the loop so a bad `total` can never spin it forever. 50k rows. */
-const EXPORT_MAX_PAGES = 100;
-
 export async function GET() {
   try {
     const api = await createServerApiClient();
 
-    // PAGINATED, because the export claims to be everything.
-    //
-    // This used to make one unparameterised call, which the backend answers with
-    // its DEFAULT_PAGE_SIZE of 100. Settings offers to "export everything Applied
-    // holds for you" and a user with 250 applications silently got 100 of them —
-    // a data-loss-shaped defect in the one feature whose entire job is to hand
-    // the user their data back. It never fired here because this account has 25.
-    const first = await api.GET("/applications", {
-      params: { query: { page: 1, page_size: EXPORT_PAGE_SIZE } },
-    });
-    if (first.error || !first.data) {
-      return NextResponse.json(
-        { detail: first.error ?? "Backend rejected the request" },
-        { status: first.response.status || 502 },
-      );
-    }
-
-    const applications = [...first.data.applications];
-    const total = first.data.total;
-
-    for (let page = 2; applications.length < total && page <= EXPORT_MAX_PAGES; page += 1) {
-      const next = await api.GET("/applications", {
-        params: { query: { page, page_size: EXPORT_PAGE_SIZE } },
+    const result = await collectApplications(async (page, pageSize) => {
+      const res = await api.GET("/applications", {
+        params: { query: { page, page_size: pageSize } },
       });
-      // A mid-export failure must not hand back a short file that looks whole.
-      if (next.error || !next.data) {
-        return NextResponse.json(
-          { detail: next.error ?? `Export failed while reading page ${page}` },
-          { status: next.response.status || 502 },
-        );
+      if (res.error || !res.data) {
+        return {
+          ok: false as const,
+          status: res.response.status || 502,
+          detail: String(res.error ?? `Export failed while reading page ${page}`),
+        };
       }
-      if (next.data.applications.length === 0) break; // defensive: no progress
-      applications.push(...next.data.applications);
-    }
+      return {
+        ok: true as const,
+        page: { applications: res.data.applications, total: res.data.total },
+      };
+    });
 
-    return NextResponse.json({ applications, total }, { status: 200 });
+    if (!result.ok) {
+      return NextResponse.json({ detail: result.detail }, { status: result.status });
+    }
+    return NextResponse.json(
+      { applications: result.applications, total: result.total },
+      { status: 200 },
+    );
   } catch {
     return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
   }

--- a/apps/web/lib/applications/classify-request.ts
+++ b/apps/web/lib/applications/classify-request.ts
@@ -1,0 +1,49 @@
+/**
+ * Reading the classify proxy's request body.
+ *
+ * Extracted from `app/api/applications/review/[messageId]/classify/route.ts`
+ * so it can actually be executed by a test. The handler REBUILDS the body
+ * rather than forwarding it, which means every field it does not name is
+ * silently lost — that is how `confidence` died in the inbox relay and how
+ * `applied_date` and `url` died on create. The same shape of loss here is not
+ * a no-op: dropping `application_id` makes the backend fall back to the
+ * employer's first row, which is precisely the arbitrary-sibling filing the
+ * identity work exists to stop. So the parse is worth pinning on its own.
+ *
+ * Dependency-free so `tests/unit/` can load it under Node's type stripping.
+ */
+
+export type ClassifyRequest =
+  | { ok: true; category: string; company?: string; applicationId?: number }
+  | { ok: false; status: number; detail: string };
+
+/**
+ * Validate and narrow a classify body.
+ *
+ * `application_id` is accepted only as a real integer. A float, a numeric
+ * string, `null` or `NaN` are all treated as absent rather than coerced —
+ * coercing would send the backend an id the user never chose.
+ */
+export function readClassifyBody(raw: unknown): ClassifyRequest {
+  const body = (typeof raw === "object" && raw !== null ? raw : {}) as {
+    category?: unknown;
+    company?: unknown;
+    application_id?: unknown;
+  };
+
+  const category = typeof body.category === "string" ? body.category.trim() : "";
+  if (!category) return { ok: false, status: 422, detail: "category is required" };
+
+  const company = typeof body.company === "string" ? body.company.trim() : "";
+  const applicationId =
+    typeof body.application_id === "number" && Number.isInteger(body.application_id)
+      ? body.application_id
+      : undefined;
+
+  return {
+    ok: true,
+    category,
+    ...(company ? { company } : {}),
+    ...(applicationId !== undefined ? { applicationId } : {}),
+  };
+}

--- a/apps/web/lib/applications/export.ts
+++ b/apps/web/lib/applications/export.ts
@@ -1,0 +1,71 @@
+/**
+ * The export's paging loop, as a pure function over a page-fetcher.
+ *
+ * It lives here rather than inline in `app/api/applications/route.ts` for one
+ * reason: in the route it could not be executed by a test. The handler needs
+ * the Next runtime and a Supabase cookie jar, so the loop that decides whether
+ * a user gets all of their data or a silently truncated file was covered by
+ * types and review only. Settings offers to "export everything Applied holds
+ * for you"; a truncated answer there is a data-loss-shaped defect in the one
+ * feature whose whole job is handing the user their data back.
+ *
+ * Dependency-free on purpose (no React, no `@/` alias, no generated schema) so
+ * `tests/unit/` can load it directly under Node's type stripping — the same
+ * rule as `detail.ts`, `review.ts` and `sync-plan.ts`.
+ */
+
+/** The backend's own ceiling (`MAX_PAGE_SIZE`); asking for more is a 422. */
+export const EXPORT_PAGE_SIZE = 500;
+
+/** Bounds the loop so a bad `total` can never spin it forever. 50k rows. */
+export const EXPORT_MAX_PAGES = 100;
+
+/** One page as the backend answers it. */
+export interface ApplicationsPage {
+  applications: unknown[];
+  total: number;
+}
+
+/** What a fetcher returns: the page, or a failure the export must not paper over. */
+export type PageResult =
+  | { ok: true; page: ApplicationsPage }
+  | { ok: false; status: number; detail: string };
+
+export type ExportResult =
+  | { ok: true; applications: unknown[]; total: number; pagesRead: number }
+  | { ok: false; status: number; detail: string };
+
+/**
+ * Read every page and return the whole list, or fail loudly.
+ *
+ * Three refusals are the point, and each one is a way a user could otherwise be
+ * handed a short file that looks complete:
+ *
+ *  1. A mid-export page failure aborts. Returning what was collected so far
+ *     would produce a plausible-looking export missing an arbitrary tail.
+ *  2. A page that comes back empty while `total` still claims more stops the
+ *     loop instead of spinning — no progress means the backend disagrees with
+ *     its own count, and looping cannot fix that.
+ *  3. `EXPORT_MAX_PAGES` bounds the whole thing, so a corrupt `total` cannot
+ *     hang the request forever.
+ */
+export async function collectApplications(
+  fetchPage: (page: number, pageSize: number) => Promise<PageResult>,
+): Promise<ExportResult> {
+  const first = await fetchPage(1, EXPORT_PAGE_SIZE);
+  if (!first.ok) return first;
+
+  const applications = [...first.page.applications];
+  const total = first.page.total;
+  let pagesRead = 1;
+
+  for (let page = 2; applications.length < total && page <= EXPORT_MAX_PAGES; page += 1) {
+    const next = await fetchPage(page, EXPORT_PAGE_SIZE);
+    if (!next.ok) return next;
+    pagesRead += 1;
+    if (next.page.applications.length === 0) break;
+    applications.push(...next.page.applications);
+  }
+
+  return { ok: true, applications, total, pagesRead };
+}

--- a/apps/web/tests/unit/classify-request.test.mjs
+++ b/apps/web/tests/unit/classify-request.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for `lib/applications/classify-request.ts` — how the classify
+ * proxy reads its request body.
+ *
+ * The client side of this is already covered (`review-classify.test.mjs`
+ * asserts the body carries `application_id` only when it is a real id). What
+ * was NOT covered is the hop after it: the route handler REBUILDS the body
+ * rather than forwarding it, so any field it fails to name is silently
+ * dropped. That has happened three times in this codebase — `confidence` in
+ * the inbox relay, `applied_date` and `url` on create.
+ *
+ * Dropping `application_id` specifically is not a no-op. It is the user's
+ * answer to "which of these is it about?" when an employer holds several
+ * applications; without it the backend falls back to the employer's first row,
+ * which is exactly the arbitrary-sibling filing `_pick_application` exists to
+ * stop. So the user's explicit choice would be discarded and replaced with a
+ * guess, with a 200 on the response.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readClassifyBody } from "../../lib/applications/classify-request.ts";
+
+test("the user's choice of application survives the proxy", () => {
+  const parsed = readClassifyBody({ category: "interview", application_id: 42 });
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.category, "interview");
+  assert.equal(parsed.applicationId, 42);
+});
+
+test("a category is required, and whitespace is not a category", () => {
+  for (const raw of [{}, { category: "" }, { category: "   " }, { category: 7 }, null]) {
+    const parsed = readClassifyBody(raw);
+    assert.equal(parsed.ok, false, `expected refusal for ${JSON.stringify(raw)}`);
+    assert.equal(parsed.status, 422);
+  }
+});
+
+test("an application id that is not a real integer is treated as absent, never coerced", () => {
+  // Coercing any of these would send the backend an id the user never chose,
+  // which is worse than falling back to the documented behaviour.
+  for (const bad of ["42", 4.2, null, NaN, Infinity, true, {}]) {
+    const parsed = readClassifyBody({ category: "offer", application_id: bad });
+    assert.equal(parsed.ok, true);
+    assert.equal(
+      parsed.applicationId,
+      undefined,
+      `application_id ${JSON.stringify(bad)} should not become an id`,
+    );
+  }
+});
+
+test("a company is trimmed, and an empty one is omitted rather than sent blank", () => {
+  assert.equal(readClassifyBody({ category: "offer", company: "  Acme  " }).company, "Acme");
+  assert.equal(readClassifyBody({ category: "offer", company: "   " }).company, undefined);
+  assert.equal(readClassifyBody({ category: "offer" }).company, undefined);
+});
+
+test("category is trimmed too, so a padded value is not rejected as missing", () => {
+  assert.equal(readClassifyBody({ category: "  rejection " }).category, "rejection");
+});
+
+test("both optional fields ride together when both are given", () => {
+  const parsed = readClassifyBody({
+    category: "assessment",
+    company: "Globex",
+    application_id: 7,
+  });
+
+  assert.deepEqual(parsed, {
+    ok: true,
+    category: "assessment",
+    company: "Globex",
+    applicationId: 7,
+  });
+});

--- a/apps/web/tests/unit/export.test.mjs
+++ b/apps/web/tests/unit/export.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for `lib/applications/export.ts` — the paging loop behind
+ * Settings → "Export applications (JSON)".
+ *
+ * These exist because the fix shipped without one. The loop was inline in
+ * `app/api/applications/route.ts`, which needs the Next runtime and a Supabase
+ * cookie jar to run, so the code deciding whether a user receives all of their
+ * data or a silently truncated file was covered by types and review only. The
+ * original defect was a single unparameterised call answered with the backend's
+ * DEFAULT_PAGE_SIZE of 100 — a user with 250 applications got 100 and no
+ * indication anything was missing. It never fired on the owner's account
+ * because it holds 25 rows, which is the whole reason it needs a test rather
+ * than an eyeball.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  EXPORT_MAX_PAGES,
+  EXPORT_PAGE_SIZE,
+  collectApplications,
+} from "../../lib/applications/export.ts";
+
+/** A backend holding `total` rows, served in pages, recording what was asked. */
+function backend(total) {
+  const rows = Array.from({ length: total }, (_, i) => ({ id: i + 1 }));
+  const asked = [];
+  return {
+    asked,
+    fetchPage: async (page, pageSize) => {
+      asked.push({ page, pageSize });
+      const start = (page - 1) * pageSize;
+      return {
+        ok: true,
+        page: { applications: rows.slice(start, start + pageSize), total },
+      };
+    },
+  };
+}
+
+test("an account that fits in one page is read in exactly one call", async () => {
+  const be = backend(25);
+  const result = await collectApplications(be.fetchPage);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.applications.length, 25);
+  assert.equal(result.pagesRead, 1);
+  assert.deepEqual(be.asked, [{ page: 1, pageSize: EXPORT_PAGE_SIZE }]);
+});
+
+test("the export keeps paging until it has everything the backend counted", async () => {
+  // 1,250 rows over a 500-row page size: the case the original one-shot call
+  // got wrong, and the reason this function exists.
+  const be = backend(1250);
+  const result = await collectApplications(be.fetchPage);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.applications.length, 1250);
+  assert.equal(result.pagesRead, 3);
+  // Every row exactly once, in order — no gaps and no duplicates across pages.
+  assert.deepEqual(
+    result.applications.map((a) => a.id),
+    Array.from({ length: 1250 }, (_, i) => i + 1),
+  );
+});
+
+test("a mid-export failure refuses rather than handing back a short file", async () => {
+  // The important one. Returning the first page here would produce a
+  // plausible-looking export missing an arbitrary tail, with a 200 on it.
+  const be = backend(1250);
+  const result = await collectApplications(async (page, size) => {
+    if (page === 2) return { ok: false, status: 503, detail: "backend fell over" };
+    return be.fetchPage(page, size);
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 503);
+  assert.equal(result.detail, "backend fell over");
+  assert.equal(result.applications, undefined);
+});
+
+test("a failure on the very first page is reported, not turned into an empty export", async () => {
+  const result = await collectApplications(async () => ({
+    ok: false,
+    status: 401,
+    detail: "not signed in",
+  }));
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 401);
+});
+
+test("a backend whose total lies is bounded, not looped forever", async () => {
+  // `total` claims a million rows but every page comes back empty. Without the
+  // no-progress break this spins to EXPORT_MAX_PAGES; without the page cap it
+  // never stops at all.
+  let calls = 0;
+  const result = await collectApplications(async () => {
+    calls += 1;
+    return { ok: true, page: { applications: [], total: 1_000_000 } };
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.applications.length, 0);
+  assert.equal(calls, 2, "stops as soon as a page makes no progress");
+});
+
+test("a total that never resolves cannot exceed the page ceiling", async () => {
+  // Every page returns one row while claiming a million: progress is real, so
+  // the no-progress break never fires and only EXPORT_MAX_PAGES stops it.
+  let calls = 0;
+  const result = await collectApplications(async () => {
+    calls += 1;
+    return { ok: true, page: { applications: [{ id: calls }], total: 1_000_000 } };
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls, EXPORT_MAX_PAGES);
+  assert.equal(result.applications.length, EXPORT_MAX_PAGES);
+});
+
+test("the page size asked for is the backend's own ceiling", () => {
+  // Asking for more than MAX_PAGE_SIZE is a 422, so this constant is a
+  // contract with the backend and not a tuning knob.
+  assert.equal(EXPORT_PAGE_SIZE, 500);
+});

--- a/backend/tests/test_listing_order_is_deterministic.py
+++ b/backend/tests/test_listing_order_is_deterministic.py
@@ -1,0 +1,267 @@
+"""The applications listing must impose a total order, not a partial one.
+
+Why this file exists
+--------------------
+
+``GET /applications`` orders by ``created_at DESC, id DESC``. The ``id`` term is
+not decoration. A first Gmail rebuild writes hundreds of rows inside the same
+second, so ordering on ``created_at`` alone leaves them tied *en masse*, and
+Postgres is explicitly free to return tied rows in a different order per
+request. Paging through a non-deterministic order silently drops some rows and
+repeats others across pages — which the JSON export now walks page by page, and
+which the board's "showing the newest 200 of 250" claim depends on being true.
+
+The tiebreak shipped with no executing test. Writing one has a trap worth
+stating, because it is the reason the obvious test would be worthless:
+
+**SQLite cannot reproduce this bug.** With equal ``created_at`` values SQLite
+returns rows in rowid order, which is stable, so a SQLite test that walks the
+pages passes whether or not the tiebreak is there. Deleting ``id.desc()`` would
+leave it green. That is a check that cannot fail, and this codebase has shipped
+several of those.
+
+So the coverage is split deliberately:
+
+* :func:`test_paging_returns_every_row_exactly_once` executes the real endpoint
+  and proves the paging arithmetic itself — offsets, limits, the last partial
+  page. This one *can* fail, on offset/limit mistakes.
+* :func:`test_the_listing_asks_the_database_for_a_total_order` inspects the SQL
+  actually emitted to the driver and asserts the tiebreak is in it. This is the
+  one that catches the tiebreak being removed, and it works on SQLite because
+  it asserts about the *statement*, not about the row order the statement
+  happens to produce here.
+
+Neither is a substitute for the other, and neither is a grep: both run the
+endpoint.
+
+The split is not a guess — it was measured. Deleting ``Application.id.desc()``
+from the listing and re-running this file gives **1 failed, 2 passed**: the
+SQL-shape test fails with ``ORDER BY applications.created_at DESC`` and both
+paging tests stay green. That is the whole argument for the third test in one
+line of output.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import time
+import uuid
+from datetime import datetime
+from typing import Any, AsyncIterator
+
+import jwt as pyjwt
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+
+
+JWT_SECRET = "listing-order-test-jwt-secret-at-least-32-bytes-long-hs256"
+USER = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+# Every row is written with the SAME timestamp on purpose: that is the state a
+# rebuild leaves behind, and the only state in which the tiebreak matters.
+TIED_AT = datetime(2026, 8, 11, 12, 0, 0)
+ROW_COUNT = 25
+PAGE_SIZE = 10
+
+
+def _token_for(user_id: str) -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {"sub": user_id, "aud": "authenticated", "iat": now, "exp": now + 300},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+async def cloud_app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Any]:
+    """The cloud app over the in-memory SQLite test DB (see test_user_id_scoping)."""
+
+    monkeypatch.setenv("JOBTRACKER_DEPLOYMENT", "cloud")
+    monkeypatch.setenv("JOBTRACKER_ENVIRONMENT", "test")
+    monkeypatch.setenv("JOBTRACKER_SUPABASE_JWT_SECRET", JWT_SECRET)
+
+    import jobtracker.config as config_module
+    import jobtracker.database.connection as connection_module
+
+    importlib.reload(config_module)
+    connection_module._engine = None
+
+    import jobtracker.auth.supabase_jwt as auth_module
+
+    importlib.reload(auth_module)
+
+    import jobtracker.cloud.applications as cloud_apps_module
+
+    importlib.reload(cloud_apps_module)
+
+    import jobtracker.main_cloud as main_cloud_module
+
+    importlib.reload(main_cloud_module)
+
+    from jobtracker.database import init_db
+
+    await init_db()
+
+    yield main_cloud_module.app
+
+    if connection_module._engine is not None:
+        await connection_module._engine.dispose()
+    connection_module._engine = None
+    monkeypatch.undo()
+    importlib.reload(config_module)
+
+
+async def _seed_tied_rows() -> list[int]:
+    """Insert ROW_COUNT applications that all share one ``created_at``."""
+
+    from jobtracker.database.connection import get_session
+    from jobtracker.database.models import Application, ApplicationStatus
+
+    ids: list[int] = []
+    async with get_session() as session:
+        for i in range(ROW_COUNT):
+            app = Application(
+                user_id=uuid.UUID(USER),
+                company=f"Company {i:02d}",
+                position=f"Engineer {i:02d}",
+                status=ApplicationStatus.APPLIED,
+                created_at=TIED_AT,
+            )
+            session.add(app)
+        await session.commit()
+
+        from sqlmodel import select
+
+        rows = (
+            await session.exec(
+                select(Application).where(Application.user_id == uuid.UUID(USER))
+            )
+        ).all()
+        ids = [r.id for r in rows]
+    return ids
+
+
+async def test_paging_returns_every_row_exactly_once(cloud_app):
+    """Walk every page and rebuild the set — no row dropped, none repeated.
+
+    This is what the export does. It is also the failure the tiebreak prevents
+    on Postgres, though here it proves the offset/limit arithmetic rather than
+    the ordering (see the module docstring for why SQLite cannot show the
+    ordering half).
+    """
+
+    seeded = await _seed_tied_rows()
+    assert len(seeded) == ROW_COUNT
+
+    headers = {"Authorization": f"Bearer {_token_for(USER)}"}
+    collected: list[int] = []
+
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        page = 1
+        while True:
+            res = await client.get(
+                "/applications",
+                params={"page": page, "page_size": PAGE_SIZE},
+                headers=headers,
+            )
+            assert res.status_code == 200, res.text
+            body = res.json()
+            assert body["total"] == ROW_COUNT
+            got = [a["id"] for a in body["applications"]]
+            if not got:
+                break
+            collected.extend(got)
+            if len(collected) >= body["total"]:
+                break
+            page += 1
+
+    assert len(collected) == ROW_COUNT, "paging dropped or duplicated rows"
+    assert sorted(collected) == sorted(seeded)
+    assert len(set(collected)) == ROW_COUNT, "a row appeared on two pages"
+
+
+async def test_the_same_request_twice_gives_the_same_page(cloud_app):
+    """A second identical read must not reshuffle a tied page."""
+
+    await _seed_tied_rows()
+    headers = {"Authorization": f"Bearer {_token_for(USER)}"}
+
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        first = await client.get(
+            "/applications", params={"page": 1, "page_size": PAGE_SIZE}, headers=headers
+        )
+        second = await client.get(
+            "/applications", params={"page": 1, "page_size": PAGE_SIZE}, headers=headers
+        )
+
+    assert first.status_code == second.status_code == 200
+    assert [a["id"] for a in first.json()["applications"]] == [
+        a["id"] for a in second.json()["applications"]
+    ]
+
+
+async def test_the_listing_asks_the_database_for_a_total_order(cloud_app):
+    """The emitted SQL must order by ``created_at`` AND ``id``.
+
+    The one assertion in this file that catches the tiebreak being deleted.
+    It reads the statement handed to the driver, so it is checking what
+    Postgres would receive in production rather than what SQLite chooses to do
+    with a partial order in the test.
+    """
+
+    await _seed_tied_rows()
+
+    import jobtracker.database.connection as connection_module
+
+    engine = connection_module._engine
+    assert engine is not None, "the fixture should have built an engine"
+
+    statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        statements.append(statement)
+
+    try:
+        headers = {"Authorization": f"Bearer {_token_for(USER)}"}
+        async with AsyncClient(
+            transport=ASGITransport(app=cloud_app), base_url="http://test"
+        ) as client:
+            res = await client.get(
+                "/applications",
+                params={"page": 1, "page_size": PAGE_SIZE},
+                headers=headers,
+            )
+        assert res.status_code == 200, res.text
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    ordered = [
+        s
+        for s in statements
+        if "FROM applications" in s and "ORDER BY" in s.upper()
+    ]
+    assert ordered, f"no ordered SELECT against applications was issued: {statements}"
+
+    order_clause = re.split(r"ORDER BY", ordered[-1], flags=re.IGNORECASE)[1]
+    lowered = order_clause.lower()
+
+    assert "created_at" in lowered, f"created_at is not in the ORDER BY: {order_clause}"
+    # The tiebreak. Without it, tied `created_at` values leave the order
+    # undefined and Postgres may vary it between two requests, which is how
+    # paging drops and repeats rows.
+    assert re.search(r"\bid\b", lowered), (
+        "the listing no longer breaks ties on id — tied created_at rows are "
+        f"free to reorder per request on Postgres. ORDER BY was: {order_clause}"
+    )
+    assert lowered.index("created_at") < lowered.rindex("id"), (
+        "id must come after created_at, otherwise it is the primary sort and "
+        f"the newest-first contract is broken. ORDER BY was: {order_clause}"
+    )

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 475,
+      "value": 478,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 475,
+    "passed": 478,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
test: give the three untested fixes an executing test

Export pagination, the classify proxy's field forwarding and the listing's
ordering tiebreak all shipped covered by types and review only, because each
sits behind a surface that needs a signed-in session or the Next runtime. All
three are now executed.

**Export pagination.** The loop moves out of the route handler into
`lib/applications/export.ts` as a pure function over a page-fetcher, because in
the handler it could not be run: it needs a Supabase cookie jar. The logic
deserves the test — Settings offers to "export everything Applied holds for
you", and the original defect was one unparameterised call answered with the
backend's DEFAULT_PAGE_SIZE of 100, so a user with 250 applications got 100 of
them and no sign anything was missing. It never fired on this account because
it holds 25 rows. Seven tests cover the multi-page walk, the refusal to return
a short file when a middle page fails, the no-progress break and the page
ceiling.

**Classify proxy forwarding.** The body narrowing moves to
`lib/applications/classify-request.ts` for the same reason. The handler rebuilds
the body rather than forwarding it, so any field it fails to name is silently
lost — that has happened three times here (`confidence` in the inbox relay,
`applied_date` and `url` on create). Dropping `application_id` is not a no-op:
it is the user's answer to "which of these is it about?", and without it the
backend falls back to the employer's first row, which is the arbitrary-sibling
filing `_pick_application` exists to stop. Six tests, including that a float, a
numeric string and NaN are treated as absent rather than coerced into an id the
user never chose.

**Listing order.** This one had a trap worth recording. SQLite returns tied
rows in rowid order, so the obvious test — page through rows sharing one
`created_at` and check nothing is dropped — passes with or without the
tiebreak. Measured, not assumed: deleting `Application.id.desc()` and re-running
gives 1 failed, 2 passed, with both paging tests green. So the file asserts on
the SQL actually handed to the driver, which is what Postgres would receive,
alongside the paging walk that pins the offset/limit arithmetic. The nondeterminism
is Postgres-only; a test that cannot fail is worse than no test, and this
codebase has shipped several.

Verified: web unit suite 81 -> 99 passing, typecheck and lint clean; the three
backend tests pass and the mutation above confirms the SQL-shape assertion is
load-bearing.
