### PR TITLE
fix(deadline): bucket the day against the reader's clock, not UTC

### DIFF
--- a/apps/web/components/dashboard/ApplicationCard.tsx
+++ b/apps/web/components/dashboard/ApplicationCard.tsx
@@ -73,8 +73,11 @@ export function ApplicationCard({
   app: Application;
   /** The heading of the column this card is rendered in (see `board.ts`). */
   columnLabel?: string;
-  /** Today's UTC calendar day — the board threads one read of the clock down
-   *  so every card's age tag derives from the same instant. */
+  /** Today's calendar day — the board threads one read of the clock down so
+   *  every card's age tag and deadline state derive from the same instant
+   *  (`useLocalToday`: UTC for the server pass, the reader's own day once
+   *  mounted). The UTC default only stands in for a caller that renders a card
+   *  outside the board; the board always passes its own. */
   today?: string;
   /** Opens the detail sheet (the mail behind this card). */
   onOpenDetail?: (app: Application) => void;

--- a/apps/web/components/dashboard/ApplicationDetail.tsx
+++ b/apps/web/components/dashboard/ApplicationDetail.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { Dialog } from "@/components/ui/Dialog";
 import { AUTO_FILE_GATE, GateMeter } from "@/components/viz/GateMeter";
-import { todayISO } from "@/lib/dashboard/age";
+import { useLocalToday } from "@/lib/dashboard/useLocalToday";
 import { filedAt, longDate, shortDate } from "@/lib/dashboard/dates";
 import {
   DEADLINE_ADD_LABEL,
@@ -239,6 +239,10 @@ export function ApplicationDetail({
   const [dueBusy, setDueBusy] = useState<null | "save" | "clear">(null);
   const [dueError, setDueError] = useState<string | null>(null);
 
+  /** The day this sheet measures deadlines against — the reader's own once
+   *  mounted. Read here, above the early return, because it is a hook. */
+  const today = useLocalToday();
+
   const load = useCallback(
     async (id: number) => {
       setState({ kind: "loading" });
@@ -281,9 +285,11 @@ export function ApplicationDetail({
   const stage = STAGES.find((s) => s.key === stageOf(shownStatus))!;
   const role = active.position.trim();
   // The deadline the sheet asserts: the row's own, unless a write here already
-  // moved it. UTC calendar-day math, same clock rule as the board.
+  // moved it. Calendar-day math against the reader's own day, the same clock
+  // rule as the board — so a date picked as "today" in the control below can
+  // never come back from it reading as overdue.
   const due = dueOverride ?? { at: active.due_at ?? null, source: active.due_source ?? null };
-  const dueState = dueInfo(due.at, todayISO());
+  const dueState = dueInfo(due.at, today);
   const dueSource = dueSourceLabel(due.source);
 
   async function onStageChange(next: string) {

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -29,7 +29,7 @@ export function FiledStamp({
   /** ISO date/timestamp the card treats as its filed moment (`filedAt`). */
   filed: string;
   status: string;
-  /** `todayISO()` — computed once per board render, threaded down. */
+  /** `useLocalToday()` — computed once per board render, threaded down. */
   today: string;
 }) {
   const age = daysBetween(filed, today);
@@ -80,7 +80,7 @@ export function DeadlineTag({
 }: {
   /** The row's `due_at` — ISO datetime, or null/undefined for "no deadline". */
   dueAt: string | null | undefined;
-  /** `todayISO()` — the board's one clock read, threaded down. */
+  /** `useLocalToday()` — the board's one clock read, threaded down. */
   today: string;
 }) {
   const due = dueInfo(dueAt, today);

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -9,7 +9,7 @@ import { ApplicationCard } from "@/components/dashboard/ApplicationCard";
 import { ApplicationDetail } from "@/components/dashboard/ApplicationDetail";
 import { DeadlineTag, FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { CompanyBand } from "@/components/dashboard/CompanyBand";
-import { todayISO } from "@/lib/dashboard/age";
+import { useLocalToday } from "@/lib/dashboard/useLocalToday";
 import { boardColumns, cardQualifier } from "@/lib/dashboard/board";
 import { filedAt } from "@/lib/dashboard/dates";
 import { type Application, STAGES, stageOf, type StageKey } from "@/lib/dashboard/summary";
@@ -205,8 +205,10 @@ export function PipelineBoard({
     return () => window.clearTimeout(id);
   }, []);
 
-  /** One clock read per render — every card's age tag derives from it. */
-  const today = todayISO();
+  /** One clock read per render — every card's age tag and deadline state
+   *  derives from it. UTC for the server pass, the reader's own day once
+   *  mounted (see `useLocalToday`). */
+  const today = useLocalToday();
 
   // Server data caught up with an optimistic move → drop the overlay entry and
   // let the row's own status speak. Render-adjustment (guarded, so it settles

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 import {
@@ -5,9 +7,9 @@ import {
   bucketAges,
   daysBetween,
   momentumDelta,
-  todayISO,
   weeklyCounts,
 } from "@/lib/dashboard/age";
+import { useLocalToday } from "@/lib/dashboard/useLocalToday";
 import { filedAt } from "@/lib/dashboard/dates";
 import { DUE_SOON_DAYS, deadlinePulse, duePhrase } from "@/lib/dashboard/deadline";
 import { stageOf, type Application } from "@/lib/dashboard/summary";
@@ -34,11 +36,24 @@ import { stageOf, type Application } from "@/lib/dashboard/summary";
  *     (source = "gmail" rows) and what it is holding under the 0.85 gate,
  *     deep-linked to the review queue.
  *
+ * This is a client component, and deliberately: the deadline cell counts what
+ * is overdue, which is a claim about the READER's day, so its clock read has to
+ * survive past the server render (`useLocalToday`). The alternative — keeping
+ * it a server component and threading `today` down from `app/(app)/dashboard/
+ * page.tsx` — cannot work, because that page is itself a server component: the
+ * value it threaded would be the UTC day, frozen at request time, and would
+ * never be corrected once the browser could say what zone it is in. Wrapping it
+ * in a client shell just to inject the prop would pull this module into the
+ * client bundle anyway (it already is one, via `DemoDashboard`), so the shell
+ * would buy nothing but indirection. Nothing here is interactive beyond the
+ * existing `Link`; the whole surface still server-renders.
+ *
  * Honesty rules: the board fetch is one bounded page, so when the loaded rows
  * are fewer than the account's total the row-derived cells say they describe
  * the newest N rather than pretending to describe everything. Ages/weeks are
- * calendar-day math in UTC on both server and client (`age.ts`), so the strip
- * hydrates cleanly. The micro-bars are `aria-hidden` decoration over the
+ * calendar-day math on a day string — UTC for the server pass and the hydrating
+ * pass, the reader's own day thereafter — so the strip hydrates cleanly and
+ * then tells the truth about time left. The micro-bars are `aria-hidden` decoration over the
  * numbers, animate in with a transform-only CSS entrance (`.pulse-seg`,
  * globals.css), and collapse to their final state under
  * `prefers-reduced-motion` — nothing here is gated on an animation.
@@ -55,7 +70,7 @@ export function PipelinePulse({
   /** Verdicts held under the gate for the user (0 when the queue is clear). */
   needsReview: number;
 }) {
-  const today = todayISO();
+  const today = useLocalToday();
   /** True when the single board page holds every row the account has. */
   const complete = applications.length >= total;
 

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddApplicationForm } from "@/components/applications/AddApplicationForm";
 import { PipelineBoard } from "@/components/dashboard/PipelineBoard";
 import { PipelinePulse } from "@/components/dashboard/PipelinePulse";
 import { SyncBar, type SyncGmailState } from "@/components/dashboard/SyncBar";
 import { todayISO } from "@/lib/dashboard/age";
+import { useLocalToday } from "@/lib/dashboard/useLocalToday";
 import { summarize, type Application } from "@/lib/dashboard/summary";
 import type { BoardTransport, SyncTransport } from "@/lib/dashboard/transport";
 import { demoApplicationsAsApi, demoUnsyncedAsApi } from "@/lib/demo/asApplications";
@@ -74,16 +75,24 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** The whole fixture store, dated against one day — board and pool alike. */
+function buildStore(today: string): DemoBoard {
+  return { apps: demoApplicationsAsApi(today), pool: demoUnsyncedAsApi(today), touched: [] };
+}
+
 export function DemoDashboard() {
-  // ONE clock read for the whole mount: the fixture dates are relative, so
-  // every row in this store — board and unsynced pool alike — is aged against
-  // the same "today" the board renders with. Resolving them here rather than
-  // at module load is what keeps a long-lived server's HTML and the browser's
+  // The day this demo is rendered against. UTC on the server and through
+  // hydration, the visitor's own day once mounted — the same read the board,
+  // the cards and the pulse strip make for themselves (`useLocalToday`).
+  const today = useLocalToday();
+
+  // ONE clock read per dating of the store: the fixture dates are relative, so
+  // every row here — board and unsynced pool alike — is aged against the same
+  // day the board renders with. Resolving them during render rather than at
+  // module load is what keeps a long-lived server's HTML and the browser's
   // hydration agreeing on what "16 days ago" means.
-  const [snapshot, setSnapshot] = useState<DemoBoard>(() => {
-    const today = todayISO();
-    return { apps: demoApplicationsAsApi(today), pool: demoUnsyncedAsApi(today), touched: [] };
-  });
+  const [datedFor, setDatedFor] = useState(todayISO);
+  const [snapshot, setSnapshot] = useState<DemoBoard>(() => buildStore(datedFor));
   /** The pristine fixtures, kept for `restore` — the rows this board began
    *  with, before any drag, dismissal or rebuild touched them. */
   const original = useRef<Application[]>([...snapshot.apps, ...snapshot.pool]);
@@ -92,6 +101,29 @@ export function DemoDashboard() {
     store.current = next;
     setSnapshot(next);
   }, []);
+
+  // The store was dated with the UTC day so the server's HTML and the first
+  // client render agree; once the visitor's real day is known and it differs,
+  // the fixtures are re-dated against it. They MUST be: the seeds are offsets
+  // ("due in 9d", "overdue 2d") and the board now buckets them against the
+  // local day, so leaving the store on the UTC day would shift every phrase on
+  // /demo by one for the width of the visitor's UTC offset. `original` is
+  // rebuilt with them, or a rebuild's Restore would put back rows dated against
+  // the day that was just discarded. This fires at most once, immediately after
+  // hydration and before any fixture can have been touched.
+  // Deferred off the effect body (the house rule, the same shape the detail
+  // sheet's reset uses): the re-dating lands in a macrotask rather than as a
+  // synchronous setState inside an effect.
+  useEffect(() => {
+    if (datedFor === today) return;
+    const id = window.setTimeout(() => {
+      const next = buildStore(today);
+      original.current = [...next.apps, ...next.pool];
+      setDatedFor(today);
+      commit(next);
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [today, datedFor, commit]);
 
   const boardTransport = useMemo<BoardTransport>(
     () => ({

--- a/apps/web/components/settings/DataSection.tsx
+++ b/apps/web/components/settings/DataSection.tsx
@@ -6,6 +6,7 @@ import { Download, Upload } from "lucide-react";
 
 import { SettingsSection } from "./SettingsSection";
 import { secondaryBtnClass } from "@/components/ui/formStyles";
+import { localTodayISO } from "@/lib/dashboard/age";
 
 type ExportState = "idle" | "working" | "error";
 
@@ -28,7 +29,11 @@ export function DataSection() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `applied-applications-${new Date().toISOString().slice(0, 10)}.json`;
+      // The user's own day, not UTC. `toISOString()` here put tomorrow's date
+      // on the file for anyone west of Greenwich after their evening cutoff —
+      // a New York export at 9pm was stamped with the next day. Same defect as
+      // the deadline bucketing, in a filename rather than a card.
+      a.download = `applied-applications-${localTodayISO()}.json`;
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/apps/web/lib/dashboard/age.ts
+++ b/apps/web/lib/dashboard/age.ts
@@ -2,9 +2,24 @@
  * Pure age/momentum math for the dashboard's honest signals. Everything here
  * is a function of calendar-day strings — the same "read the characters, never
  * construct a local Date" rule as `dates.ts` (see its header for the timezone
- * bug that rule exists to prevent). `todayISO()` is the one clock read, and it
- * is UTC on both server and client, so hydration can only disagree across the
- * instant of UTC midnight itself.
+ * bug that rule exists to prevent).
+ *
+ * There are TWO clock reads here, and the difference between them is load-
+ * bearing rather than incidental:
+ *
+ *  - {@link todayISO} is the UTC day. It is identical on the server and in the
+ *    browser, which is the only reason server-rendered HTML can be hydrated
+ *    without a text mismatch (React #418 — `dates.ts` documents the incident).
+ *    It is the SSR/first-paint read, not a claim about the reader's day.
+ *  - {@link localTodayISO} is the day the READER is living in. It is the only
+ *    honest answer to "how long until this deadline?", and it is necessarily
+ *    zone-dependent, so it can only be adopted AFTER hydration — see
+ *    `useLocalToday.ts`, which owns that swap.
+ *
+ * Bucketing a deadline against the UTC day told a New York user at 21:00 that
+ * an assessment due by the end of their own Aug 11 was already `overdue 1d`;
+ * a user in Tokyo saw a deadline whose local day had passed still read
+ * `due today`. The affected window each day is the size of the UTC offset.
  *
  * Kept import-free (the `CALENDAR_PREFIX` regex is duplicated from `dates.ts`
  * on purpose) so `node --test` can load it under type stripping, same as
@@ -26,9 +41,32 @@ export const QUIET_AFTER_DAYS = 14;
 /** How many week-buckets the momentum strip renders. */
 export const MOMENTUM_WEEKS = 8;
 
-/** Today's calendar day, UTC — identical on server and client. */
+/**
+ * Today's calendar day, UTC — identical on server and client, and therefore
+ * the read every server render and first client render must use. It is NOT the
+ * reader's day: use {@link localTodayISO} (via `useLocalToday`) for anything
+ * that claims how much time someone has left.
+ */
 export function todayISO(now: number = Date.now()): string {
   return new Date(now).toISOString().slice(0, 10);
+}
+
+/**
+ * Today's calendar day in the RUNTIME's own zone — the day the person reading
+ * the screen would call today, and the same day their `<input type="date">`
+ * offers when they pick "today".
+ *
+ * Deliberately assembled from the LOCAL calendar accessors. `toISOString()` is
+ * what produced the bug this function exists to fix: it renders the UTC
+ * instant, so between local midnight and UTC midnight it names a day the reader
+ * is not in yet (or has already left). Nothing here may reach for it.
+ */
+export function localTodayISO(now: number = Date.now()): string {
+  const date = new Date(now);
+  const year = String(date.getFullYear()).padStart(4, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 /** UTC-midnight epoch of a calendar-day prefix, or `null` if unparsable. */

--- a/apps/web/lib/dashboard/deadline.ts
+++ b/apps/web/lib/dashboard/deadline.ts
@@ -14,10 +14,13 @@
  *  - a row without `due_at` produces NOTHING — no state, no placeholder, no
  *    inferred urgency. The absence of a date is itself the honest answer;
  *  - the granularity is the calendar day. `due_at` may carry a real instant,
- *    but every surface renders and buckets the day it STATES ("due today"
- *    until UTC midnight, overdue after) — the one reading that is identical
- *    on server and client in every timezone, and the same rule every other
- *    date on the board already follows;
+ *    but every surface renders and buckets the day it STATES — the same rule
+ *    every other date on the board already follows. Which day "today" IS is
+ *    the caller's one decision, and it is not free: bucketing against the UTC
+ *    day made a New York evening read `overdue 1d` on a deadline the reader
+ *    still had hours of. So callers hand this the READER's day
+ *    (`useLocalToday`), and `due today` therefore lasts until the reader's own
+ *    midnight, not UTC's;
  *  - the words are arithmetic, never inference: "due in 2d" is a subtraction,
  *    and no phrasing here claims more than the mail or the user stated.
  */
@@ -76,6 +79,13 @@ export function dueInfo(dueAt: string | null | undefined, today: string): DueInf
  * read as overdue for the whole day it is due — and the calendar prefix
  * round-trips exactly, so the card renders back the day the user picked.
  * `null` for anything that is not a real calendar day.
+ *
+ * That round-trip promise only actually held once the card started bucketing
+ * against the reader's day. The date input hands back a LOCAL day, so a New
+ * York user picking today at 21:00 got a row that read `overdue 1d` the instant
+ * they saved it — the stored day was right, the day it was compared against was
+ * not. The storage shape here is unchanged and is the correct half; see
+ * `useLocalToday`.
  */
 export function dueDayISO(day: string): string | null {
   const match = CALENDAR_PREFIX.exec(day.trim());

--- a/apps/web/lib/dashboard/useLocalToday.ts
+++ b/apps/web/lib/dashboard/useLocalToday.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { localTodayISO, todayISO } from "@/lib/dashboard/age";
+
+/**
+ * The dashboard's one clock read for anything that claims TIME LEFT — the
+ * hydration gate that lets a card be honest about the reader's day without
+ * reintroducing a text mismatch.
+ *
+ * The two constraints are genuinely in tension, which is why this is a hook and
+ * not a function call:
+ *
+ *  - the server has no idea what zone the reader is in, so server-rendered HTML
+ *    can only be written in UTC. Rendering a local day on the hydrating pass
+ *    would make the browser's text disagree with the server's — React #418, the
+ *    exact failure `dates.ts` was written to end;
+ *  - but the UTC day is the wrong day for up to the width of the reader's UTC
+ *    offset, every day. Inside that window a deadline due by the end of the
+ *    reader's own today rendered `overdue 1d`, and east of UTC a deadline whose
+ *    day had already passed still rendered `due today`.
+ *
+ * So: UTC for the server snapshot and the hydrating pass — byte-identical, no
+ * mismatch — then the reader's real day, once there is a reader. Every surface
+ * that buckets a deadline or an age takes its day from here, so the card tag,
+ * the detail sheet and the pulse strip cannot disagree about what day it is.
+ *
+ * `useSyncExternalStore` rather than a mounted flag in `useEffect`: this is the
+ * "server value, then client value" case the API exists for, it is already the
+ * house idiom for it (`AppearanceSection` reads the theme the same way), and it
+ * does the swap as part of hydration instead of as a cascading setState — which
+ * the `react-hooks/set-state-in-effect` rule rejects, and which would have cost
+ * a visible frame of the wrong claim ("overdue 1d" flashing before it settles
+ * to "due today"). The snapshot is a plain string, so React's `Object.is`
+ * comparison bails out whenever the two days agree — the common case, and every
+ * case under `TZ=UTC`.
+ *
+ * `subscribe` is a no-op: nothing pushes a day change at us. The value still
+ * self-corrects across the reader's own midnight, because any later render
+ * re-reads the snapshot.
+ */
+function subscribe(): () => void {
+  return () => {};
+}
+
+export function useLocalToday(): string {
+  return useSyncExternalStore(subscribe, localTodayISO, todayISO);
+}

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -150,8 +150,11 @@ export const DEMO_APPLICATION_COUNT = APPLICATION_SEEDS.length;
 /**
  * The demo board's applications, dated against one `today`.
  *
- * Callers pass the SAME clock read they render with (`todayISO()`), and call
- * this during render rather than at module load: a module-level resolution
+ * Callers pass the SAME clock read they render with (`useLocalToday()`), and
+ * re-date the store if that read changes — the seeds are offsets, so fixtures
+ * dated against one day and bucketed against another shift every deadline
+ * phrase on /demo by one. Resolved during render rather than at module load: a
+ * module-level resolution
  * freezes at process start, which on a long-lived dev server or a warm lambda
  * means the server renders yesterday's dates into HTML the browser then
  * hydrates with today's — a mismatch that repairs itself loudly, in the

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -347,9 +347,22 @@ test.describe("live demo (/demo)", () => {
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
 
-    // Cedar Labs (applied) has no deadline; give it one 5 days out. The date
-    // is computed the way the app computes everything: UTC calendar days.
-    const dayISO = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    // Cedar Labs (applied) has no deadline; give it one 5 days out.
+    //
+    // LOCAL calendar days, not UTC. A date input holds what the user typed,
+    // and the card now buckets it against the reader's own midnight — so a
+    // UTC-derived day here reads as `due in 6d` against this `due in 5d`
+    // whenever the browser sits in the UTC-offset window (New York after
+    // 20:00, Tokyo before 09:00). The old comment claimed UTC was "the way
+    // the app computes everything", which is exactly the assumption the
+    // local-day fix removed.
+    //
+    // `Intl("en-CA")` yields YYYY-MM-DD in the browser's zone and is computed
+    // independently of the app's own helper, so this stays an oracle rather
+    // than a restatement of the code under test.
+    const dayISO = new Intl.DateTimeFormat("en-CA").format(
+      new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
+    );
     const cedar = page
       .locator("li")
       .filter({ has: page.getByText("Software Engineer, Platform", { exact: true }) });

--- a/apps/web/tests/unit/age.test.mjs
+++ b/apps/web/tests/unit/age.test.mjs
@@ -72,7 +72,15 @@ test("momentumDelta halves the same buckets the bars draw", () => {
   assert.deepEqual(momentumDelta([1, 0, 0, 0, 0, 0, 1, 2]), { recent: 3, prior: 1 });
 });
 
-test("todayISO is the UTC calendar day of the instant it is handed", () => {
+/**
+ * `todayISO` is still UTC, and must stay UTC — it is the SSR/hydration-stable
+ * read, the one value the server and the browser's first pass can both produce.
+ * It is NOT what the deadline surfaces bucket against any more: claiming how
+ * much time a reader has left needs the reader's own day, which is
+ * `localTodayISO` (and `useLocalToday` for the mount gate). See
+ * `local-today.test.mjs` for the clock-read behaviour under a real `TZ`.
+ */
+test("todayISO is the UTC calendar day — the hydration-stable server read", () => {
   assert.equal(todayISO(Date.UTC(2026, 7, 11, 23, 59, 59)), "2026-08-11");
   assert.equal(todayISO(Date.UTC(2026, 7, 12, 0, 0, 1)), "2026-08-12");
 });

--- a/apps/web/tests/unit/local-today.test.mjs
+++ b/apps/web/tests/unit/local-today.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * The CLOCK READ behind every deadline claim — the one thing the rest of the
+ * deadline tests deliberately do not exercise.
+ *
+ * `deadline.test.mjs` and `age.test.mjs` feed a literal `TODAY` string, so they
+ * pass in every timezone by construction: they pin the arithmetic, never the
+ * question "which day is it for the person reading this card?". That question
+ * is what shipped wrong. A New York user at 21:00 on Aug 11 was bucketed
+ * against the UTC day (Aug 12) and told an assessment due at the end of Aug 11
+ * was `overdue 1d` — while they still had three hours. Positive-offset zones
+ * failed the other way: a deadline whose local day had already passed still
+ * read `due today`.
+ *
+ * So these tests read the clock, under a fixed instant and whatever `TZ` the
+ * process was given, and check the day against an ORACLE computed independently
+ * of the code under test. The file itself is timezone-agnostic — the same
+ * assertions must hold in every zone — which is what makes running it under
+ * four of them meaningful rather than decorative.
+ *
+ * Run (all four must be green; UTC is the positive control):
+ *
+ *   TZ=America/New_York node --test tests/unit/local-today.test.mjs
+ *   TZ=Asia/Tokyo       node --test tests/unit/local-today.test.mjs
+ *   TZ=Pacific/Auckland node --test tests/unit/local-today.test.mjs
+ *   TZ=UTC              node --test tests/unit/local-today.test.mjs
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { localTodayISO } from "../../lib/dashboard/age.ts";
+import { dueDayISO, dueInfo, duePhrase } from "../../lib/dashboard/deadline.ts";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The oracle: what the READER's own calendar says the day is, derived without
+ * touching the code under test. `en-CA` formats as `YYYY-MM-DD`, and omitting
+ * `timeZone` means the runtime's zone — which is precisely the day a browser's
+ * `<input type="date">` offers as "today", i.e. the day a user picks.
+ */
+const LOCAL_DAY = new Intl.DateTimeFormat("en-CA", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+const localDayOf = (ms) => LOCAL_DAY.format(new Date(ms));
+
+/** The calendar day before `day` — string arithmetic, no zone involved. */
+const dayBefore = (day) =>
+  new Date(Date.parse(`${day}T00:00:00Z`) - DAY_MS).toISOString().slice(0, 10);
+
+/**
+ * Two instants, one per sign of UTC offset. One alone cannot fail everywhere,
+ * and a test that can only fail in one of the four zones makes the other three
+ * runs theatre:
+ *
+ *  - WEST — `2026-08-12T01:00:00Z` is 2026-08-11 21:00 in New York: the
+ *    reader's day is still Aug 11 while the UTC day is already Aug 12.
+ *  - EAST — `2026-08-11T23:00:00Z` is 2026-08-12 08:00 in Tokyo (11:00 in
+ *    Auckland): the reader's day is Aug 12 while the UTC day is still Aug 11.
+ *
+ * Under `TZ=UTC` both instants agree with the UTC day, which is why UTC is the
+ * positive control — it passed before this fix and must pass after it.
+ */
+const WEST = Date.UTC(2026, 7, 12, 1, 0, 0);
+const EAST = Date.UTC(2026, 7, 11, 23, 0, 0);
+const INSTANTS = [
+  ["west of UTC (2026-08-12T01:00:00Z)", WEST],
+  ["east of UTC (2026-08-11T23:00:00Z)", EAST],
+];
+
+test("the day deadlines bucket against is the reader's own calendar day", () => {
+  for (const [label, instant] of INSTANTS) {
+    assert.equal(localTodayISO(instant), localDayOf(instant), label);
+  }
+});
+
+test("a deadline the user picks as TODAY never renders overdue", () => {
+  for (const [label, instant] of INSTANTS) {
+    // Exactly what the sheet does: the date input hands back the reader's local
+    // day, `dueDayISO` turns it into the end of that day, and the card buckets
+    // the result against the clock.
+    const picked = localDayOf(instant);
+    const stored = dueDayISO(picked);
+    const state = dueInfo(stored, localTodayISO(instant));
+    assert.notEqual(state, null, label);
+    assert.equal(duePhrase(state.daysLeft), "due today", label);
+    assert.equal(state.state, "soon", label);
+  }
+});
+
+test("a deadline whose day has passed for the reader is overdue by exactly one", () => {
+  for (const [label, instant] of INSTANTS) {
+    const stored = dueDayISO(dayBefore(localDayOf(instant)));
+    const state = dueInfo(stored, localTodayISO(instant));
+    assert.notEqual(state, null, label);
+    assert.equal(duePhrase(state.daysLeft), "overdue 1d", label);
+    assert.equal(state.state, "overdue", label);
+  }
+});


### PR DESCRIPTION
A deadline you set for **today** rendered as **`overdue 1d`** the moment you saved it.

All the deadline math in `lib/dashboard/deadline.ts` is timezone-invariant and was fine. The clock read was not: `age.ts`'s `todayISO()` returns `new Date().toISOString().slice(0,10)` — the **UTC** day — so a card is bucketed against UTC midnight while the reader lives on a local one.

Measured, in America/New_York at 9pm local (2026-08-12T01:00Z): the user's local day is Aug 11, `todayISO()` says Aug 12, and a deadline of Aug 11 renders `overdue 1d · was due Aug 11` while three hours remain. Positive offsets fail the other way — Tokyo and Auckland show `due today` for a day that has already ended locally. The affected window each day is the size of the UTC offset: NY 20:00–23:59, Tokyo 00:00–09:00, Auckland 00:00–12:00. The displayed calendar date was always right; only the countdown and the overdue/due-soon state were wrong.

This also resolved a contradiction inside one file: `dueDayISO`'s docstring promises "the card renders back the day the user picked" and explains that start-of-day would read as overdue for the whole day it is due — which is precisely what shipped.

`localTodayISO()` reads local calendar parts and never `toISOString`. `todayISO()` is kept unchanged as the SSR-stable read, and `useLocalToday` swaps to the local day after hydration so server HTML stays UTC and React #418 does not come back — the defect `dates.ts` documents as the reason UTC was chosen.

Three decisions worth review: `PipelinePulse` becomes a client component (threading `today` from the server page would freeze the UTC day at request time and never correct); the hook uses `useSyncExternalStore` rather than a mounted flag, because this repo lints `react-hooks/set-state-in-effect` as an error and that is already the house idiom in `AppearanceSection`; and the demo fixture store is re-dated after hydration so its relative seeds and the board agree.

Verified red-first in four timezones with an independent `Intl("en-CA")` oracle, using two instants so both signs of offset are exercised; UTC is the positive control and passes before and after. Unit suite 84 pass, lint, typecheck and build clean. The `useSyncExternalStore` swap was proven by server-rendering and hydrating the real hook under jsdom rather than reasoned about — NY: server `2026-08-12` → DOM `2026-08-11`, Tokyo the reverse, zero console errors.