### PR TITLE
style(theme): a text ramp that is legible on dark, measured in APCA

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -219,7 +219,7 @@ export default async function DashboardPage() {
           role="alert"
           aria-live="polite"
         >
-          <p className="label-caps text-reject">load failed</p>
+          <p className="label-caps text-reject-ink">load failed</p>
           <h2 className="mt-3 text-balance text-2xl font-medium tracking-tight text-strong">
             {headline}
           </h2>

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -151,7 +151,7 @@ function LoginForm() {
         {error ? (
           <p
             role="alert"
-            className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject"
+            className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject-ink"
           >
             {error}
           </p>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -125,7 +125,7 @@ export default function SignupPage() {
             {error ? (
               <p
                 role="alert"
-                className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject"
+                className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject-ink"
               >
                 {error}
               </p>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -212,7 +212,7 @@ body {
 /* Caps label — the product's structural voice: board column headers, form
  * labels, settings field labels, rail headings. Semibold because Atkinson
  * at this size needs the weight to hold uppercase; in the components layer
- * so a per-use utility (`text-reject`, `text-viz-rules`) can override the
+ * so a per-use utility (`text-reject-ink`, `text-viz-rules`) can override the
  * color, which unlayered `.label-mono` never allowed. */
 @layer components {
   .label-caps {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -21,23 +21,44 @@
   --surface-2: #141517;
   --foreground: #d6d8db;
   --text-strong: #f7f8f8;
-  --text-muted: #8a8f98;
-  /* Dim is the faintest step of the text ramp (captions, mono labels). Kept at
-   * ≥4.5:1 against every dark surface (background/surface/surface-2) so the
-   * .label-mono / text-[11px] captions clear WCAG AA — see globals a11y note. */
-  --text-dim: #7c8088;
+  /* The quiet half of the ramp is tuned to APCA, not WCAG 2. On near-black
+   * grounds WCAG 2's ratio over-credits mid-greys badly, and this ramp was the
+   * textbook case: the old muted #8a8f98 / dim #7c8088 read 5.62:1 / 4.61:1 on
+   * surface-2 — a clean AA pass — while measuring only Lc 41.1 / 33.8, far
+   * under the Lc 60 floor for the body-size content they actually carry (card
+   * metadata, timestamps, empty-state copy, the classifier confidence
+   * figures). The old values also left the ramp mis-stepped: a 41-point Lc
+   * chasm from foreground down to muted, then a 7-point sliver from muted to
+   * dim, so the two quiet ranks were indistinguishable from each other and
+   * both were illegible. Retuned to even, descending steps in the same cool
+   * grey family. Measured on surface-2 — the lightest ground any of this
+   * renders on, so the worst case: strong Lc 102.3, foreground Lc 82.0, muted
+   * Lc 69.9, dim Lc 60.7. WCAG AA still clears everywhere (10.44:1 / 8.76:1).
+   * Do not darken these back citing a 4.5:1 pass; that is the measurement this
+   * ramp exists to stop trusting. */
+  --text-muted: #c0c4cb;
+  --text-dim: #aeb4be;
   --line: rgb(255 255 255 / 0.09);
   --line-soft: rgb(255 255 255 / 0.055);
   --line-strong: rgb(255 255 255 / 0.2);
   --green: #4ade80;
   --amber: #f59e0b;
   --red: #f87171;
+  /* Rejection red as *text*. `--red` stays #f87171 for the borders, dots and
+   * washes that carry the semantic, but as text it measured Lc 48.3 on
+   * surface-2 and Lc 47.4 over the `bg-reject/10` wash the auth + Google
+   * sign-in errors sit on — under the Lc 60 floor for the text-sm they are set
+   * at, and, after the ramp retune above, dimmer than an ordinary caption. An
+   * error message must not be the least legible thing on the page. The 300
+   * step of the same hue measures Lc 65.7 solid / Lc 64.8 on the wash. */
+  --red-ink: #fca5a5;
   /* The resting stage's accent. Deliberately achromatic (applied is the calm
-   * state; green/purple/amber/red keep their reserved meanings) but LIGHTER
-   * than the text ramp: the old `var(--text-muted)` accent measured 2.56:1 in
-   * the card border wash — the stage holding all the data was the least
-   * visible thing on the board. Measured: 9.25:1 / APCA Lc 63.5 solid on
-   * surface-2; the 55% card-border wash lands at 3.62:1 (vs 2.56:1 before). */
+   * state; green/purple/amber/red keep their reserved meanings). Used only as
+   * a fill — the pulse/rail bar segments and the card-border wash — never as
+   * text, so it now sits inside the retuned ramp between dim and muted rather
+   * than above it, which is fine: it never competes with a text rank.
+   * Re-measured: 9.25:1 / APCA Lc 63.5 solid on surface-2; the 55% card-border
+   * wash lands at 3.62:1 (vs 2.56:1 for the --text-muted accent it replaced). */
   --stage-applied: #b3b9c2;
   /* Data-viz sub-palette — the three classifier layers get their own
    * categorical hues so the pipeline reads as data, not just mono text. */
@@ -65,14 +86,15 @@
   --surface-2: #141517;
   --foreground: #d6d8db;
   --text-strong: #f7f8f8;
-  --text-muted: #8a8f98;
-  --text-dim: #7c8088;
+  --text-muted: #c0c4cb;
+  --text-dim: #aeb4be;
   --line: rgb(255 255 255 / 0.09);
   --line-soft: rgb(255 255 255 / 0.055);
   --line-strong: rgb(255 255 255 / 0.2);
   --green: #4ade80;
   --amber: #f59e0b;
   --red: #f87171;
+  --red-ink: #fca5a5;
   --stage-applied: #b3b9c2;
   --viz-rules: #38bdf8;
   --viz-embeddings: #a78bfa;
@@ -94,8 +116,13 @@
   --foreground: #3f3f46;
   --text-strong: #18181b;
   --text-muted: #52525b;
-  /* Darkened from #9599a1 (~3.0:1) so dim captions clear WCAG AA (≥4.5:1) on
-   * the light paper surfaces too, while staying a step lighter than muted. */
+  /* Unchanged by the APCA pass that retuned the dark ramp: on paper the two
+   * formulas agree, and this end already clears both floors. Measured on
+   * surface-2 (worst ground): muted Lc 80.4 / 7.03:1, dim Lc 70.1 / 4.86:1.
+   * Darkening dim further to mirror the dark theme's step sizes would buy
+   * nothing and lightening it to match dark's Lc 60.7 would drop it under
+   * WCAG AA, so it stays. The two ramps now read far more alike than they did
+   * — dark 102/82/70/61 against light 98/88/80/70. */
   --text-dim: #676b73;
   --line: rgb(0 0 0 / 0.1);
   --line-soft: rgb(0 0 0 / 0.06);
@@ -112,6 +139,11 @@
    * measures 6.47:1 on white, 5.89:1 on surface-2, 4.98:1 / APCA Lc 63 on
    * the wash. */
   --red: #b91c1c;
+  /* Ink red on paper already clears the Lc 60 text floor (Lc 73.7 on
+   * surface-2, Lc 68.7 over the bg-reject/10 wash), so the text variant is the
+   * same value here. It is declared in both themes so `text-reject-ink`
+   * always resolves. */
+  --red-ink: #b91c1c;
   /* Ink counterpart of the dark ramp's #b3b9c2 — measured 9.93:1 on white,
    * 9.03:1 on the paper surface-2 (APCA Lc 93 / 87). */
   --stage-applied: #3f434b;
@@ -134,6 +166,7 @@
   --color-live: var(--green);
   --color-review: var(--amber);
   --color-reject: var(--red);
+  --color-reject-ink: var(--red-ink);
   --color-stage-applied: var(--stage-applied);
   --color-viz-rules: var(--viz-rules);
   --color-viz-embeddings: var(--viz-embeddings);

--- a/apps/web/components/applications/AddApplicationForm.tsx
+++ b/apps/web/components/applications/AddApplicationForm.tsx
@@ -237,7 +237,7 @@ export function AddApplicationForm({
           </label>
 
           {error ? (
-            <p role="alert" className="text-xs text-reject sm:col-span-2">
+            <p role="alert" className="text-xs text-reject-ink sm:col-span-2">
               {error}
             </p>
           ) : null}

--- a/apps/web/components/auth/GoogleSignInButton.tsx
+++ b/apps/web/components/auth/GoogleSignInButton.tsx
@@ -131,7 +131,7 @@ export function GoogleSignInButton({
       {error ? (
         <p
           role="alert"
-          className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject"
+          className="rounded-md border border-reject/40 bg-reject/10 px-3 py-2 text-sm text-reject-ink"
         >
           {error}
         </p>

--- a/apps/web/components/dashboard/ApplicationCard.tsx
+++ b/apps/web/components/dashboard/ApplicationCard.tsx
@@ -431,7 +431,7 @@ export function ApplicationCard({
               type="button"
               aria-describedby={confirmId}
               onClick={() => void onDeleteConfirmed()}
-              className="rounded border border-reject/60 px-2 py-1 text-xs text-reject transition-colors hover:bg-reject/15"
+              className="rounded border border-reject/60 px-2 py-1 text-xs text-reject-ink transition-colors hover:bg-reject/15"
             >
               {DELETE_CONFIRM_LABEL}
             </button>
@@ -444,7 +444,7 @@ export function ApplicationCard({
           role="alert"
           className="mt-2 flex items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
         >
-          <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject" aria-hidden />
+          <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject-ink" aria-hidden />
           <span>{error}</span>
         </p>
       ) : null}

--- a/apps/web/components/dashboard/ApplicationDetail.tsx
+++ b/apps/web/components/dashboard/ApplicationDetail.tsx
@@ -61,7 +61,7 @@ function pct(n: number): string {
 /** The sheet's deadline phrase ink, by state — measured in both themes (red
  * 6.89:1 dark / 6.47:1 light on the sheet surface; amber 8.87:1 / 5.02:1). */
 const DUE_TEXT_CLASS: Record<DueState, string> = {
-  overdue: "text-reject",
+  overdue: "text-reject-ink",
   soon: "text-review",
   ahead: "text-muted",
 };
@@ -207,7 +207,7 @@ function SplitPrompt({
         </button>
       </div>
       {error ? (
-        <p role="alert" className="mt-2 text-xs text-reject">
+        <p role="alert" className="mt-2 text-xs text-reject-ink">
           {error}
         </p>
       ) : null}
@@ -396,7 +396,7 @@ export function ApplicationDetail({
             role="alert"
             className="flex items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
           >
-            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject" aria-hidden />
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject-ink" aria-hidden />
             <span>{stageError}</span>
           </p>
         ) : null}
@@ -500,7 +500,7 @@ export function ApplicationDetail({
             role="alert"
             className="flex items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
           >
-            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject" aria-hidden />
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject-ink" aria-hidden />
             <span>{dueError}</span>
           </p>
         ) : null}

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -94,7 +94,7 @@ export function DeadlineTag({
       className={`tabular mt-2 inline-flex items-center gap-1.5 rounded border px-1.5 py-0.5 font-mono text-[10px] leading-snug ${DUE_TAG_CLASS[due.state]}`}
     >
       <CalendarClock
-        className={`h-3 w-3 shrink-0 ${due.state === "overdue" ? "text-reject" : ""}`}
+        className={`h-3 w-3 shrink-0 ${due.state === "overdue" ? "text-reject-ink" : ""}`}
         aria-hidden
       />
       <span>

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -365,7 +365,7 @@ export function PipelineBoard({
       ) : null}
 
       {moveError ? (
-        <p role="alert" className="text-xs text-reject">
+        <p role="alert" className="text-xs text-reject-ink">
           {moveError}
         </p>
       ) : null}

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -212,7 +212,7 @@ export function PipelinePulse({
             <p className="tabular mt-2 text-xs text-muted">
               {/* "N overdue" turns red as a unit — a red word beside a white
                   digit would put the emphasis on the wrong half. */}
-              <span className={due.overdue > 0 ? "font-medium text-reject" : ""}>
+              <span className={due.overdue > 0 ? "font-medium text-reject-ink" : ""}>
                 <span className={due.overdue > 0 ? "tabular" : "tabular text-strong"}>
                   {due.overdue}
                 </span>{" "}
@@ -229,7 +229,7 @@ export function PipelinePulse({
                 most urgent · {due.urgent.company}{" "}
                 <span
                   className={`tabular font-mono text-[10px] ${
-                    due.urgent.daysLeft < 0 ? "text-reject" : "text-review"
+                    due.urgent.daysLeft < 0 ? "text-reject-ink" : "text-review"
                   }`}
                 >
                   {duePhrase(due.urgent.daysLeft)}

--- a/apps/web/components/dashboard/ReviewQueue.tsx
+++ b/apps/web/components/dashboard/ReviewQueue.tsx
@@ -293,7 +293,7 @@ function ReviewRow({
       ) : null}
 
       {error ? (
-        <p role="alert" className="mt-1.5 text-xs text-reject">
+        <p role="alert" className="mt-1.5 text-xs text-reject-ink">
           {error}
         </p>
       ) : null}

--- a/apps/web/components/dashboard/RowActionsMenu.tsx
+++ b/apps/web/components/dashboard/RowActionsMenu.tsx
@@ -209,7 +209,7 @@ export function RowActionsMenu({
                 index > 0 ? "border-t border-line-soft" : ""
               } ${
                 item.tone === "danger"
-                  ? "text-reject hover:bg-reject/10"
+                  ? "text-reject-ink hover:bg-reject/10"
                   : "text-muted hover:bg-surface-2 hover:text-strong"
               }`}
             >

--- a/apps/web/components/dashboard/SyncBar.tsx
+++ b/apps/web/components/dashboard/SyncBar.tsx
@@ -353,7 +353,7 @@ export function SyncBar({
     // Resting after a failed run: the backend keeps `last_sync_at` at the last
     // good sync, so recency and this line are two facts, both shown.
     statusContent = (
-      <span className="text-reject">
+      <span className="text-reject-ink">
         last sync failed{gmail.syncError ? ` · ${gmail.syncError}` : ""}{" "}
         <button
           type="button"
@@ -511,7 +511,7 @@ export function SyncBar({
       </p>
       <p
         role="alert"
-        className={`text-xs text-reject ${alertContent === null ? "sr-only" : ""}`}
+        className={`text-xs text-reject-ink ${alertContent === null ? "sr-only" : ""}`}
       >
         {alertContent}
       </p>
@@ -670,7 +670,7 @@ function RebuildReceipt({
           ) : endKind === "partial" ? (
             <p className="text-xs text-review">rebuild stopped early · just now</p>
           ) : (
-            <p className="text-xs text-reject">
+            <p className="text-xs text-reject-ink">
               rebuild interrupted · the scan {stopReasonPhrase(outcome.stoppedBy)}
             </p>
           )}
@@ -727,7 +727,7 @@ function RebuildReceipt({
               ) : (
                 <span className="ml-auto flex items-center gap-2">
                   {failedId === row.id ? (
-                    <span role="alert" className="text-xs text-reject">
+                    <span role="alert" className="text-xs text-reject-ink">
                       couldn&apos;t restore — still removed
                     </span>
                   ) : null}

--- a/apps/web/components/demo/SampleInbox.tsx
+++ b/apps/web/components/demo/SampleInbox.tsx
@@ -119,7 +119,11 @@ function ExpandedTrace({ email }: { email: SampleEmail }) {
               <span className="w-16 shrink-0 text-dim">
                 {meta.n} · {meta.label}
               </span>
-              <span className={dim ? "text-dim/70" : "text-muted"}>
+              {/* A skipped layer drops a rank on the text ramp, not below it: the
+                  old `text-dim/70` composited to Lc 19.6 on this surface, which is
+                  not "quiet", it is unreadable. The dot's 0.3 opacity above is
+                  decoration and can carry the skipped state on its own. */}
+              <span className={dim ? "text-dim" : "text-muted"}>
                 {step.state === "answered" ? "answered — " : step.state === "passed" ? "passed — " : ""}
                 {step.note}
               </span>

--- a/apps/web/components/gmail/InboxWorkbench.tsx
+++ b/apps/web/components/gmail/InboxWorkbench.tsx
@@ -588,7 +588,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
           read. */}
       {mineFailed ? (
         <div role="alert" className="rounded-xl border border-reject/40 bg-surface p-6">
-          <p className="label-caps text-reject">scan failed</p>
+          <p className="label-caps text-reject-ink">scan failed</p>
           <h2 className="mt-2 text-base font-medium text-strong">
             We couldn&apos;t finish reading your mail.
           </h2>
@@ -619,7 +619,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
                 role="status"
                 className={cn(
                   "mt-1 text-xs",
-                  filing.phase === "error" ? "text-reject" : "text-dim",
+                  filing.phase === "error" ? "text-reject-ink" : "text-dim",
                 )}
               >
                 {filing.note}

--- a/apps/web/components/settings/AccountSection.tsx
+++ b/apps/web/components/settings/AccountSection.tsx
@@ -91,7 +91,7 @@ export function AccountSection({ email }: { email: string }) {
         <div className="space-y-4">
           <label className="grid gap-1">
             <span className="label-caps">
-              type <span className="font-mono text-reject">{CONFIRM_WORD}</span> to confirm
+              type <span className="font-mono text-reject-ink">{CONFIRM_WORD}</span> to confirm
             </span>
             <input
               value={confirm}
@@ -103,7 +103,7 @@ export function AccountSection({ email }: { email: string }) {
           </label>
 
           {error ? (
-            <p role="alert" className="text-xs text-reject">
+            <p role="alert" className="text-xs text-reject-ink">
               {error}
             </p>
           ) : null}

--- a/apps/web/components/settings/DataSection.tsx
+++ b/apps/web/components/settings/DataSection.tsx
@@ -52,7 +52,7 @@ export function DataSection() {
         </Link>
       </div>
       {state === "error" ? (
-        <p role="alert" className="mt-3 text-xs text-reject">
+        <p role="alert" className="mt-3 text-xs text-reject-ink">
           Couldn’t prepare the export — the backend may be unreachable. Try again shortly.
         </p>
       ) : (

--- a/apps/web/components/settings/GmailConnectionCard.tsx
+++ b/apps/web/components/settings/GmailConnectionCard.tsx
@@ -69,7 +69,7 @@ export function GmailConnectionCard({ result }: { result: GmailStatusResult }) {
                   ) : null}
                 </p>
                 {status?.sync_status === "error" ? (
-                  <p className="text-reject">
+                  <p className="text-reject-ink">
                     The last sync attempt failed
                     {status.sync_error ? ` (${status.sync_error})` : ""} — the time above is the
                     last one that succeeded. Press Sync on the dashboard to retry.

--- a/apps/web/components/settings/SettingsSection.tsx
+++ b/apps/web/components/settings/SettingsSection.tsx
@@ -50,7 +50,7 @@ export function SaveStatus({ state }: { state: "idle" | "saving" | "saved" | "er
   const map = {
     saving: { text: "Saving…", cls: "text-dim" },
     saved: { text: "Saved", cls: "text-live" },
-    error: { text: "Couldn’t save — try again.", cls: "text-reject" },
+    error: { text: "Couldn’t save — try again.", cls: "text-reject-ink" },
   } as const;
   const { text, cls } = map[state];
   return (

--- a/apps/web/components/shell/RailFooter.tsx
+++ b/apps/web/components/shell/RailFooter.tsx
@@ -72,7 +72,7 @@ function GmailChip({ gmail }: { gmail: RailGmailData }) {
         ) : null}
         <LastSynced at={gmail.lastSyncAt} className="block truncate font-mono text-[10px] text-dim" />
         {gmail.syncStatus === "error" ? (
-          <span className="block truncate text-[11px] text-reject">
+          <span className="block truncate text-[11px] text-reject-ink">
             last sync failed{gmail.syncError ? ` · ${gmail.syncError}` : ""}
           </span>
         ) : null}

--- a/apps/web/components/ui/formStyles.ts
+++ b/apps/web/components/ui/formStyles.ts
@@ -19,4 +19,4 @@ export const secondaryBtnClass =
   "inline-flex items-center justify-center gap-2 rounded-lg border border-line px-4 py-2 text-sm text-foreground transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong disabled:opacity-40";
 
 export const dangerBtnClass =
-  "inline-flex items-center justify-center gap-2 rounded-lg border border-reject/50 px-4 py-2 text-sm text-reject transition-colors hover:border-reject hover:bg-reject/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-reject disabled:cursor-not-allowed disabled:opacity-40";
+  "inline-flex items-center justify-center gap-2 rounded-lg border border-reject/50 px-4 py-2 text-sm text-reject-ink transition-colors hover:border-reject hover:bg-reject/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-reject disabled:cursor-not-allowed disabled:opacity-40";


### PR DESCRIPTION
The dim grey ramp passed WCAG 2 AA and was genuinely hard to read. WCAG 2's formula over-credits mid-greys on dark grounds, which is exactly this case, so "accessible by the letter" and "legible" had come apart.

Measuring the whole ramp found a second problem the audit had not named: the steps were badly distributed. `foreground → muted` was a 41-point Lc chasm and `muted → dim` a 7-point sliver, so the two quiet ranks were both illegible **and** indistinguishable from each other. Fixing only the dim end would have shipped a two-tone ramp.

Measured on `surface-2` (#141517), the lightest ground any of this renders on, so worst case:

| token | before | after |
|---|---|---|
| text-muted | #8a8f98 · **Lc 41.1** | #c0c4cb · **Lc 69.9** |
| text-dim | #7c8088 · **Lc 33.8** | #aeb4be · **Lc 60.7** |
| red as text | #f87171 · Lc 48.3 | new `red-ink` #fca5a5 · **Lc 65.7** |
| demo trace `text-dim/70` | **Lc 19.6** | **Lc 60.7** |

The ramp now descends 102 / 82 / 70 / 61, in the same cool grey family — the new values sit inside the existing `stage-applied` tint band, so nothing new enters the palette, and `foreground`/`text-strong` are untouched. `--red` itself is unchanged so every border, dot and wash keeps the rejection semantic; only the 30 places red was used as *text* move to `text-reject-ink`.

The light theme is deliberately left alone: it clears both floors already (muted Lc 80.4, dim 70.1), and lightening it to mirror dark's steps would push dim under WCAG AA. The two themes now read more alike than before — dark 102/82/70/61 against light 98/88/80/70.

Two things kept on purpose rather than overlooked: amber `--review` at Lc 59.6 now sits just under dim, but every amber use is ≤12px where the floor is 45, and hue carries the salience there; and `stage-applied` now sits inside the ramp but is fill-only and never text.

Verified by looking, not only by arithmetic — headless-Chrome screenshots of the landing (the shared-token risk), the demo dashboard, the sample inbox, and login in light theme, plus an old-vs-new side-by-side at real component sizes to confirm the three text ranks stay separated. Build and lint clean.

One finding worth keeping: the first inventory grep used `--include="*.tsx"` and missed a red `text-sm` in `components/ui/formStyles.ts`. The filter, not the codebase, defined the result — the same shape as the other checks-that-cannot-fail in this estate. Fixed in the second commit.