### PR TITLE
test(account): assert deletion covers every table the schema says a user owns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-488%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-493%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -373,13 +373,13 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**488 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 446 `test_*` functions across 30 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 488 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**493 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 451 `test_*` functions across 31 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 493 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
 Those tests drive the production machinery, not a fixture: `jobtracker.database.connection.get_session` with its real GUC and `search_path` handling, against a non-`BYPASSRLS` role, asserting that a raw query with the application-level `WHERE user_id = ...` filter *removed* still returns nothing for another tenant.
 
-**Coverage**, from the same run: **57.08%** overall — 9,166 statements, 3,934 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **85.6%**; `auth` 80.5%; `database` 77.2%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
+**Coverage**, from the same run: **57.09%** overall — 9,166 statements, 3,933 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **85.6%**; `auth` 80.5%; `database` 77.2%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -534,7 +534,7 @@ applied/
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
 │   ├── alembic/versions/    # 11 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 30 modules
+│   └── tests/               # 31 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/backend/tests/test_account_deletion_covers_every_table.py
+++ b/backend/tests/test_account_deletion_covers_every_table.py
@@ -1,0 +1,156 @@
+"""Deleting an account must clear every table that holds the user's rows.
+
+Why this file exists
+--------------------
+
+``jobtracker/cloud/account.py`` purges a user by iterating a hand-written tuple,
+``_DELETION_ORDER``. That tuple is referenced nowhere else in the codebase — no
+test, no invariant, nothing. So the correctness of "Delete account" rests
+entirely on a future author remembering to add their new table to a list they
+have no reason to look at.
+
+The failure mode is silent and it is the bad kind: the endpoint deletes what it
+knows about, commits, logs success and answers **200** with
+``tables_cleared: 8``, while the forgotten table keeps the user's rows forever.
+A user who asked to be deleted, and was told they were, would not be. This is
+not hypothetical — the cascade was added in the first place after it was found
+orphaning rows.
+
+So the assertion here is deliberately not "the tuple has eight entries", which
+would be a restatement. It derives the required set from the schema itself: any
+table carrying a ``user_id`` column is tenant-owned by construction, and must be
+purged. A new tenant table fails this test on the commit that introduces it,
+which is the only moment the omission is cheap to fix.
+
+The ordering property is asserted too, because it is load-bearing for a
+different reason: the foreign keys default to RESTRICT, so a parent deleted
+before its children raises and the whole purge rolls back. Verified by mutation
+rather than by reading: appending ``_DELETION_ORDER = tuple(reversed(...))``
+turns that assertion red and names all four offending edges
+(``contacts→applications``, ``email_embeddings→emails``, ``emails→applications``,
+``interviews→applications``).
+
+One note on how this file was written, because it is the defect it guards
+against in miniature. The ordering test first hardcoded four pairs using
+guessed singular table names — ``email``, ``application`` — where the schema
+says ``emails``, ``applications``. Every case hit its ``pytest.skip`` guard and
+the run reported **3 passed, 4 skipped**: four tests that looked fine and could
+not fail. Deriving the pairs from the metadata is what fixed it, and that is
+why nothing in here is a hand-written list of names.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import SQLModel
+
+# Importing the models module populates ``SQLModel.metadata`` with every table.
+from jobtracker.database import models  # noqa: F401
+from jobtracker.cloud.account import _DELETION_ORDER
+
+
+# Tables that carry a ``user_id`` but are NOT the user's own data to purge.
+# Empty today. Anything added here needs a reason in this comment, because the
+# whole point of the test is that membership is derived, not chosen.
+_NOT_TENANT_DATA: frozenset[str] = frozenset()
+
+
+def _tenant_tables() -> set[str]:
+    """Every table in the schema with a ``user_id`` column."""
+
+    return {
+        name
+        for name, table in SQLModel.metadata.tables.items()
+        if "user_id" in table.columns and name not in _NOT_TENANT_DATA
+    }
+
+
+def _purged_tables() -> set[str]:
+    """Every table ``delete_account`` actually issues a DELETE against."""
+
+    return {model.__tablename__ for model in _DELETION_ORDER}
+
+
+def test_every_tenant_table_is_purged_on_account_deletion():
+    """The set the endpoint clears must cover the set the schema defines."""
+
+    missed = _tenant_tables() - _purged_tables()
+    assert not missed, (
+        "these tables hold rows owned by a user and would SURVIVE account "
+        f"deletion: {sorted(missed)}. Add them to `_DELETION_ORDER` in "
+        "jobtracker/cloud/account.py, children before parents. The endpoint "
+        "would otherwise answer 200 and report success while leaving this "
+        "user's data behind."
+    )
+
+
+def test_the_deletion_order_names_no_table_that_does_not_exist():
+    """The converse: a stale entry would raise at request time, not import time."""
+
+    unknown = _purged_tables() - set(SQLModel.metadata.tables)
+    assert not unknown, f"_DELETION_ORDER names tables not in the schema: {sorted(unknown)}"
+
+
+def test_no_model_is_listed_twice():
+    """A duplicate is harmless but means the list was edited without reading it."""
+
+    names = [model.__tablename__ for model in _DELETION_ORDER]
+    assert len(names) == len(set(names)), f"_DELETION_ORDER repeats a table: {names}"
+
+
+def _tenant_foreign_keys() -> list[tuple[str, str]]:
+    """Every (child, parent) edge between two tenant tables, read from the schema.
+
+    Derived rather than listed. The first version of this test hardcoded four
+    pairs using guessed table names (``email``, ``application``) instead of the
+    real ones (``emails``, ``applications``), and every case silently
+    ``pytest.skip``-ed — four green-looking tests that could not fail. Reading
+    the edges out of the metadata removes the class of mistake entirely: a new
+    foreign key is covered the moment it exists, and a renamed table cannot
+    quietly drop its own constraint from the check.
+    """
+
+    tenant = _tenant_tables()
+    edges: list[tuple[str, str]] = []
+    for name, table in SQLModel.metadata.tables.items():
+        if name not in tenant:
+            continue
+        for fk in table.foreign_keys:
+            parent = fk.column.table.name
+            if parent in tenant and parent != name:
+                edges.append((name, parent))
+    return sorted(set(edges))
+
+
+def test_the_foreign_key_graph_is_not_empty():
+    """Guards the guard: an empty edge list would make the next test vacuous."""
+
+    edges = _tenant_foreign_keys()
+    assert edges, (
+        "no foreign keys found between tenant tables — either the schema "
+        "changed shape or this test is no longer reading it correctly, and "
+        "the ordering assertion below has quietly become a no-op"
+    )
+
+
+def test_children_are_deleted_before_their_parents():
+    """Order is not cosmetic — the foreign keys default to RESTRICT.
+
+    Deleting an ``Application`` while its ``Email`` rows still point at it
+    raises, the transaction rolls back, and the user's deletion request fails
+    outright — so a user who asked to be deleted gets an error instead, or
+    worse, a partial purge.
+    """
+
+    order = [model.__tablename__ for model in _DELETION_ORDER]
+    wrong = [
+        (child, parent)
+        for child, parent in _tenant_foreign_keys()
+        if child in order and parent in order and order.index(child) > order.index(parent)
+    ]
+    assert not wrong, (
+        "these children are deleted AFTER the parent they reference: "
+        f"{wrong}. The foreign keys are RESTRICT, so the parent delete raises "
+        "and the entire purge rolls back. Reorder `_DELETION_ORDER` in "
+        "jobtracker/cloud/account.py so children come first."
+    )

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 488,
+      "value": 493,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,7 +12,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 57.08,
+      "value": 57.09,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
@@ -20,7 +20,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3934,
+      "value": 3933,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 488,
+    "passed": 493,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
`_DELETION_ORDER` in `cloud/account.py` is a hand-written tuple referenced nowhere else in the codebase — no test, no invariant. So the correctness of **Delete account** rested entirely on a future author remembering to add their new table to a list they have no reason to open.

The failure mode is the bad kind. The endpoint deletes what it knows about, commits, logs success and answers **200** with `tables_cleared: 8`, while the forgotten table keeps the user's rows forever. A user who asked to be deleted, and was told they were, would not be. That is not hypothetical here — the cascade was added in the first place after it was found orphaning rows.

So the required set is **derived from the schema**, not restated: any table carrying a `user_id` column is tenant-owned by construction and must be purged, and a new one fails this test on the commit that introduces it — the only moment the omission is cheap to fix. Ordering is derived too, from the real foreign keys, because they default to RESTRICT: a parent deleted before its children raises and rolls the entire purge back.

Verified by mutation, not by reading — appending `_DELETION_ORDER = tuple(reversed(_DELETION_ORDER))` turns the ordering assertion red and names all four offending edges (`contacts→applications`, `email_embeddings→emails`, `emails→applications`, `interviews→applications`).

**One thing worth keeping in the record:** the first draft of the ordering test was itself the defect it guards against. It hardcoded four pairs using guessed singular table names (`email`, `application`) where the schema says `emails`, `applications`. Every case hit its `pytest.skip` guard and the run reported **3 passed, 4 skipped** — four tests that looked fine and could not fail. Reading the edges out of the metadata is what removed the class of mistake, and is why nothing in the file is a hand-written list of names.

Backend suite 488 → 493, 0 skipped.