### PR TITLE
fix(auth): /inbox and /settings lost your return path after signing in

### DIFF
--- a/apps/web/lib/supabase/middleware.ts
+++ b/apps/web/lib/supabase/middleware.ts
@@ -5,6 +5,7 @@ import {
 } from "@supabase/ssr";
 
 import { publicEnv } from "@/lib/env";
+import { isProtectedPath } from "@/lib/supabase/protectedRoutes";
 
 /**
  * Paths under this prefix require an authenticated Supabase session. In the
@@ -15,15 +16,7 @@ import { publicEnv } from "@/lib/env";
  * that way, the proxy keeps running on all app routes but only *redirects*
  * for known-protected ones.
  */
-const PROTECTED_PREFIXES = ["/dashboard"];
-
 const PUBLIC_AUTH_PATHS = new Set(["/login", "/signup", "/callback"]);
-
-function isProtectedPath(pathname: string): boolean {
-  return PROTECTED_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
 
 /**
  * `updateSession` is called from `proxy.ts` for every request that matches

--- a/apps/web/lib/supabase/protectedRoutes.ts
+++ b/apps/web/lib/supabase/protectedRoutes.ts
@@ -1,0 +1,33 @@
+/**
+ * Which URL prefixes require an authenticated Supabase session.
+ *
+ * Lives in its own module, dependency-free (no `next/server`, no `@supabase/ssr`,
+ * no `@/` alias), for one reason: `tests/unit/` can then load it under Node's
+ * type stripping and check it against the filesystem. Inside `middleware.ts`
+ * this list could not be executed by a test at all, and it drifted — `/inbox`
+ * and `/settings` were never added for as long as they have existed.
+ *
+ * The drift was not harmless. Both routes still redirected, but from the
+ * protected layout's bare `redirect("/login")` rather than from the proxy, and
+ * that path carries no `?redirect=` — so signing in after following a Settings
+ * link landed you on the dashboard, while the identical journey through
+ * `/dashboard` returned you where you meant to go. Measured against production
+ * before the fix:
+ *
+ *     /dashboard  →  307  /login?redirect=%2Fdashboard
+ *     /inbox      →  307  /login
+ *     /settings   →  307  /login
+ *
+ * In the App Router the `(app)` and `(auth)` route groups are NOT part of the
+ * URL, so gating has to happen on the literal prefix. Extend this list rather
+ * than the negative matcher in `proxy.ts` when adding a protected page: the
+ * proxy keeps running on every app route and only *redirects* for known ones.
+ */
+export const PROTECTED_PREFIXES: readonly string[] = ["/dashboard", "/inbox", "/settings"];
+
+/** True when `pathname` is a protected page or lives beneath one. */
+export function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}

--- a/apps/web/tests/unit/protected-routes.test.mjs
+++ b/apps/web/tests/unit/protected-routes.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Every page under `app/(app)/` must be gated by the proxy, not only by the
+ * layout.
+ *
+ * Both mechanisms redirect a signed-out visitor, so the omission is invisible
+ * to any "does it redirect?" test — which is why it survived. The difference is
+ * where you land afterwards: the proxy sends you to
+ * `/login?redirect=<where you were going>` and the login form honours it, while
+ * `app/(app)/layout.tsx`'s defence-in-depth `redirect("/login")` carries no
+ * such hint and drops you on the dashboard.
+ *
+ * Measured against production before the fix:
+ *
+ *     /dashboard  →  307  /login?redirect=%2Fdashboard
+ *     /inbox      →  307  /login
+ *     /settings   →  307  /login
+ *
+ * `/inbox` and `/settings` had been in `app/(app)/` since they were written and
+ * were never added to the list, even though the middleware's own comment says
+ * to extend it when adding a protected page. So this test derives the expected
+ * set from the directory rather than restating it: a new protected page fails
+ * here on the commit that creates it.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  PROTECTED_PREFIXES,
+  isProtectedPath,
+} from "../../lib/supabase/protectedRoutes.ts";
+
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const appGroupDir = join(webRoot, "app", "(app)");
+
+/** URL prefixes implied by the directories inside `app/(app)/`. */
+function routesInProtectedGroup() {
+  return readdirSync(appGroupDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    // A route group in parentheses contributes no URL segment; a page needs a
+    // page.tsx to exist at all.
+    .filter((e) => !e.name.startsWith("(") && !e.name.startsWith("_"))
+    .filter((e) => existsSync(join(appGroupDir, e.name, "page.tsx")))
+    .map((e) => `/${e.name}`);
+}
+
+test("the protected group is not empty — otherwise this file proves nothing", () => {
+  // Guards the guard. If the directory moved, every assertion below would pass
+  // vacuously against an empty list.
+  assert.ok(
+    routesInProtectedGroup().length >= 3,
+    `expected pages under app/(app)/, found ${JSON.stringify(routesInProtectedGroup())}`,
+  );
+});
+
+test("every page in app/(app)/ is gated by the proxy", () => {
+  const missing = routesInProtectedGroup().filter(
+    (route) => !PROTECTED_PREFIXES.includes(route),
+  );
+
+  assert.deepEqual(
+    missing,
+    [],
+    `these pages live in app/(app)/ but are not in PROTECTED_PREFIXES, so a ` +
+      `signed-out visitor is redirected by the layout instead of the proxy and ` +
+      `loses their return path after signing in: ${missing.join(", ")}`,
+  );
+});
+
+test("the list names no route that does not exist", () => {
+  const known = routesInProtectedGroup();
+  const stale = PROTECTED_PREFIXES.filter((p) => !known.includes(p));
+  assert.deepEqual(stale, [], `PROTECTED_PREFIXES names removed routes: ${stale.join(", ")}`);
+});
+
+test("matching covers the page and everything beneath it, and nothing else", () => {
+  assert.equal(isProtectedPath("/settings"), true);
+  assert.equal(isProtectedPath("/settings/billing"), true);
+  assert.equal(isProtectedPath("/inbox"), true);
+  assert.equal(isProtectedPath("/dashboard"), true);
+
+  // Public routes must stay public — a prefix match that is too eager here
+  // would lock signed-out visitors out of the demo and the landing.
+  assert.equal(isProtectedPath("/"), false);
+  assert.equal(isProtectedPath("/demo"), false);
+  assert.equal(isProtectedPath("/demo/inbox"), false);
+  assert.equal(isProtectedPath("/import"), false);
+  assert.equal(isProtectedPath("/login"), false);
+
+  // A path that merely STARTS with the same characters is a different route.
+  assert.equal(isProtectedPath("/settings-export"), false);
+  assert.equal(isProtectedPath("/inboxes"), false);
+});


### PR DESCRIPTION
The proxy gates on a literal URL prefix list, and `/inbox` and `/settings` were never added to it — for as long as they have existed — even though the middleware's own comment says to extend that list when adding a protected page.

Both routes still redirected, which is exactly why nothing caught it: the protected layout's defence-in-depth `redirect("/login")` fires instead. The difference is where you land afterwards. The proxy sends you to `/login?redirect=<where you were going>` and the login form honours it; the layout's bare redirect carries no hint, so signing in after following a Settings link drops you on the dashboard.

Measured against production before the fix:

    /dashboard  →  307  /login?redirect=%2Fdashboard
    /inbox      →  307  /login
    /settings   →  307  /login

The list moves into its own dependency-free module so a unit test can load it under Node's type stripping — inside `middleware.ts` it pulls `next/server` and `@supabase/ssr` and could not be executed at all, which is precisely how it drifted. The test derives the expected set from the contents of `app/(app)/` rather than restating it, so a new protected page fails on the commit that creates it. It also guards its own premise: an empty directory listing would make every assertion vacuous, so that is asserted first.

Verified by mutation — dropping `/settings` from the list turns the test red and names `/settings`. Unit suite 86 → 103; typecheck, lint and build clean.