### PR TITLE
feat(ml): make 'does learning help?' a number CI prints, not a claim

### DIFF
--- a/.github/workflows/learning-gate.yml
+++ b/.github/workflows/learning-gate.yml
@@ -1,0 +1,92 @@
+name: Learning Gate
+
+# Measures the FULL three-layer cascade against rules-only on the committed v3
+# set, and checks it against backend/data/evaluation/baseline_cascade_v3.json.
+#
+# READ THIS BEFORE FIXING A RED RUN
+# ---------------------------------
+# On a GitHub-hosted runner this workflow FAILS, on purpose, with
+# "no SetFit checkpoint found" and the directory it searched. That is not a
+# broken build: SetFit checkpoints are trained on disk under the app's data
+# directory, are excluded by .gitignore, and none ships in this repository, so
+# a hosted runner has nothing to load. The failure is the finding.
+#
+# The alternative was worse and is what this repository keeps catching itself
+# doing: run `--mode hybrid` anyway, watch it degrade to the rules layer,
+# score 0.9791, print PASS, and report the regex engine as the cascade. The
+# harness refuses to do that (see _assert_layers_exercised), and so does this.
+#
+# It is therefore NOT scheduled. A weekly red build is a build people mute.
+# Dispatch it from a runner that has a checkpoint -- pass `checkpoint_path`, or
+# use a self-hosted runner whose app data directory holds one. Making it green
+# on hosted CI needs the checkpoint published as a downloadable artifact, which
+# is a decision about distributing a model trained on real mail, not a CI chore.
+#
+# The gate that DOES run on every backend change is in backend-ci.yml, and it
+# measures the deterministic path only. That is the gap this workflow names.
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkpoint_path:
+        description: "SetFit checkpoint directory on the runner (blank = newest in the app models dir)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: learning-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cascade:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install -r requirements-dev.txt
+
+      - name: Report which learned artifacts this runner has
+        # Printed before the gate runs so a failure is legible at a glance, and
+        # so a PASS carries evidence next to it rather than being taken on faith.
+        working-directory: backend
+        env:
+          JOBTRACKER_ENVIRONMENT: test
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+        run: |
+          python -c "
+          from jobtracker.classifier.setfit_model import get_latest_model_path, get_models_dir
+          models_dir = get_models_dir()
+          latest = get_latest_model_path()
+          print(f'setfit models dir: {models_dir}')
+          print(f'newest checkpoint: {latest}')
+          print(f'contents: {sorted(p.name for p in models_dir.iterdir())}')
+          "
+
+      - name: Run cascade gate (rules vs full cascade on v3)
+        env:
+          JOBTRACKER_ENVIRONMENT: test
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+          JOBTRACKER_SETFIT_CHECKPOINT: ${{ inputs.checkpoint_path }}
+        run: scripts/cascade_gate.sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-516%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-523%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -303,7 +303,7 @@ Versions are pinned from `apps/web/package.json`, `requirements.txt`, and the CI
 | --- | --- |
 | **macOS app** | SwiftUI, Xcode project target macOS 26.2, local FastAPI sidecar, packaged `.app` |
 | **Hosting** | Vercel (Next.js + one Python function, `maxDuration` 60), Supabase Postgres, Hugging Face Spaces |
-| **CI** | GitHub Actions — 10 workflows (see [Verify it](#verify-it)) |
+| **CI** | GitHub Actions — 11 workflows (see [Verify it](#verify-it)) |
 
 ---
 
@@ -316,6 +316,8 @@ The **rules layer** — 201 regex patterns and no model — scores **0.9791 macr
 The trap is that `baseline_hybrid_v3.json` reports 0.9791 too. It does so because it was regenerated under the evaluator's `deterministic` hybrid profile, which calls `set_lite_mode(True)` and blanks `_known_embeddings` — so it measures the deterministic path, which is the regexes. Every metric block in the two files is identical, including both mismatch records; only the `meta` block differs, by `mode`, `hybrid_profile` and timestamp. `benchmark_history.md` says this in its own header. CI runs that profile on purpose, because a gate that consults a stochastic model is a gate that goes red for reasons unrelated to the change under test.
 
 Being fair to the model: on the **v2** set the cascade beat the rules — 0.9843 against 0.9686 macro-F1 (`docs/ML_EXECUTION_TRACKER.md`, Cycle B5). The learned layers are not decoration; they lost on v3.
+
+That comparison is now a measurement rather than a citation. `scripts/cascade_gate.sh` scores the full cascade and the rules layer over the same set in one run, and commits the delta, the per-example exchange and the checkpoint that produced it to `backend/data/evaluation/baseline_cascade_v3.json`. It does **not** run in CI, and the reason is not an omission: no SetFit checkpoint ships in this repository, so a GitHub-hosted runner has nothing to load. `learning-gate.yml` is therefore `workflow_dispatch`, and on a hosted runner it fails naming the directory it searched rather than degrading to the rules layer and reporting that as the cascade. What the number gates — the margin a learned layer has to clear before it may touch real mail, and what puts it back — is [`docs/ML_PROMOTION_POLICY.md`](docs/ML_PROMOTION_POLICY.md).
 
 What the v3 set is, exactly, from `classifier_eval_v3_spec.json` and the dataset itself: **96 examples, 12 per label across 8 labels**, grouped as 65 core-positive, 17 edge-noise, 8 historical-miss and 6 core-negative, with confusion-pair tagging. The rows carry `subject`, `body_text`, `label`, `sender_email`, `scenario_group` and `confusion_pair` — and **no provenance field**, so the dataset does not record how many examples came from a real inbox versus a generator. That is a real limit on how far 0.9791 generalizes, and 96 examples is a small sample under any reading.
 
@@ -373,13 +375,13 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**516 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 467 `test_*` functions across 32 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 516 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**523 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 474 `test_*` functions across 32 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 523 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
 Those tests drive the production machinery, not a fixture: `jobtracker.database.connection.get_session` with its real GUC and `search_path` handling, against a non-`BYPASSRLS` role, asserting that a raw query with the application-level `WHERE user_id = ...` filter *removed* still returns nothing for another tenant.
 
-**Coverage**, from the same run: **57.66%** overall — 9,194 statements, 3,893 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.7%**; `auth` 80.5%; `database` 77.2%. What pulls the average down is `jobtracker/scripts` at 2,240 statements and 33.7%, of which eight modules no test imports account for 1,006 statements at 0%.
+**Coverage**, from the same run: **57.36%** overall — 9,308 statements, 3,969 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.7%**; `auth` 80.5%; `database` 77.2%. What pulls the average down is `jobtracker/scripts` at 2,354 statements and 33.6%, of which eight modules no test imports account for 1,006 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -545,7 +547,7 @@ applied/
 ├── api/index.py             # Vercel Python entry → jobtracker.main_cloud
 ├── requirements.txt         # the CLOUD dependency set; deliberately not backend/requirements.txt
 ├── docs/                    # architecture, API spec, ML strategy + runbooks, RLS audit
-└── .github/workflows/       # 10 workflows
+└── .github/workflows/       # 11 workflows
 ```
 
 ---
@@ -582,6 +584,7 @@ Every number above terminates in something you can open.
 - `classifier_eval_v3.jsonl` and `classifier_eval_v3_spec.json` — the 96 examples and the coverage contract they must satisfy
 - `baseline_rules_v3.json` — where 0.9791 lives, with the confusion matrix and both mismatches
 - `baseline_hybrid_v3.json` — the deterministic-profile file that reads the same, which is the trap this README exists to defuse
+- `baseline_cascade_v3.json` — the cascade with its models actually answering, with the checkpoint that produced it, the layer that answered each mismatch, and the delta to rules
 - `benchmark_history.{md,jsonl}` — every baseline, v1 through v3, with its profile
 - `ml_monitoring_report.{md,json}`, `ml_monitoring_history.jsonl`, `label_balance_report.md`
 - `ml/browser/artifacts/model_quantized.onnx` — 22,843,695 bytes; check it with `stat`
@@ -602,6 +605,7 @@ Every number above terminates in something you can open.
 | [`docs/API_SPEC.md`](docs/API_SPEC.md) | Backend REST + WebSocket contract |
 | [`docs/ML_STRATEGY.md`](docs/ML_STRATEGY.md) | Classifier behaviour, training lifecycle, metadata contract |
 | [`docs/ML_EXECUTION_TRACKER.md`](docs/ML_EXECUTION_TRACKER.md) | Every ML cycle with its measured results — the source for the cascade's 0.9583 |
+| [`docs/ML_PROMOTION_POLICY.md`](docs/ML_PROMOTION_POLICY.md) | What a learned layer must beat before it serves real mail, and what puts it back |
 | [`docs/ML_WEEKLY_OPERATIONS.md`](docs/ML_WEEKLY_OPERATIONS.md) · [`docs/ML_MONITORING_RUNBOOK.md`](docs/ML_MONITORING_RUNBOOK.md) | Weekly SOP and monitoring triage |
 | [`docs/RLS-AUDIT-2026-08-03.md`](docs/RLS-AUDIT-2026-08-03.md) | Live row-level-security audit |
 | [`docs/SETUP.md`](docs/SETUP.md) | Local setup and day-to-day development |

--- a/backend/data/evaluation/baseline_cascade_v3.json
+++ b/backend/data/evaluation/baseline_cascade_v3.json
@@ -1,0 +1,294 @@
+{
+  "artifacts": {
+    "embeddings": {
+      "example_count": 0,
+      "loaded": true,
+      "model": "intfloat/e5-small-v2"
+    },
+    "setfit": {
+      "base_model": "sentence-transformers/paraphrase-MiniLM-L6-v2",
+      "checkpoint": "setfit_model_20260306_175404",
+      "loaded": true,
+      "source_counts": {
+        "external_dataset": 50,
+        "mock_seed": 4,
+        "mock_seed_v2": 42,
+        "mock_seed_v3": 57,
+        "user_correction": 39
+      },
+      "total_examples": 192,
+      "trained_at": "2026-03-06T22:54:04.334060"
+    }
+  },
+  "comparison": {
+    "broken_vs_reference": [
+      {
+        "expected": "applied",
+        "method": "setfit",
+        "predicted": "pending_application",
+        "subject": "Submission confirmed for Product Analytics role"
+      },
+      {
+        "expected": "applied",
+        "method": "setfit",
+        "predicted": "pending_application",
+        "subject": "Receipt: application for Site Reliability Engineer"
+      },
+      {
+        "expected": "other",
+        "method": "setfit",
+        "predicted": "interview",
+        "subject": "Interview prep webinar this Thursday"
+      }
+    ],
+    "delta": {
+      "accuracy": -0.02083333333333326,
+      "macro_f1": -0.020960905036991884,
+      "misclassified": 2,
+      "weighted_f1": -0.020960905036991995
+    },
+    "fixed_vs_reference": [
+      {
+        "expected": "follow_up",
+        "method": "rules",
+        "predicted": "assessment",
+        "subject": "Follow-up after completing assessment"
+      }
+    ],
+    "promotable": false,
+    "promotion_margin": 0.005,
+    "reference_layers": {
+      "rules": 96
+    },
+    "reference_mode": "rules",
+    "reference_overall": {
+      "accuracy": 0.9791666666666666,
+      "macro_f1": 0.9791304347826086,
+      "misclassified": 2,
+      "weighted_f1": 0.9791304347826086
+    },
+    "verdict": "behind_rules"
+  },
+  "confusion_matrix": {
+    "applied": {
+      "applied": 10,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 0,
+      "offer": 0,
+      "other": 0,
+      "pending_application": 2,
+      "rejection": 0
+    },
+    "assessment": {
+      "applied": 0,
+      "assessment": 12,
+      "follow_up": 0,
+      "interview": 0,
+      "offer": 0,
+      "other": 0,
+      "pending_application": 0,
+      "rejection": 0
+    },
+    "follow_up": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 12,
+      "interview": 0,
+      "offer": 0,
+      "other": 0,
+      "pending_application": 0,
+      "rejection": 0
+    },
+    "interview": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 12,
+      "offer": 0,
+      "other": 0,
+      "pending_application": 0,
+      "rejection": 0
+    },
+    "offer": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 0,
+      "offer": 12,
+      "other": 0,
+      "pending_application": 0,
+      "rejection": 0
+    },
+    "other": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 1,
+      "offer": 0,
+      "other": 11,
+      "pending_application": 0,
+      "rejection": 0
+    },
+    "pending_application": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 0,
+      "offer": 0,
+      "other": 0,
+      "pending_application": 12,
+      "rejection": 0
+    },
+    "rejection": {
+      "applied": 0,
+      "assessment": 0,
+      "follow_up": 0,
+      "interview": 0,
+      "offer": 0,
+      "other": 1,
+      "pending_application": 0,
+      "rejection": 11
+    }
+  },
+  "label_distribution": {
+    "applied": 12,
+    "assessment": 12,
+    "follow_up": 12,
+    "interview": 12,
+    "offer": 12,
+    "other": 12,
+    "pending_application": 12,
+    "rejection": 12
+  },
+  "layers": {
+    "content_filter": 5,
+    "fallback": 13,
+    "rules": 58,
+    "setfit": 20
+  },
+  "meta": {
+    "dataset": "data/evaluation/classifier_eval_v3.jsonl",
+    "dataset_sha256": "0aa053536573cd733293fa6a054076a5f78b5c01ebc559e7f912f629fd6adf7e",
+    "generated_at": "2026-08-11T23:56:44.090309+00:00",
+    "hybrid_profile": "full",
+    "mode": "hybrid",
+    "sample_count": 96
+  },
+  "mismatches": [
+    {
+      "expected": "applied",
+      "method": "setfit",
+      "predicted": "pending_application",
+      "subject": "Submission confirmed for Product Analytics role"
+    },
+    {
+      "expected": "applied",
+      "method": "setfit",
+      "predicted": "pending_application",
+      "subject": "Receipt: application for Site Reliability Engineer"
+    },
+    {
+      "expected": "rejection",
+      "method": "fallback",
+      "predicted": "other",
+      "subject": "Thank you for interviewing with us"
+    },
+    {
+      "expected": "other",
+      "method": "setfit",
+      "predicted": "interview",
+      "subject": "Interview prep webinar this Thursday"
+    }
+  ],
+  "overall": {
+    "accuracy": 0.9583333333333334,
+    "macro_f1": 0.9581695297456168,
+    "misclassified": 4,
+    "weighted_f1": 0.9581695297456166
+  },
+  "per_label": {
+    "applied": {
+      "f1": 0.9090909090909091,
+      "fn": 2,
+      "fp": 0,
+      "precision": 1.0,
+      "recall": 0.8333333333333334,
+      "support": 12,
+      "tp": 10
+    },
+    "assessment": {
+      "f1": 1.0,
+      "fn": 0,
+      "fp": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 12,
+      "tp": 12
+    },
+    "follow_up": {
+      "f1": 1.0,
+      "fn": 0,
+      "fp": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 12,
+      "tp": 12
+    },
+    "interview": {
+      "f1": 0.9600000000000001,
+      "fn": 0,
+      "fp": 1,
+      "precision": 0.9230769230769231,
+      "recall": 1.0,
+      "support": 12,
+      "tp": 12
+    },
+    "offer": {
+      "f1": 1.0,
+      "fn": 0,
+      "fp": 0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 12,
+      "tp": 12
+    },
+    "other": {
+      "f1": 0.9166666666666666,
+      "fn": 1,
+      "fp": 1,
+      "precision": 0.9166666666666666,
+      "recall": 0.9166666666666666,
+      "support": 12,
+      "tp": 11
+    },
+    "pending_application": {
+      "f1": 0.923076923076923,
+      "fn": 0,
+      "fp": 2,
+      "precision": 0.8571428571428571,
+      "recall": 1.0,
+      "support": 12,
+      "tp": 12
+    },
+    "rejection": {
+      "f1": 0.9565217391304348,
+      "fn": 1,
+      "fp": 0,
+      "precision": 1.0,
+      "recall": 0.9166666666666666,
+      "support": 12,
+      "tp": 11
+    }
+  },
+  "prediction_distribution": {
+    "applied": 10,
+    "assessment": 12,
+    "follow_up": 12,
+    "interview": 13,
+    "offer": 12,
+    "other": 12,
+    "pending_application": 14,
+    "rejection": 11
+  }
+}

--- a/backend/data/evaluation/benchmark_history.jsonl
+++ b/backend/data/evaluation/benchmark_history.jsonl
@@ -1,3 +1,4 @@
+{"accuracy": 0.9583333333333334, "dataset": "data/evaluation/classifier_eval_v3.jsonl", "macro_f1": 0.9581695297456168, "misclassified": 4, "mode": "cascade", "profile": "full", "version": 3, "weighted_f1": 0.9581695297456166}
 {"accuracy": 1.0, "dataset": "data/evaluation/classifier_eval_v1.jsonl", "macro_f1": 1.0, "misclassified": 0, "mode": "hybrid", "profile": "n/a", "version": 1, "weighted_f1": 1.0}
 {"accuracy": 0.84375, "dataset": "data/evaluation/classifier_eval_v2.jsonl", "macro_f1": 0.8597619047619047, "misclassified": 10, "mode": "hybrid", "profile": "n/a", "version": 2, "weighted_f1": 0.8597619047619047}
 {"accuracy": 0.9791666666666666, "dataset": "data/evaluation/classifier_eval_v3.jsonl", "macro_f1": 0.9791304347826086, "misclassified": 2, "mode": "hybrid", "profile": "deterministic", "version": 3, "weighted_f1": 0.9791304347826086}

--- a/backend/data/evaluation/benchmark_history.md
+++ b/backend/data/evaluation/benchmark_history.md
@@ -7,8 +7,15 @@ Auto-generated from `baseline_*_v*.json` files.
 machine-stable CI gating, so a `deterministic` hybrid row measures the
 deterministic path -- which is why it matches the `rules` row exactly.
 
+A `cascade` row is the same classifier with the learned layers switched on
+and a SetFit checkpoint loaded, recorded by `scripts/cascade_gate.sh`. Its
+gap to the `rules` row of the same version is the only measurement of what
+the learned layers are worth. It is not produced by CI: no checkpoint ships
+in this repository, so a GitHub-hosted runner has nothing to load.
+
 | mode | version | profile | dataset | accuracy | macro_f1 | weighted_f1 | misclassified |
 |------|---------|---------|---------|----------|----------|-------------|---------------|
+| cascade | v3 | full | `data/evaluation/classifier_eval_v3.jsonl` | 0.9583 | 0.9582 | 0.9582 | 4 |
 | hybrid | v1 | n/a | `data/evaluation/classifier_eval_v1.jsonl` | 1.0000 | 1.0000 | 1.0000 | 0 |
 | hybrid | v2 | n/a | `data/evaluation/classifier_eval_v2.jsonl` | 0.8438 | 0.8598 | 0.8598 | 10 |
 | hybrid | v3 | deterministic | `data/evaluation/classifier_eval_v3.jsonl` | 0.9792 | 0.9791 | 0.9791 | 2 |

--- a/backend/jobtracker/scripts/build_benchmark_history.py
+++ b/backend/jobtracker/scripts/build_benchmark_history.py
@@ -10,7 +10,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-BASELINE_RE = re.compile(r"^baseline_(rules|hybrid)_v(\d+)\.json$")
+# `cascade` is `--mode hybrid --hybrid-profile full` with the learned layers
+# actually answering -- recorded by scripts/cascade_gate.sh, which refuses to
+# write a baseline in which they did not. It is listed as its own mode rather
+# than folded into `hybrid` because the reader's question is "does the ML help?"
+# and the answer is the gap between this row and the `rules` row of the same
+# version. Without the row, the table's only hybrid v3 entry is the
+# deterministic one, which is the regexes wearing the cascade's name.
+BASELINE_RE = re.compile(r"^baseline_(rules|hybrid|cascade)_v(\d+)\.json$")
 
 
 @dataclass
@@ -103,6 +110,12 @@ def write_markdown(rows: list[BenchmarkRow], out_path: Path) -> None:
         "`deterministic` disables SetFit and blanks the embedding examples for",
         "machine-stable CI gating, so a `deterministic` hybrid row measures the",
         "deterministic path -- which is why it matches the `rules` row exactly.",
+        "",
+        "A `cascade` row is the same classifier with the learned layers switched on",
+        "and a SetFit checkpoint loaded, recorded by `scripts/cascade_gate.sh`. Its",
+        "gap to the `rules` row of the same version is the only measurement of what",
+        "the learned layers are worth. It is not produced by CI: no checkpoint ships",
+        "in this repository, so a GitHub-hosted runner has nothing to load.",
         "",
         "| mode | version | profile | dataset | accuracy | macro_f1 | weighted_f1 | misclassified |",
         "|------|---------|---------|---------|----------|----------|-------------|---------------|",

--- a/backend/jobtracker/scripts/evaluate_classifier.py
+++ b/backend/jobtracker/scripts/evaluate_classifier.py
@@ -3,12 +3,20 @@
 
 This harness produces per-class precision/recall/F1, overall metrics,
 and optional non-regression checks against a saved baseline report.
+
+``--compare-rules`` additionally scores the rules-only classifier over the same
+examples in the same invocation and prints the delta, which is the only
+measurement of whether the learned layers earn their place; every report also
+records the artifacts that answered (``artifacts``) and the SHA-256 of the
+corpus, so a verdict can be traced to the checkpoint and dataset that produced
+it. See ``docs/ML_PROMOTION_POLICY.md``.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 from collections import Counter
 from dataclasses import dataclass
@@ -33,6 +41,15 @@ DEFAULT_BASELINES = {
 # loading, and "rules"/"fallback", which are the deterministic path itself.
 # Kept in sync with the ``method=`` values in classifier/hybrid.py.
 SEMANTIC_LAYERS = frozenset({"embeddings", "setfit"})
+
+# How far ahead of rules-only the cascade must be on the committed set before a
+# learned layer may serve real mail. Stated here, in the harness that measures
+# it, so ``docs/ML_PROMOTION_POLICY.md`` cites executing code rather than an
+# intention. It is a *reporting* threshold: --compare-rules prints the verdict
+# and records it in the report, and no run fails merely for being behind.
+# Today the cascade is behind rules by ~0.021 macro-F1, so nothing is
+# promotable and the honest thing is to say so in the artifact.
+PROMOTION_MARGIN = 0.005
 
 VALID_LABELS = {category.value for category in EmailCategory}
 DEFAULT_LABEL_ORDER = [
@@ -61,6 +78,10 @@ class ExampleOutcome:
     expected: str
     predicted: str
     subject: str
+    # Which layer produced the wrong answer. Aggregate tallies say a model ran;
+    # this says whether the model is what got it wrong, which is the difference
+    # between "the cascade is behind" and "the cascade is behind because of X".
+    method: str | None = None
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -76,6 +97,14 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     with path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, sort_keys=True)
         f.write("\n")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _string_or_empty(value: Any) -> str:
@@ -131,11 +160,13 @@ async def predict_labels(
     mode: str,
     *,
     hybrid_profile: str,
-) -> tuple[list[str], dict[str, int]]:
+) -> tuple[list[str], list[str], HybridClassifier | None]:
     """
     Run classifier predictions for all examples.
 
-    Returns the predicted labels *and* a tally of which layer produced each one.
+    Returns the predicted labels, the layer that produced each one, and (for
+    hybrid runs) the classifier instance itself, so the caller can record which
+    artifacts answered — see ``_collect_artifact_provenance``.
 
     The tally is not diagnostics. ``HybridClassifier`` degrades on purpose when a
     semantic layer will not load — the API must keep answering when the SetFit
@@ -148,15 +179,17 @@ async def predict_labels(
     it fatal.
     """
     predictions: list[str] = []
-    methods: Counter[str] = Counter()
+    methods: list[str] = []
 
     if mode == "rules":
-        classifier = get_rules_classifier()
+        rules_classifier = get_rules_classifier()
         for item in examples:
-            result = classifier.classify(item.subject, item.body_text, item.sender_email)
-            predictions.append(result.category.value)
-            methods["rules"] += 1
-        return predictions, dict(methods)
+            rules_result = rules_classifier.classify(
+                item.subject, item.body_text, item.sender_email
+            )
+            predictions.append(rules_result.category.value)
+            methods.append("rules")
+        return predictions, methods, None
 
     if mode == "hybrid":
         classifier = HybridClassifier()
@@ -164,10 +197,71 @@ async def predict_labels(
         for item in examples:
             result = await classifier.classify(item.subject, item.body_text, item.sender_email)
             predictions.append(result.category.value)
-            methods[getattr(result, "method", None) or "unknown"] += 1
-        return predictions, dict(methods)
+            methods.append(getattr(result, "method", None) or "unknown")
+        return predictions, methods, classifier
 
     raise ValueError(f"Unsupported mode: {mode}")
+
+
+def _collect_artifact_provenance(classifier: HybridClassifier | None) -> dict[str, Any]:
+    """
+    Record *which* learned artifacts answered, not just that some layer did.
+
+    A macro-F1 without this is untraceable: SetFit checkpoints are trained on
+    disk, are never committed, and rotate (``MAX_SAVED_MODELS = 3``), so a
+    cascade score six weeks old cannot otherwise be attributed to the model that
+    produced it, and a bad retrain cannot be pointed at. Everything here is read
+    off instances that already exist — nothing is loaded to fill this block, so
+    a run that never touched a model records it as absent rather than loading
+    one to find out.
+    """
+    provenance: dict[str, Any] = {}
+    if classifier is None:
+        return provenance
+
+    embeddings = getattr(classifier, "_embeddings_instance", None)
+    if embeddings is not None:
+        embedding_model = getattr(embeddings, "_model", None)
+        provenance["embeddings"] = {
+            "model": getattr(type(embedding_model), "MODEL_NAME", None),
+            "loaded": getattr(embedding_model, "_model", None) is not None,
+            # The store the similarity layer searches. Zero means the layer was
+            # present and had nothing to compare against, which is a different
+            # fact from the model failing to load.
+            "example_count": len(getattr(embeddings, "_known_embeddings", []) or []),
+        }
+
+    setfit = getattr(classifier, "_setfit_instance", None)
+    if setfit is not None:
+        from jobtracker.classifier.setfit_model import get_latest_model_path, get_models_dir
+
+        checkpoint = get_latest_model_path()
+        entry: dict[str, Any] = {
+            "loaded": getattr(setfit, "_model", None) is not None,
+            "checkpoint": checkpoint.name if checkpoint is not None else None,
+        }
+        if checkpoint is None:
+            # Only recorded when there is nothing to record instead: the search
+            # path is what makes an absent checkpoint diagnosable, and it is a
+            # machine-specific path that would otherwise churn the committed
+            # baseline on every re-record.
+            entry["models_dir"] = str(get_models_dir())
+        if checkpoint is not None:
+            metadata_path = checkpoint / "training_metadata.json"
+            if metadata_path.exists():
+                try:
+                    metadata = _read_json(metadata_path)
+                except (OSError, ValueError):
+                    metadata = {}
+                # A deliberate subset: what identifies the artifact and what it
+                # was trained on. The full metadata (per-label source counts)
+                # stays next to the checkpoint.
+                for key in ("base_model", "trained_at", "total_examples", "source_counts"):
+                    if key in metadata:
+                        entry[key] = metadata[key]
+        provenance["setfit"] = entry
+
+    return provenance
 
 
 def _assert_layers_exercised(
@@ -204,8 +298,27 @@ def _assert_layers_exercised(
         "rules classifier and would report it as hybrid. Known causes: setfit or "
         "sentence-transformers failed to import (check the warnings above), "
         "JOBTRACKER_LITE_MODE is set, or deployment=cloud forces lite mode. "
+        f"{_missing_artifact_hint(report)}"
         "Re-run with --allow-degraded-layers if a rules-only measurement is what you want."
     ]
+
+
+def _missing_artifact_hint(report: dict[str, Any]) -> str:
+    """
+    Name the artifact that is absent, with the path that was searched.
+
+    On a GitHub-hosted runner the cause is always the same and is not a bug:
+    SetFit checkpoints live under the app's data directory and are not in the
+    repository, so there is nothing to load. Saying which directory was empty
+    turns that from a puzzling red build into the documented blocker it is.
+    """
+    setfit = (report.get("artifacts") or {}).get("setfit") or {}
+    if not setfit:
+        return ""
+    checkpoint = setfit.get("checkpoint")
+    if checkpoint is None:
+        return f"No SetFit checkpoint was found in {setfit.get('models_dir')}. "
+    return f"A SetFit checkpoint is on disk ({checkpoint}) but did not answer. "
 
 
 def _configure_hybrid_profile(classifier: HybridClassifier, profile: str) -> None:
@@ -259,6 +372,7 @@ def compute_report(
     examples: list[EvaluationExample],
     dataset_path: Path,
     mode: str,
+    methods: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build aggregate metrics and confusion matrix."""
     if len(expected) != len(predicted):
@@ -315,9 +429,12 @@ def compute_report(
     for actual, pred in zip(expected, predicted, strict=True):
         confusion_matrix[actual][pred] += 1
 
+    layer_of: list[str | None] = list(methods) if methods is not None else [None] * total
     mismatches = [
-        ExampleOutcome(expected=exp, predicted=pred, subject=item.subject)
-        for item, exp, pred in zip(examples, expected, predicted, strict=True)
+        ExampleOutcome(expected=exp, predicted=pred, subject=item.subject, method=method)
+        for item, exp, pred, method in zip(
+            examples, expected, predicted, layer_of, strict=True
+        )
         if exp != pred
     ]
 
@@ -346,6 +463,7 @@ def compute_report(
                 "expected": item.expected,
                 "predicted": item.predicted,
                 "subject": item.subject,
+                **({"method": item.method} if item.method is not None else {}),
             }
             for item in mismatches
         ],
@@ -373,6 +491,38 @@ def compare_against_baseline(
             f"was generated with '{baseline_profile}'. These measure different classifiers "
             "and their scores are not comparable. Point --baseline at a file recorded "
             "under the same profile, or regenerate with --update-baseline."
+        )
+        return failures
+
+    # The same idea one level deeper. A `full` run whose SetFit checkpoint is
+    # missing still passes the profile check and still answers every example --
+    # from rules -- so against a baseline that *did* have the model it reports
+    # the model's absence as a quality regression. The layer guard above catches
+    # the case where NO semantic layer answered; this catches the case where one
+    # answered and the other, which the baseline was recorded with, did not.
+    baseline_layers = baseline.get("layers") or {}
+    current_layers = report.get("layers") or {}
+    absent = [
+        layer
+        for layer in sorted(SEMANTIC_LAYERS)
+        if baseline_layers.get(layer, 0) > 0 and current_layers.get(layer, 0) == 0
+    ]
+    if absent:
+        recorded_checkpoint = ((baseline.get("artifacts") or {}).get("setfit") or {}).get(
+            "checkpoint"
+        )
+        detail = (
+            f" The baseline was recorded with checkpoint {recorded_checkpoint}."
+            if "setfit" in absent and recorded_checkpoint
+            else ""
+        )
+        failures.append(
+            f"learned layer mismatch: the baseline was recorded with "
+            f"{', '.join(absent)} answering, and here "
+            f"{'it' if len(absent) == 1 else 'they'} answered nothing.{detail} "
+            "This run measures a smaller classifier than the baseline does, so the "
+            "score difference is the missing artifact and not a quality change. "
+            "Supply the artifact, or compare against a baseline recorded without it."
         )
         return failures
 
@@ -442,6 +592,26 @@ def print_summary(report: dict[str, Any], max_mismatches: int) -> None:
         # whether the score came from the classifier named in `mode`.
         answered = ", ".join(f"{name}={count}" for name, count in sorted(layers.items()))
         print(f"answered by: {answered}")
+    artifacts = report.get("artifacts") or {}
+    if artifacts:
+        # The other half of "which classifier was this": the layer tally says a
+        # model answered, this says *which* model, in the run log where a reader
+        # of a green build will see it.
+        embeddings = artifacts.get("embeddings") or {}
+        if embeddings:
+            print(
+                f"embeddings: model={embeddings.get('model')} "
+                f"loaded={embeddings.get('loaded')} "
+                f"examples={embeddings.get('example_count')}"
+            )
+        setfit = artifacts.get("setfit") or {}
+        if setfit:
+            print(
+                f"setfit: checkpoint={setfit.get('checkpoint')} "
+                f"loaded={setfit.get('loaded')} "
+                f"base={setfit.get('base_model')} "
+                f"trained_on={setfit.get('total_examples')} examples"
+            )
     print(
         f"accuracy: {overall['accuracy']:.4f} | macro_f1: {overall['macro_f1']:.4f} | "
         f"weighted_f1: {overall['weighted_f1']:.4f} | misclassified: {overall['misclassified']}"
@@ -466,7 +636,145 @@ def print_summary(report: dict[str, Any], max_mismatches: int) -> None:
             predicted = item.get("predicted", "")
             subject = str(item.get("subject", ""))
             preview = subject if len(subject) <= 90 else subject[:87] + "..."
-            print(f"- expected={expected:<20} predicted={predicted:<20} subject={preview}")
+            answered_by = f" by={item['method']}" if item.get("method") else ""
+            print(
+                f"- expected={expected:<20} predicted={predicted:<20}"
+                f"{answered_by} subject={preview}"
+            )
+
+
+def build_comparison(
+    report: dict[str, Any],
+    reference: dict[str, Any],
+    *,
+    promotion_margin: float,
+) -> dict[str, Any]:
+    """
+    Score this run against the rules-only run of the same dataset.
+
+    The question "do the learned layers help?" has been answered in prose for
+    months and measured by nothing: CI runs rules, and hybrid under the
+    `deterministic` profile that switches the learned layers off, which is why
+    both committed baselines read the same 0.9791. A delta computed here, in the
+    same invocation and over the same examples, is the smallest thing that makes
+    the answer a number rather than a claim.
+
+    ``promotable`` is deliberately not a pass/fail. Being behind rules is the
+    status quo, and a gate that failed for it would be red on day one and
+    deleted by week two; what matters is that the number is printed, pinned in
+    the committed baseline, and cannot move without showing up in a diff.
+    """
+    current_overall = report.get("overall", {})
+    reference_overall = reference.get("overall", {})
+
+    delta = {
+        metric: float(current_overall.get(metric, 0.0)) - float(reference_overall.get(metric, 0.0))
+        for metric in ("accuracy", "macro_f1", "weighted_f1")
+    }
+    delta["misclassified"] = int(current_overall.get("misclassified", 0)) - int(
+        reference_overall.get("misclassified", 0)
+    )
+
+    macro_delta = delta["macro_f1"]
+    if macro_delta > 0:
+        verdict = "ahead_of_rules"
+    elif macro_delta < 0:
+        verdict = "behind_rules"
+    else:
+        verdict = "level_with_rules"
+
+    # Which examples changed hands. A macro-F1 delta says the learned layers cost
+    # two examples; this says which two, and which layer answered them -- the
+    # difference between a number to argue about and a defect to work on.
+    reference_mismatches = {
+        str(item.get("subject", "")): item
+        for item in reference.get("mismatches", [])
+        if isinstance(item, dict)
+    }
+    current_mismatches = {
+        str(item.get("subject", "")): item
+        for item in report.get("mismatches", [])
+        if isinstance(item, dict)
+    }
+    fixed = [
+        reference_mismatches[subject]
+        for subject in reference_mismatches
+        if subject not in current_mismatches
+    ]
+    broken = [
+        current_mismatches[subject]
+        for subject in current_mismatches
+        if subject not in reference_mismatches
+    ]
+
+    return {
+        "reference_mode": reference.get("meta", {}).get("mode", "rules"),
+        "reference_overall": reference_overall,
+        "reference_layers": reference.get("layers", {}),
+        "fixed_vs_reference": fixed,
+        "broken_vs_reference": broken,
+        "delta": delta,
+        "verdict": verdict,
+        "promotion_margin": promotion_margin,
+        # The single bit the promotion policy turns on. False today, and the day
+        # it flips the committed baseline diff dates the event.
+        "promotable": macro_delta >= promotion_margin,
+    }
+
+
+def print_comparison(report: dict[str, Any]) -> None:
+    """Print the rules-vs-this-run table."""
+    comparison = report.get("comparison")
+    if not comparison:
+        return
+
+    meta = report.get("meta", {})
+    this_run = meta.get("mode", "current")
+    if meta.get("hybrid_profile"):
+        this_run = f"{this_run}/{meta['hybrid_profile']}"
+    reference_mode = comparison.get("reference_mode", "rules")
+
+    current_overall = report.get("overall", {})
+    reference_overall = comparison.get("reference_overall", {})
+    delta = comparison.get("delta", {})
+
+    print(f"\n=== {reference_mode} vs {this_run} ===")
+    print(f"{'metric':<16}{reference_mode:>12}{this_run:>16}{'delta':>12}")
+    for metric in ("accuracy", "macro_f1", "weighted_f1"):
+        print(
+            f"{metric:<16}{float(reference_overall.get(metric, 0.0)):>12.4f}"
+            f"{float(current_overall.get(metric, 0.0)):>16.4f}"
+            f"{float(delta.get(metric, 0.0)):>+12.4f}"
+        )
+    print(
+        f"{'misclassified':<16}{int(reference_overall.get('misclassified', 0)):>12}"
+        f"{int(current_overall.get('misclassified', 0)):>16}"
+        f"{int(delta.get('misclassified', 0)):>+12}"
+    )
+
+    # In both lists `by=` names the layer that produced the WRONG answer, in
+    # whichever of the two runs got it wrong.
+    for heading, key in (
+        (f"fixed vs {reference_mode} (wrong there, right here)", "fixed_vs_reference"),
+        (f"broken vs {reference_mode} (right there, wrong here)", "broken_vs_reference"),
+    ):
+        items = comparison.get(key) or []
+        print(f"\n{heading}: {len(items)}")
+        for item in items:
+            answered_by = f" by={item['method']}" if item.get("method") else ""
+            print(
+                f"- expected={item.get('expected', ''):<20} "
+                f"predicted={item.get('predicted', ''):<20}{answered_by} "
+                f"subject={item.get('subject', '')}"
+            )
+
+    margin = float(comparison.get("promotion_margin", PROMOTION_MARGIN))
+    macro_delta = float(delta.get("macro_f1", 0.0))
+    print(
+        f"verdict: {comparison.get('verdict')} "
+        f"({macro_delta:+.4f} macro-F1; promotion needs >= {margin:+.4f}) -> "
+        f"promotable={comparison.get('promotable')}"
+    )
 
 
 async def run_evaluation(
@@ -474,22 +782,51 @@ async def run_evaluation(
     mode: str,
     *,
     hybrid_profile: str,
+    compare_rules: bool = False,
+    promotion_margin: float = PROMOTION_MARGIN,
 ) -> dict[str, Any]:
     await init_db()
     examples = load_dataset(dataset)
     expected = [item.label for item in examples]
-    predicted, layers = await predict_labels(
+    predicted, methods, classifier = await predict_labels(
         examples,
         mode=mode,
         hybrid_profile=hybrid_profile,
     )
-    report = compute_report(expected, predicted, examples, dataset_path=dataset, mode=mode)
+    report = compute_report(
+        expected, predicted, examples, dataset_path=dataset, mode=mode, methods=methods
+    )
     # Which layer answered, and how often. Recorded in the report so the artifact
     # itself says whether the ML path ran, rather than leaving that to be inferred
     # from a score that rules alone can reproduce.
-    report["layers"] = layers
+    report["layers"] = dict(Counter(methods))
+    # Which artifacts answered, so the score can be traced back to them later.
+    report["artifacts"] = _collect_artifact_provenance(classifier)
+    # The corpus, by content rather than by filename: a baseline is only a
+    # baseline for the dataset it was measured on, and datasets get edited.
+    report["meta"]["dataset_sha256"] = _sha256(dataset)
     if mode == "hybrid":
         report["meta"]["hybrid_profile"] = hybrid_profile
+
+    if compare_rules:
+        reference_predicted, reference_methods, _ = await predict_labels(
+            examples,
+            mode="rules",
+            hybrid_profile="full",
+        )
+        reference = compute_report(
+            expected,
+            reference_predicted,
+            examples,
+            dataset_path=dataset,
+            mode="rules",
+            methods=reference_methods,
+        )
+        reference["layers"] = dict(Counter(reference_methods))
+        report["comparison"] = build_comparison(
+            report, reference, promotion_margin=promotion_margin
+        )
+
     return report
 
 
@@ -540,6 +877,24 @@ def parse_args() -> argparse.Namespace:
             "classifier and reports it as hybrid."
         ),
     )
+    parser.add_argument(
+        "--compare-rules",
+        action="store_true",
+        help=(
+            "Also run the rules classifier over the same dataset and report the "
+            "delta. This is the only measurement of whether the learned layers "
+            "help; it never fails the run on its own."
+        ),
+    )
+    parser.add_argument(
+        "--promotion-margin",
+        type=float,
+        default=PROMOTION_MARGIN,
+        help=(
+            "Macro-F1 margin over rules-only required before a learned layer is "
+            "promotable (see docs/ML_PROMOTION_POLICY.md). Reported, not enforced."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -554,11 +909,14 @@ def main() -> int:
             args.dataset,
             args.mode,
             hybrid_profile=args.hybrid_profile,
+            compare_rules=args.compare_rules,
+            promotion_margin=args.promotion_margin,
         )
     )
     baseline_path = args.baseline or DEFAULT_BASELINES[args.mode]
 
     print_summary(report, max_mismatches=args.max_mismatches)
+    print_comparison(report)
 
     if args.output is not None:
         _write_json(args.output, report)

--- a/backend/tests/test_evaluate_classifier.py
+++ b/backend/tests/test_evaluate_classifier.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 
 from jobtracker.scripts.evaluate_classifier import (
+    PROMOTION_MARGIN,
     _configure_hybrid_profile,
+    build_comparison,
     compare_against_baseline,
     compute_report,
     load_dataset,
@@ -48,6 +50,106 @@ def test_compute_report_generates_expected_metrics() -> None:
     assert report["per_label"]["applied"]["recall"] == 0.5
     assert report["per_label"]["other"]["precision"] == 2 / 3
     assert report["overall"]["misclassified"] == 1
+
+
+def test_compute_report_records_which_layer_answered_each_mismatch() -> None:
+    """A wrong answer is only actionable once you know which layer produced it."""
+    dataset = Path(__file__).resolve().parents[1] / "data" / "evaluation" / "classifier_eval_v1.jsonl"
+    examples = load_dataset(dataset)[:3]
+    expected = ["applied", "applied", "other"]
+    predicted = ["applied", "other", "other"]
+
+    report = compute_report(
+        expected,
+        predicted,
+        examples,
+        dataset_path=Path("dummy.jsonl"),
+        mode="hybrid",
+        methods=["rules", "setfit", "content_filter"],
+    )
+
+    assert [item["method"] for item in report["mismatches"]] == ["setfit"]
+
+
+def test_compute_report_omits_the_layer_when_it_was_not_recorded() -> None:
+    dataset = Path(__file__).resolve().parents[1] / "data" / "evaluation" / "classifier_eval_v1.jsonl"
+    examples = load_dataset(dataset)[:2]
+
+    report = compute_report(
+        ["applied", "other"],
+        ["other", "other"],
+        examples,
+        dataset_path=Path("dummy.jsonl"),
+        mode="rules",
+    )
+
+    assert "method" not in report["mismatches"][0]
+
+
+def _overall(macro_f1: float, misclassified: int) -> dict:
+    return {
+        "accuracy": macro_f1,
+        "macro_f1": macro_f1,
+        "weighted_f1": macro_f1,
+        "misclassified": misclassified,
+    }
+
+
+def test_build_comparison_measures_the_gap_to_rules() -> None:
+    """
+    The committed shape: the cascade loses to the rules layer on v3, and the
+    report has to say so in a field rather than in a paragraph somewhere else.
+    """
+    cascade = {
+        "meta": {"mode": "hybrid", "hybrid_profile": "full"},
+        "overall": _overall(0.9582, 4),
+        "mismatches": [
+            {"subject": "Receipt: application", "expected": "applied", "predicted": "pending_application", "method": "setfit"},
+            {"subject": "Thank you for interviewing", "expected": "rejection", "predicted": "other", "method": "fallback"},
+        ],
+    }
+    rules = {
+        "meta": {"mode": "rules"},
+        "overall": _overall(0.9791, 2),
+        "mismatches": [
+            {"subject": "Follow-up after assessment", "expected": "follow_up", "predicted": "assessment", "method": "rules"},
+            {"subject": "Thank you for interviewing", "expected": "rejection", "predicted": "other", "method": "rules"},
+        ],
+    }
+
+    comparison = build_comparison(cascade, rules, promotion_margin=PROMOTION_MARGIN)
+
+    assert comparison["verdict"] == "behind_rules"
+    assert comparison["promotable"] is False
+    assert comparison["delta"]["macro_f1"] < 0
+    assert comparison["delta"]["misclassified"] == 2
+    # Which examples changed hands, not just how many.
+    assert [item["subject"] for item in comparison["fixed_vs_reference"]] == [
+        "Follow-up after assessment"
+    ]
+    assert [item["subject"] for item in comparison["broken_vs_reference"]] == [
+        "Receipt: application"
+    ]
+    assert comparison["broken_vs_reference"][0]["method"] == "setfit"
+
+
+def test_build_comparison_requires_the_margin_not_merely_a_win() -> None:
+    rules = {"meta": {"mode": "rules"}, "overall": _overall(0.9791, 2), "mismatches": []}
+
+    narrow = build_comparison(
+        {"meta": {"mode": "hybrid"}, "overall": _overall(0.9821, 2), "mismatches": []},
+        rules,
+        promotion_margin=0.005,
+    )
+    clear = build_comparison(
+        {"meta": {"mode": "hybrid"}, "overall": _overall(0.9851, 1), "mismatches": []},
+        rules,
+        promotion_margin=0.005,
+    )
+
+    assert narrow["verdict"] == "ahead_of_rules"
+    assert narrow["promotable"] is False, "ahead by less than the margin is not promotable"
+    assert clear["promotable"] is True
 
 
 def test_compare_against_baseline_flags_f1_regression() -> None:

--- a/backend/tests/test_evaluate_classifier_layer_guard.py
+++ b/backend/tests/test_evaluate_classifier_layer_guard.py
@@ -123,6 +123,74 @@ def test_full_run_is_not_compared_against_a_deterministic_baseline() -> None:
     assert len(failures) == 1, "the mismatch must short-circuit, not add to metric noise"
 
 
+def test_layer_guard_names_the_directory_it_searched() -> None:
+    """
+    On a hosted runner the cause is always "no checkpoint ships in the repo".
+    Saying which directory was empty is what keeps that from reading as a bug.
+    """
+    report = _report({"content_filter": 5, "fallback": 33, "rules": 58})
+    report["artifacts"] = {"setfit": {"checkpoint": None, "models_dir": "/runner/models/setfit"}}
+
+    failures = _assert_layers_exercised(report, mode="hybrid", hybrid_profile="full")
+
+    assert failures
+    assert "/runner/models/setfit" in failures[0]
+
+
+def test_baseline_recorded_with_setfit_is_not_compared_to_a_run_without_it() -> None:
+    """
+    The cascade baseline was recorded with a checkpoint loaded. Run the same
+    command where no checkpoint exists and every prediction comes from rules --
+    which scores HIGHER on this dataset. Compared naively that is a pass, and it
+    would pin the rules number under the cascade's name.
+    """
+    current = {
+        "meta": {"mode": "hybrid", "hybrid_profile": "full"},
+        "overall": {"accuracy": 0.9792, "macro_f1": 0.9791, "weighted_f1": 0.9791},
+        "per_label": {},
+        "layers": {"rules": 58, "fallback": 33, "content_filter": 5},
+    }
+    baseline = {
+        "meta": {"mode": "hybrid", "hybrid_profile": "full"},
+        "overall": {"accuracy": 0.9583, "macro_f1": 0.9582, "weighted_f1": 0.9582},
+        "per_label": {},
+        "layers": {"rules": 58, "setfit": 20, "fallback": 13, "content_filter": 5},
+        "artifacts": {"setfit": {"checkpoint": "setfit_model_20260306_175404"}},
+    }
+
+    failures = compare_against_baseline(current, baseline, tolerance=0.0)
+
+    assert failures, "a run without the baseline's model is not comparable to it"
+    assert "learned layer mismatch" in failures[0]
+    assert "setfit" in failures[0]
+    assert "setfit_model_20260306_175404" in failures[0]
+    assert len(failures) == 1, "the mismatch must short-circuit, not add to metric noise"
+
+
+def test_legacy_baselines_without_a_layer_tally_still_compare() -> None:
+    """
+    Every baseline committed before the tally existed stores ``layers: null``.
+    Those must keep comparing on metrics rather than failing as unattributable.
+    """
+    current = {
+        "meta": {"mode": "rules"},
+        "overall": {"accuracy": 0.90, "macro_f1": 0.89, "weighted_f1": 0.90},
+        "per_label": {},
+        "layers": {"rules": 96},
+    }
+    baseline = {
+        "meta": {"mode": "rules"},
+        "overall": {"accuracy": 0.95, "macro_f1": 0.94, "weighted_f1": 0.95},
+        "per_label": {},
+        "layers": None,
+    }
+
+    failures = compare_against_baseline(current, baseline, tolerance=0.0)
+
+    assert not any("learned layer mismatch" in f for f in failures)
+    assert any("overall.macro_f1" in f for f in failures)
+
+
 def test_matching_profiles_still_compare_metrics() -> None:
     same = {"meta": {"mode": "hybrid", "hybrid_profile": "deterministic"}}
     current = {

--- a/docs/ML_EXECUTION_TRACKER.md
+++ b/docs/ML_EXECUTION_TRACKER.md
@@ -646,3 +646,65 @@ Verification:
   - `pytest -q tests/test_ml_monitoring_report.py tests/test_prepare_ml_monitoring_alert_issue.py` -> `9 passed`
 - full backend suite:
   - `pytest -q` -> `150 passed`
+
+---
+
+## Cycle N (August 11, 2026): Cascade Measurement Gate + Promotion Policy - Completed
+
+Goal:
+- Make the learned layers measurable instead of asserted. Until now neither CI gate
+  touched them (`--mode rules`, and `--mode hybrid --hybrid-profile deterministic`,
+  which disables SetFit), so "does learning help?" had no executing check behind it.
+
+### Step N1 - Cascade evaluation + provenance in the harness (`completed`)
+
+Implemented in `jobtracker/scripts/evaluate_classifier.py`:
+- `--compare-rules`: scores the rules classifier over the same examples in the same
+  invocation and reports the delta, the per-example exchange
+  (`comparison.fixed_vs_reference` / `broken_vs_reference`) and a promotion verdict
+  against `PROMOTION_MARGIN = 0.005`.
+- every report now records `artifacts` (SetFit checkpoint directory, base model,
+  `trained_at`, training-example and per-source counts; embedding model, whether it
+  loaded, and the store size), the dataset SHA-256, and the layer that answered each
+  mismatch.
+- `compare_against_baseline` refuses a run whose learned layer is absent where the
+  baseline had it answering. Without that, a checkpoint-less run scores 0.9791 --
+  higher than the cascade -- and passes as a cascade non-regression.
+
+### Step N2 - Cascade baseline + gate (`completed`)
+
+Artifacts:
+- `backend/data/evaluation/baseline_cascade_v3.json` (new, `--hybrid-profile full`)
+- `scripts/cascade_gate.sh` - runs the cascade where a checkpoint exists, against a
+  scratch data directory holding only a link to it, so the score is a function of the
+  checkpoint and not of anybody's mail
+- `.github/workflows/learning-gate.yml` - `workflow_dispatch`; on a GitHub-hosted
+  runner it fails naming the searched directory, because no checkpoint ships here
+- `benchmark_history.{md,jsonl}` now carry a `cascade` row
+
+Measured on `classifier_eval_v3.jsonl` (96 examples), checkpoint
+`setfit_model_20260306_175404`, empty embedding store:
+- rules-only reference run: `accuracy=0.9792`, `macro_f1=0.9791`, `misclassified=2`
+- cascade (full profile): `accuracy=0.9583`, `macro_f1=0.9582`, `misclassified=4`
+- delta: `macro_f1=-0.0210`, verdict `behind_rules`, `promotable=false`
+- layers: `rules=58`, `setfit=20`, `fallback=13`, `content_filter=5`, `embeddings=0`
+- exchange: SetFit fixed 1 (`follow_up` read as `assessment` by the rules layer) and
+  broke 3 (two `applied` -> `pending_application`, one `other` -> `interview`)
+
+Note on the fourth decimal: Cycle H records `macro_f1=0.9583` for this configuration.
+The measured value is `0.9581695...` (0.9582 at four decimals); `0.9583` is the
+accuracy. Cycle H stands as the record of what was run in March -- `README.md` and
+`scripts/readme_facts.py` both pin it -- and `baseline_cascade_v3.json` is the
+definition site from here.
+
+Reproducibility check: the Cycle-H-era checkpoint `setfit_model_20260228_131948`
+produces identical metrics and identical mismatches, differing only in how many
+examples SetFit answered (22 vs 20). The cascade number is attributable to the
+checkpoint alone.
+
+### Step N3 - Promotion rule (`completed`)
+
+- `docs/ML_PROMOTION_POLICY.md`: the margin a learned layer must clear before it may
+  serve real mail, that promotion is its own reviewed commit rather than a side
+  effect of a retrain, the rollback triggers, and the provenance still missing (code
+  revision, a content hash of the weights, which training rows produced a checkpoint).

--- a/docs/ML_PROMOTION_POLICY.md
+++ b/docs/ML_PROMOTION_POLICY.md
@@ -1,0 +1,186 @@
+# ML Promotion Policy
+
+When a learned layer is allowed to classify real user mail, what it has to beat
+first, and what puts it back.
+
+This exists because "the app learns from your corrections" is currently a
+description of a *training* path, not of a serving one, and because the two
+gates in `backend-ci.yml` measure neither. Both committed baselines read 0.9791
+because both runs are the deterministic path: `--mode rules`, and `--mode hybrid
+--hybrid-profile deterministic`, which calls `set_lite_mode(True)` and blanks the
+embedding store. Nothing in CI has ever scored a model.
+
+## Status today — 2026-08-11
+
+Measured on the committed 96-example v3 set
+(`backend/data/evaluation/classifier_eval_v3.jsonl`,
+SHA-256 `0aa053536573cd733293fa6a054076a5f78b5c01ebc559e7f912f629fd6adf7e`) by
+`scripts/cascade_gate.sh`:
+
+| configuration | macro-F1 | accuracy | misclassified |
+| --- | --- | --- | --- |
+| rules only | 0.9791 | 0.9792 | 2 |
+| full cascade, checkpoint `setfit_model_20260306_175404` | 0.9582 | 0.9583 | 4 |
+
+Delta: **−0.0210 macro-F1**. The learned layers make it worse. Verdict recorded
+in `backend/data/evaluation/baseline_cascade_v3.json` as
+`comparison.verdict = behind_rules`, `promotable = false`.
+
+Which layers answered, from the same run: `rules=58`, `setfit=20`,
+`fallback=13`, `content_filter=5` — and `embeddings=0`, because the gate runs
+against an empty embedding store on purpose (see "Why the store is empty"
+below).
+
+The delta is not diffuse. SetFit answered 20 of the 96 and the exchange is
+one-for-three, recorded per example in `comparison.fixed_vs_reference` and
+`comparison.broken_vs_reference`:
+
+- **Fixed** — one the rules layer got wrong: *Follow-up after completing
+  assessment*, `follow_up` misread as `assessment`.
+- **Broken** — three the rules layer got right, all three answered by SetFit:
+  *Submission confirmed for Product Analytics role* and *Receipt: application
+  for Site Reliability Engineer*, both `applied` pulled to
+  `pending_application`; and *Interview prep webinar this Thursday*, an `other`
+  pulled to `interview`.
+- **Shared** — *Thank you for interviewing with us*, `rejection` read as
+  `other`, missed by both and answered by the fallback path.
+
+So the learned layer is not uniformly worse; it is worse on the
+`applied` / `pending_application` boundary and on promotional mail that reads
+like an interview. That is a training-data shape, and it is where a retrain
+would have to show improvement.
+
+Two notes on that table, so neither reads as a correction later:
+
+- The cascade number is reproducible from the checkpoint alone. Both checkpoints
+  on this machine — `setfit_model_20260228_131948`, contemporary with Cycle H,
+  and `setfit_model_20260306_175404` — produce the identical metrics and the
+  identical four mismatches, differing only in how many examples SetFit chose to
+  answer (22 vs 20).
+- `docs/ML_EXECUTION_TRACKER.md` Cycle H records this configuration as
+  `macro_f1=0.9583`. The measured value is 0.9581695…, which is 0.9582 at four
+  decimals; 0.9583 is the accuracy. Cycle H is the historical record of what was
+  run in March and is left exactly as it stands — `README.md` and
+  `scripts/readme_facts.py` both pin it. From here the number to compare against
+  is the one in `baseline_cascade_v3.json`, which was produced by a run whose
+  artifacts are named in the file.
+
+## The rule
+
+A learned layer may serve real user mail only when **all** of these hold.
+
+1. **It beats rules-only by a stated margin.** At least `PROMOTION_MARGIN`
+   (0.005 macro-F1, defined in
+   `backend/jobtracker/scripts/evaluate_classifier.py`) on the committed
+   evaluation set, measured by `scripts/cascade_gate.sh` with the exact
+   checkpoint that would be deployed. Not the newest checkpoint, not a
+   re-training of it: that directory.
+2. **The measurement shows the learned layers answering.** `layers.setfit > 0`
+   or `layers.embeddings > 0` in the report. A cascade run that degraded to the
+   rules layer scores 0.9791 and passes every other check, which is the exact
+   failure this repository has shipped before; `_assert_layers_exercised`
+   refuses it, and `--allow-degraded-layers` must not appear in a promotion run.
+3. **Promotion is its own commit.** Retraining writes a checkpoint. It does not
+   change what serves, and must not: the serving path is selected by
+   `settings.lite_mode` and by the `deployment == "cloud"` rules-only
+   short-circuit in `jobtracker/classifier/hybrid.py`. Changing either is a
+   reviewed change that names the checkpoint, links the gate run, and quotes the
+   delta. A retrain that flipped the serving path as a side effect would promote
+   a model nobody measured.
+4. **The baseline moves with it.** Re-record
+   `backend/data/evaluation/baseline_cascade_v3.json` in the same change
+   (`scripts/cascade_gate.sh --update-baseline`) and rebuild
+   `benchmark_history.{md,jsonl}`. The recorded `artifacts` block — checkpoint
+   directory, base model, `trained_at`, training-example count and source
+   counts — is what makes the new number attributable.
+5. **The sample size is stated, not implied.** 96 examples, 12 per label. A
+   0.005 margin on 96 examples is roughly half of one example; a promotion note
+   that does not say so is overselling the measurement. Prefer a margin the
+   evaluation set can actually support, and grow the set before tightening it.
+6. **Nothing is promoted on a set it was trained on.** The v3 corpus is an
+   evaluation set. If a future retrain draws from it, the promotion measurement
+   moves to a corpus that retrain did not see.
+
+## What puts it back
+
+Roll back to the rules-only serving path when any of these is observed:
+
+- The cascade gate goes red against the committed baseline at `--tolerance
+  0.001`, on overall metrics or on any per-label F1. Either the checkpoint
+  drifted or the classifier around it changed; both mean the deployed
+  configuration is no longer the measured one.
+- Macro-F1 falls below the 0.95 floor `backend-ci.yml` enforces for the rules
+  gate. That floor is the product's stated minimum and does not become optional
+  because a model is in the path.
+- A per-label collapse that the macro average hides — most plausibly
+  `applied` / `pending_application`, which is where SetFit already loses
+  examples, or the `assessment` / `follow_up` pair that
+  `ml-monitoring-weekly.yml` watches.
+- The weekly monitoring report raises a low-confidence-growth or
+  distribution-drift alert that coincides with a promotion.
+- User corrections rise after a promotion: corrections are the product's own
+  signal that the classifier got worse, and they are already recorded per user
+  in `training_data`.
+
+Rolling back is reverting the promotion commit — the serving path returns to
+rules-only, which is what production runs today anyway. The previous checkpoint
+is still on disk (`MAX_SAVED_MODELS = 3`), so restoring a known-good model is
+pointing at that directory, not a retrain. **Never** re-record the baseline to
+make a red gate green; the baseline moves only when a better classifier is
+deliberately promoted.
+
+## Why the store is empty
+
+`scripts/cascade_gate.sh` points the run at a scratch data directory holding
+nothing but a link to the checkpoint, so the embedding store starts empty. That
+is deliberate twice:
+
+- The real store is built from *this user's* mail. A baseline recorded against
+  it would be neither reproducible by anyone else nor publishable.
+- With the store empty, the score is a function of the checkpoint alone, which
+  is what makes "which artifact produced this verdict" answerable.
+
+The consequence is stated rather than hidden: this gate does not measure what
+the embedding layer contributes on a populated store. That is a genuine gap, and
+closing it needs a shareable, non-personal example store — not a baseline
+recorded against private data.
+
+## Where this can run
+
+| Where | What it measures |
+| --- | --- |
+| `backend-ci.yml`, every backend change | rules, and hybrid under `deterministic`. No learned layer, by design — a gate that consults a stochastic model goes red for reasons unrelated to the change under test |
+| `learning-gate.yml`, `workflow_dispatch` | the full cascade. On a GitHub-hosted runner it **fails**, naming the directory it searched: no checkpoint ships in this repository |
+| `scripts/cascade_gate.sh`, locally | the full cascade, where the checkpoint actually is |
+
+That hosted-CI failure is the honest state of things, not an oversight. Making
+it green means publishing a checkpoint the workflow can download, which is a
+decision about distributing a model trained partly on real mail (39 of the 192
+training examples in the current checkpoint are user corrections) — not a CI
+chore.
+
+## Provenance a verdict needs
+
+Recorded today in every report and baseline:
+
+- the checkpoint directory name, its base model, `trained_at`, its
+  training-example count and per-source counts;
+- the embedding model name, whether it loaded, and how many examples the store
+  held;
+- the layer tally — which layer answered each example;
+- the dataset path and its SHA-256, so a re-labelled corpus cannot silently
+  change the meaning of a number;
+- the rules-only comparison, its delta and the promotion verdict.
+
+Still missing, and worth adding before any retrain is automated:
+
+- **The code revision.** A report does not record the git SHA of the classifier
+  it measured, so a score cannot be attributed to a rules change versus a model
+  change.
+- **A content hash of the checkpoint weights.** The directory name is a
+  timestamp, and timestamps can collide across machines or be restored from a
+  copy; a hash would identify the artifact itself.
+- **Which training rows produced the checkpoint.** `training_metadata.json`
+  records counts by source, not row identities, so a bad retrain cannot be
+  traced to the examples that caused it. Row identities are user mail; whatever
+  is recorded has to be an identifier, not the text.

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 516,
+      "value": 523,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,15 +12,15 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 57.66,
+      "value": 57.36,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 9194,
+      "value": 9308,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3893,
+      "value": 3969,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
@@ -36,11 +36,11 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScriptsStatements": {
-      "value": 2240,
+      "value": 2354,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScripts": {
-      "value": 33.7,
+      "value": 33.6,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "scriptsZeroModules": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 516,
+    "passed": 523,
     "failed": 0,
     "skipped": 0,
     "errors": 0,

--- a/scripts/cascade_gate.sh
+++ b/scripts/cascade_gate.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Measure the FULL three-layer cascade against rules-only on the committed v3
+# set, and check it against the committed cascade baseline.
+#
+# Why this is a script and not two more steps in backend-ci.yml
+# -------------------------------------------------------------
+# CI's two classifier gates run `--mode rules` and `--mode hybrid
+# --hybrid-profile deterministic`, and `deterministic` switches SetFit off and
+# blanks the embedding store. That is correct for a fast, machine-stable gate --
+# and it means neither gate has ever measured a learned layer. Both committed
+# baselines read the same 0.9791 for exactly that reason.
+#
+# The cascade needs a SetFit checkpoint. Checkpoints are trained on disk, live
+# under the app's data directory, are not in the repository (see .gitignore),
+# and rotate after three. So this runs where the checkpoint is -- a developer
+# machine, or any runner that has one -- and fails with the searched path when
+# it is not there. It never degrades to a rules-only measurement and calls it a
+# cascade; the harness's own layer guard forbids that.
+#
+# Reproducibility: the run is pointed at a scratch data directory holding
+# nothing but a link to the checkpoint. The embedding store is therefore empty,
+# which is deliberate twice over -- the real store is per-user mail, so a
+# baseline recorded against it would be neither shareable nor reproducible, and
+# an empty store makes the number a function of the checkpoint alone.
+#
+# Usage:
+#   scripts/cascade_gate.sh [--checkpoint PATH] [--update-baseline]
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+
+# $PYTHON wins when set, so a runner (or a git worktree without its own venv)
+# can name the interpreter that has the ML dependencies installed.
+if [ -n "${PYTHON:-}" ]; then
+  :
+elif [ -f "$BACKEND_DIR/.venv311/bin/python" ]; then
+  PYTHON="$BACKEND_DIR/.venv311/bin/python"
+elif [ -f "$BACKEND_DIR/.venv/bin/python" ]; then
+  PYTHON="$BACKEND_DIR/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+CHECKPOINT="${JOBTRACKER_SETFIT_CHECKPOINT:-}"
+UPDATE_BASELINE=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --checkpoint)
+      CHECKPOINT="$2"
+      shift 2
+      ;;
+    --update-baseline)
+      UPDATE_BASELINE=true
+      shift
+      ;;
+    --help|-h)
+      cat <<USAGE
+Usage: scripts/cascade_gate.sh [--checkpoint PATH] [--update-baseline]
+
+Options:
+  --checkpoint PATH   SetFit checkpoint directory to evaluate. Defaults to the
+                      newest one under the app's models directory, or
+                      \$JOBTRACKER_SETFIT_CHECKPOINT.
+  --update-baseline   Rewrite backend/data/evaluation/baseline_cascade_v3.json
+                      from this run. Promoting a new checkpoint is a decision;
+                      see docs/ML_PROMOTION_POLICY.md before using it.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "[cascade-gate] unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$BACKEND_DIR"
+
+# Where the app keeps checkpoints, asked of the app's own configuration rather
+# than hardcoded, so this does not drift from get_models_dir().
+MODELS_DIR="$("$PYTHON" -c 'from jobtracker.classifier.setfit_model import get_models_dir; print(get_models_dir())')"
+
+if [ -z "$CHECKPOINT" ]; then
+  # Newest by name, which is how get_latest_model_path() picks: the directory
+  # names are timestamps.
+  CHECKPOINT="$(/bin/ls -d "$MODELS_DIR"/*/ 2>/dev/null | /usr/bin/sort -r | /usr/bin/head -1 || true)"
+  CHECKPOINT="${CHECKPOINT%/}"
+fi
+
+if [ -z "$CHECKPOINT" ] || [ ! -d "$CHECKPOINT" ]; then
+  cat >&2 <<MISSING
+[cascade-gate] FAIL: no SetFit checkpoint found.
+
+Searched: $MODELS_DIR
+
+The cascade cannot be measured without one, and measuring rules-only and
+calling it the cascade is the failure this gate exists to prevent. On a
+GitHub-hosted runner this is the expected outcome and is not a bug: no
+checkpoint ships in the repository. Run this on a machine that has trained one,
+or pass --checkpoint PATH.
+MISSING
+  exit 1
+fi
+
+SCRATCH_DIR="$(/usr/bin/mktemp -d)"
+trap '/bin/rm -r "$SCRATCH_DIR"' EXIT
+/bin/mkdir -p "$SCRATCH_DIR/models/setfit"
+/bin/ln -s "$CHECKPOINT" "$SCRATCH_DIR/models/setfit/$(/usr/bin/basename "$CHECKPOINT")"
+
+echo "[cascade-gate] Python: $PYTHON"
+echo "[cascade-gate] checkpoint: $CHECKPOINT"
+echo "[cascade-gate] scratch data dir: $SCRATCH_DIR"
+
+EXTRA_ARGS=()
+if [ "$UPDATE_BASELINE" = true ]; then
+  EXTRA_ARGS+=(--update-baseline)
+else
+  EXTRA_ARGS+=(--tolerance 0.001)
+fi
+
+JOBTRACKER_DATABASE_DIR="$SCRATCH_DIR" \
+JOBTRACKER_ENVIRONMENT=test \
+PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring \
+TOKENIZERS_PARALLELISM=false \
+  "$PYTHON" -m jobtracker.scripts.evaluate_classifier \
+    --mode hybrid \
+    --hybrid-profile full \
+    --compare-rules \
+    --dataset data/evaluation/classifier_eval_v3.jsonl \
+    --baseline data/evaluation/baseline_cascade_v3.json \
+    "${EXTRA_ARGS[@]}"

--- a/scripts/generate_eval_baselines.sh
+++ b/scripts/generate_eval_baselines.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Generate and update evaluation baselines for a versioned dataset.
 #
+# This covers two of the three committed baselines: rules, and hybrid under the
+# `deterministic` profile that CI gates on. The third -- baseline_cascade_v3.json,
+# the cascade with its learned layers actually answering -- is written by
+# `scripts/cascade_gate.sh --update-baseline`, because it needs a SetFit
+# checkpoint and a data directory isolated from anyone's mail. Passing
+# `--hybrid-profile full` here does NOT produce it: it would overwrite the
+# deterministic baseline that backend-ci.yml compares against, and the evaluator
+# then refuses the comparison as a profile mismatch.
+#
 # Examples:
 #   scripts/generate_eval_baselines.sh --version 3
 #   scripts/generate_eval_baselines.sh --version 3 --skip-hybrid


### PR DESCRIPTION
Before Applied can honestly "train itself and get better", the question has to be measurable. Today it is not: `backend-ci.yml` runs `--mode rules` and `--mode hybrid --hybrid-profile deterministic`, and the deterministic profile disables SetFit — which is why both committed baselines read an identical **0.9791**. The cascade's real score lived only in a doc.

**Measured now, with attribution:**

```
answered by: content_filter=5, fallback=13, rules=58, setfit=20
rules 0.9791 / 2 misclassified   cascade 0.9582 / 4   delta -0.0210 → behind_rules, promotable=False
fixed vs rules:  1 (a follow_up the rules misread as assessment)
broken vs rules: 3 — all by=setfit (2× applied→pending_application, 1× other→interview)
```

That last pair is the point. The cascade is not vaguely worse — SetFit breaks three specific examples and fixes one, and the report now names them and the layer that answered. That is a research programme instead of a shrug.

**The load-bearing guard is not the gate, it's the comparability check.** A cascade run with no checkpoint present scores **0.9791** — *higher* than the real cascade, because it silently degrades to rules. Without a guard that refuses to compare a run where SetFit answered nothing against a baseline where it did, that run passes as a cascade non-regression and pins the rules number under the cascade's name. Exactly the defect shape this repo keeps finding, and it would have been invisible.

Also added: per-report `artifacts` provenance (checkpoint dir, base model, `trained_at`, training counts by source, embedding model and store size), the dataset SHA-256, the answering layer per mismatch, `baseline_cascade_v3.json` as the definition site, and `docs/ML_PROMOTION_POLICY.md` — margin, rollback triggers, and "promotion is its own reviewed commit, never a side effect of a retrain". Runs via `scripts/cascade_gate.sh` and a `workflow_dispatch` workflow.

**Two things it found that the brief did not anticipate:**

1. **The cascade's score is attributable to the checkpoint alone.** The Cycle-H-era checkpoint reproduces identical metrics and identical mismatches; embeddings contributed nothing in either run.
2. **Cycle H's recorded `macro_f1 = 0.9583` is actually the accuracy.** True macro-F1 is 0.9582. Deliberately **not** "fixed" — `readme_facts` pins it and it is the March record; the discrepancy is documented and `baseline_cascade_v3.json` is the definition site from here.

Verified: backend suite 516 → 523, 0 skipped. Gate re-run against the committed baseline passes; the no-checkpoint path exits 1 naming the directory it searched. **No GitHub Actions run has executed this yet** — the failure path was proven locally only.