### PR TITLE
fix(shell): stop the rail printing the same address twice

### DIFF
--- a/apps/web/components/shell/RailFooter.tsx
+++ b/apps/web/components/shell/RailFooter.tsx
@@ -94,7 +94,11 @@ function ConnectionLine({ gmail, userEmail }: { gmail: RailGmailData; userEmail:
         />
         <span className="min-w-0 flex-1">
           <span className="block truncate text-[11px] text-dim">Gmail not connected</span>
-          <span className="block truncate text-[11px] text-dim transition-colors group-hover:text-muted">
+          {/* `muted`, not `dim`, and brighter than the state above it: this is
+              the only actionable thing in the not-connected state, and `dim` is
+              the ramp's FLOOR for text this size (Lc 60.7, see globals.css) —
+              the call to action must not be the quietest thing in the block. */}
+          <span className="block truncate text-[11px] text-muted transition-colors group-hover:text-strong">
             connect in settings <span aria-hidden="true">→</span>
           </span>
         </span>

--- a/apps/web/components/shell/RailFooter.tsx
+++ b/apps/web/components/shell/RailFooter.tsx
@@ -4,33 +4,57 @@ import { LastSynced } from "@/components/gmail/LastSynced";
 import type { RailGmailData } from "@/lib/shell/rail";
 
 /**
- * The sidebar's anchored footer: the Gmail connection chip and, at the very
- * bottom, the user chip.
+ * The sidebar's anchored footer: ONE identity block — who is signed in, and,
+ * hanging off it, whether Gmail is connected and when it last built the board.
  *
- * Connection chip — three honest states:
- *   - connected     → live emerald dot (`.beta-dot` ping), the account email,
- *                     when the board was last built. Links to the dashboard,
- *                     where sync now lives.
- *   - not connected → a quiet chip that links to Settings, where connecting
+ * Why one block
+ * -------------
+ * This was two stacked chips, and for very nearly every user they printed the
+ * SAME address twice, eight pixels apart: you sign in to Applied with the
+ * Google account you then connect. "Gmail · connected / aesh…@gmail.com" over
+ * "aesh…@gmail.com / SIGNED IN" does not read as two facts, it reads as a bug.
+ *
+ * So the address is printed ONCE, in the identity row, and the connection is a
+ * subordinate line beneath it. The order flipped with it — identity used to sit
+ * under the chip; it is now the anchor, because the account is the thing and
+ * the connection is something the account *has*. Identity still lives
+ * bottom-left (the Linear/Notion convention) and sign-out still lives in the
+ * top bar.
+ *
+ * When the two accounts genuinely DIFFER — signed in as one, Gmail connected as
+ * another — the connection line names its own address ("connected as
+ * billing@corp.com") and both are on screen. Which means the *absence* of a
+ * second address is what asserts the two are the same mailbox. That is a quiet
+ * read, and it is the deliberate trade: the alternative is printing the
+ * identical string twice, which is the defect this collapse exists to remove.
+ *
+ * Connection line — the same three honest states as before:
+ *   - connected     → live emerald dot (`.beta-dot` ping), the state, and when
+ *                     the board was last built. Links to the dashboard, where
+ *                     sync now lives.
+ *   - not connected → a quiet line that links to Settings, where connecting
  *                     actually lives.
- *   - unknown       → chip omitted entirely (a failed status probe is not a
+ *   - unknown       → line omitted entirely (a failed status probe is not a
  *                     disconnection; never show a guessed state).
  *
- * The re-sync icon button is GONE — it was the fourth sync trigger, an
+ * The re-sync icon button is still GONE — it was the fourth sync trigger, an
  * unlabelled icon that did something different from the identically-iconed
  * header button. The rail keeps what a rail is for: glanceable truth. Sync is
- * one click away (chip → dashboard → `Sync`), and this component is now a
+ * one click away (line → dashboard → `Sync`), and this component remains a
  * server component — no fetch, no state, just what it was handed.
  *
- * "Last synced" lives here because the connection state already does, and it
- * is the answer to the question that drove the repeated manual re-syncs:
- * *did this thing ever run?* Whether the last sync SUCCEEDED and when are two
- * different facts: the backend leaves `last_sync_at` at the last good run when
- * one fails, so both render rather than one overwriting the other.
+ * "Last synced" survived the collapse because it is the answer to the question
+ * that drove the repeated manual re-syncs: *did this thing ever run?* Whether
+ * the last sync SUCCEEDED and when are two different facts — the backend leaves
+ * `last_sync_at` at the last good run when one fails — so both still render,
+ * one under the other, rather than one overwriting the other.
  *
- * User chip — identity lives bottom-left (the Linear/Notion convention): a
- * monogram tile plus the truncated email, linking to Settings. Sign-out stays
- * in the top bar.
+ * Type: the sync label is no longer `font-mono`. "last synced 3 minutes ago" is
+ * a sentence, and globals.css is explicit that a sentence in mono is a defect;
+ * mono is for machine values. The machine value is still there for anything
+ * that wants it — `LastSynced` puts the absolute UTC instant in `title` and
+ * `dateTime`. (`.label-caps`, dropped here for other reasons, was never mono:
+ * it is Atkinson, the product's structural voice.)
  */
 
 type FooterProps = {
@@ -38,17 +62,39 @@ type FooterProps = {
   userEmail: string | null;
 };
 
-function GmailChip({ gmail }: { gmail: RailGmailData }) {
+/**
+ * Is the connected mailbox a *different* account from the signed-in one, and
+ * therefore worth naming? Compared case-insensitively: Google echoes the
+ * address in whatever case it was typed, and `Aesh@gmail.com` is not a second
+ * account. Returns `null` when there is nothing extra to say — either the
+ * addresses match, or the status probe carried no address at all, and inventing
+ * a second account on screen is exactly what this component must not do.
+ */
+function distinctMailbox(gmailEmail: string | null, userEmail: string | null): string | null {
+  if (!gmailEmail) return null;
+  if (!userEmail) return gmailEmail;
+  return gmailEmail.trim().toLowerCase() === userEmail.trim().toLowerCase() ? null : gmailEmail;
+}
+
+/** Shared with the identity row so the two rows behave as one control strip. */
+const ROW =
+  "group flex rounded-md px-2 py-1.5 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules";
+
+function ConnectionLine({ gmail, userEmail }: { gmail: RailGmailData; userEmail: string | null }) {
   if (!gmail.connected) {
     return (
       <Link
         href="/settings"
-        className="group flex items-center gap-2.5 rounded-lg border border-line-soft px-2.5 py-2 transition-colors hover:border-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+        aria-label="Gmail is not connected — connect it in settings"
+        className={`${ROW} items-start gap-2`}
       >
-        <span aria-hidden="true" className="h-[0.45rem] w-[0.45rem] shrink-0 rounded-full bg-line-strong" />
-        <span className="min-w-0">
-          <span className="label-caps block">gmail · not connected</span>
-          <span className="block truncate text-xs text-muted transition-colors group-hover:text-strong">
+        <span
+          aria-hidden="true"
+          className="mt-[0.3rem] h-[0.45rem] w-[0.45rem] shrink-0 rounded-full bg-line-strong"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[11px] text-dim">Gmail not connected</span>
+          <span className="block truncate text-[11px] text-dim transition-colors group-hover:text-muted">
             connect in settings <span aria-hidden="true">→</span>
           </span>
         </span>
@@ -56,21 +102,42 @@ function GmailChip({ gmail }: { gmail: RailGmailData }) {
     );
   }
 
+  const otherMailbox = distinctMailbox(gmail.email, userEmail);
+
   return (
     <Link
       href="/dashboard"
-      aria-label="Gmail connected — open dashboard"
-      className="group flex items-center gap-2.5 rounded-lg border border-line-soft px-2.5 py-2 transition-colors hover:border-line focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+      aria-label={
+        otherMailbox
+          ? `Gmail connected as ${otherMailbox} — open dashboard`
+          : "Gmail connected — open dashboard"
+      }
+      className={`${ROW} items-start gap-2`}
     >
-      <span className="beta-dot" aria-hidden="true" />
+      {/* The dot aligns to the FIRST line, not to the centre of the stack: it
+          annotates "connected", and the lines below it are that state's detail.
+          Nothing here is indented under the address above — the rail is 240px
+          wide, and buying the visual indent would cost ~42px of a sync sentence
+          that already truncates. */}
+      <span className="beta-dot mt-[0.3rem]" aria-hidden="true" />
       <span className="min-w-0 flex-1">
-        <span className="label-caps block">gmail · connected</span>
-        {gmail.email ? (
-          <span title={gmail.email} className="block truncate text-xs text-muted">
-            {gmail.email}
-          </span>
-        ) : null}
-        <LastSynced at={gmail.lastSyncAt} className="block truncate font-mono text-[10px] text-dim" />
+        <span className="block truncate text-[11px] text-dim transition-colors group-hover:text-muted">
+          {otherMailbox ? (
+            <>
+              Gmail connected as{" "}
+              <span title={otherMailbox} className="text-muted">
+                {otherMailbox}
+              </span>
+            </>
+          ) : (
+            "Gmail connected"
+          )}
+        </span>
+        {/* Its own line, with no prefix or separator around it: `LastSynced`
+            renders EMPTY until the browser knows `now` (it refuses to compute a
+            relative label on the server), so any "· " glued to it would hang
+            there with nothing after it on first paint and with JS off. */}
+        <LastSynced at={gmail.lastSyncAt} className="block truncate text-[11px] text-dim" />
         {gmail.syncStatus === "error" ? (
           <span className="block truncate text-[11px] text-reject-ink">
             last sync failed{gmail.syncError ? ` · ${gmail.syncError}` : ""}
@@ -85,12 +152,14 @@ export function RailFooter({ gmail, userEmail }: FooterProps) {
   const initial = userEmail?.charAt(0).toUpperCase() ?? "·";
 
   return (
-    <div className="space-y-2">
-      {gmail ? <GmailChip gmail={gmail} /> : null}
+    <div className="space-y-0.5">
       <Link
         href="/settings"
-        aria-label="Account — open settings"
-        className="group flex items-center gap-2.5 rounded-lg px-2 py-2 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+        // Named, not just "Account": this link and the not-connected Gmail line
+        // both point at /settings, and two adjacent links with near-identical
+        // accessible names is how a screen reader loses the plot.
+        aria-label={userEmail ? `Signed in as ${userEmail} — open settings` : "Account — open settings"}
+        className={`${ROW} items-center gap-2.5`}
       >
         <span
           aria-hidden="true"
@@ -98,16 +167,14 @@ export function RailFooter({ gmail, userEmail }: FooterProps) {
         >
           {initial}
         </span>
-        <span className="min-w-0">
-          <span
-            title={userEmail ?? undefined}
-            className="block truncate text-xs text-muted transition-colors group-hover:text-strong"
-          >
-            {userEmail ?? "account"}
-          </span>
-          <span className="label-caps block">signed in</span>
+        <span
+          title={userEmail ?? undefined}
+          className="min-w-0 flex-1 truncate text-xs text-muted transition-colors group-hover:text-strong"
+        >
+          {userEmail ?? "account"}
         </span>
       </Link>
+      {gmail ? <ConnectionLine gmail={gmail} userEmail={userEmail} /> : null}
     </div>
   );
 }

--- a/apps/web/components/shell/Sidebar.tsx
+++ b/apps/web/components/shell/Sidebar.tsx
@@ -17,7 +17,9 @@ import { RailPipeline } from "./RailPipeline";
  * Top to bottom: the Applied lockup, the four nav items, a live pipeline
  * snapshot (`RailPipeline` — total, stage distribution, needs-review nudge),
  * then — anchored to the viewport bottom via the sticky full-height column —
- * the Gmail connection chip and the user chip (`RailFooter`). The rail is
+ * one identity block: who is signed in, with the Gmail connection state as a
+ * subordinate line beneath it (`RailFooter`, which explains why those two
+ * chips became one). The rail is
  * `sticky top-0 h-dvh`, so it stays in view while long pages scroll and the
  * footer genuinely anchors; the middle section scrolls internally on short
  * viewports so the footer is never pushed out of reach.


### PR DESCRIPTION
## The defect

The sidebar footer rendered the signed-in address **twice**, eight pixels apart:

1. a bordered chip — green dot, `you@gmail.com`, "last synced 1 hour ago";
2. directly beneath it — monogram tile, `you@gmail.com` again, and the caps eyebrow "SIGNED IN".

For very nearly every user those strings are identical: you sign in to Applied with the Google account you then connect. Two chips repeating one address doesn't read as two facts — it reads as a bug.

## The collapse

One identity block:

```
[A]  you@gmail.com                 -> /settings   (aria: "Signed in as you@gmail.com — open settings")
 •   Gmail connected               -> /dashboard  (aria: "Gmail connected — open dashboard")
     last synced 3 minutes ago
```

The address is printed **once**, in the identity row, and the connection becomes a subordinate line beneath it. The order flipped with it: the account is the anchor; the connection is something the account *has*. Identity still sits bottom-left (the Linear/Notion convention), sign-out still lives in the top bar.

**Nothing was dropped.** All three facts the two chips carried still render:

| fact | where it lives now |
| --- | --- |
| who is signed in | the identity row (monogram + address), plus a named `aria-label` |
| whether Gmail is connected | the connection line — same three honest states |
| when it last synced | its own line under the state |
| a failed sync | still a *separate* line under the last-good time |

The three connection states are untouched: **connected** (live `.beta-dot`, links to the dashboard where sync lives), **not connected** (quiet line into Settings), **unknown** — a failed status probe still renders no line at all, never a guessed state. A failed sync and the last *good* sync are still two different facts and still render together, because the backend leaves `last_sync_at` at the last successful run.

## When the two accounts differ

Signed in as one account, Gmail connected as another is a real case, so the connection line names its own address in that case — "Gmail connected as billing@corp.com" — and both are on screen. Comparison is case-insensitive and trimmed (Google echoes whatever case was typed; `Aesh@gmail.com` is not a second account), and a status probe that carries no address never invents one.

Which means the *absence* of a second address is what asserts the two are the same mailbox. That is a quiet read, and it is the deliberate trade — the alternative is printing the identical string twice, which is the defect this removes. The doc comment says so, in those words.

## Type

The sync label lost `font-mono`. "last synced 3 minutes ago" is a sentence, and `globals.css` is explicit that mono is the data voice and *a sentence in mono is a defect*. The machine value survives where machines read it: `LastSynced` still puts the absolute UTC instant in `title` and `dateTime`.

One premise correction for the record: `.label-caps` was never mono — `globals.css` defines it as Atkinson, "the product's structural voice", and `.label-mono` is the mono one. The eyebrows it set here ("SIGNED IN", "GMAIL · CONNECTED") went away because they *were* the redundancy, not because of the typeface. `font-mono` on the same sentence still ships in `components/settings/GmailConnectionCard.tsx:66` and `components/dashboard/SyncBar.tsx:444` — deliberately left alone here to keep this change tight.

## Constraints kept

- `RailFooter` is still a **server component** — no fetch, no state, no hooks; the prop shape (`lib/shell/rail.ts`) is unchanged.
- Links preserved: identity → `/settings`, connected Gmail → `/dashboard`, not-connected → `/settings`.
- The two links that both target `/settings` now have deliberately **distinct** accessible names — adjacent links with near-identical names is how a screen reader loses the plot.
- Every row keeps the codebase's visible focus ring (`focus-visible:ring-2 focus-visible:ring-viz-rules`).

## Verification

From `apps/web`: `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (121 pass), `pnpm build` — all green. The build needs the same placeholder Supabase env `frontend-ci.yml` sets; without it, it dies in page-data collection on env validation, unrelated to this change.

No e2e was run. No selector in `tests/e2e/` references the footer's text or its `aria-label`s (`shell.spec.ts` asserts only the primary nav and `aria-current`), so nothing there should need updating.

**Third copy of the address:** the sidebar is `hidden md:flex` and `TopBar`'s email is `md:hidden`, so those two are mutually exclusive at every width. On `/settings` specifically, the address does appear twice on screen — once in this rail and once in the page body (`ProfileSection`'s read-only `email` field, and `GmailConnectionCard`'s "Connected · …"). That is the page whose subject *is* the account, so it is content, not chrome duplication.
