### PR TITLE
feat(mail): list every stored message, not just the un-reviewed ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**534 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 500 `test_*` functions across 34 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 534 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**534 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 516 `test_*` functions across 35 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The remaining difference from 534 is parametrization. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
@@ -536,7 +536,7 @@ applied/
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
 │   ├── alembic/versions/    # 11 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 34 modules
+│   └── tests/               # 35 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/apps/web/app/api/applications/mail/route.ts
+++ b/apps/web/app/api/applications/mail/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { getMail } from "@/lib/applications/server";
+
+/**
+ * Same-origin proxy for the full mail listing — every message the sync stored,
+ * whatever the classifier decided and whether or not it has been reviewed.
+ *
+ * The Supabase JWT is attached server-side; the listing is user-scoped. Only
+ * `page`, `page_size`, `category` and `q` are forwarded (see `getMail`), and
+ * the backend validates them, so a bad value comes back as its own 422 rather
+ * than being silently dropped here.
+ *
+ * This is the read `/applications/review` never was: that queue hides a verdict
+ * as soon as it is reviewed or filed, which left corrected-once messages
+ * unreachable from every screen in the product even though the correction
+ * endpoint would still accept them.
+ */
+export async function GET(request: NextRequest) {
+  const r = await getMail(new URL(request.url).searchParams);
+  return NextResponse.json(r.data ?? {}, { status: r.status });
+}

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -248,6 +248,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/applications/mail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Mail Listing Cloud
+         * @description Every message this user has stored, whatever the classifier decided.
+         *
+         *     Declared ABOVE ``GET /{application_id}`` deliberately: FastAPI matches in
+         *     declaration order and would otherwise try ``"mail"`` as an int path param
+         *     and answer 422. Same pattern as ``/summary``, ``/review`` and ``/statuses``.
+         *
+         *     WHY THIS EXISTS
+         *     ---------------
+         *     ``/review`` is the only other listing of classified mail, and it filters to
+         *     ``needs_review AND unlinked AND not-yet-reviewed``. That is the right set
+         *     for a work queue and the wrong set for a correction surface, because those
+         *     three predicates make a verdict unreachable the moment it is touched:
+         *
+         *     * a message already reviewed once drops out for good — emails 58 and 59 of
+         *       the owner's account sit at ``needs_review`` with ``is_reviewed = true``
+         *       and no endpoint in the product could name them, so no screen could
+         *       change them;
+         *     * a message linked to an application drops out too, so a ``rejection``
+         *       filed as ``applied`` is a wrong stored verdict a user can see on the
+         *       board and never correct at its source;
+         *     * and for an account whose mail all classified confidently, ``/review``
+         *       returns zero rows and the review UI never renders at all.
+         *
+         *     The write path never had that restriction — :func:`classify_review_item`
+         *     selects on ``(user_id, message_id)`` alone — so correcting any of these
+         *     already worked. What was missing was a way to *find* them. This is that
+         *     read, and nothing more: no new write, no body, no state change.
+         *
+         *     SHAPE
+         *     -----
+         *     Newest first with an ``id`` tiebreak, for the same reason the applications
+         *     listing has one: a sync writes a batch of rows carrying identical
+         *     ``received_at`` values, tied rows are free to come back in a different
+         *     order per request on Postgres, and paging a partial order drops some rows
+         *     and repeats others.
+         *
+         *     One entry per MESSAGE — unlike ``/review``, which collapses a thread to its
+         *     newest message because being asked the same question twice is duplicated
+         *     work. Here the user is auditing what is stored, and every stored row is
+         *     correctable individually, so hiding siblings would hide exactly the rows
+         *     this endpoint exists to reach.
+         */
+        get: operations["mail_listing_cloud_applications_mail_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/applications/{application_id}": {
         parameters: {
             query?: never;
@@ -962,6 +1022,88 @@ export interface components {
             company: string;
         };
         /**
+         * MailListResponse
+         * @description A page of the user's stored mail, plus the counts the chips need.
+         *
+         *     ``total`` is the size of the CURRENT query — it respects both ``category``
+         *     and ``q``, because it is the number ``page``/``page_size`` walk.
+         *
+         *     ``category_counts`` is deliberately different: it respects ``q`` but NOT
+         *     ``category``, so each filter chip can show its own total while one of them
+         *     is active. Counting only the filtered set would make every chip but the
+         *     selected one read zero.
+         */
+        MailListResponse: {
+            /** Messages */
+            messages: components["schemas"]["MailMessageResponse"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Category Counts */
+            category_counts: {
+                [key: string]: number;
+            };
+        };
+        /**
+         * MailMessageResponse
+         * @description One stored message in the full mail listing.
+         *
+         *     Deliberately METADATA ONLY. ``snippet`` is the persisted ``body_snippet``
+         *     and there is no field for ``body_text`` or ``body_html``: the cloud sync
+         *     never fetches a body and this listing is not the place to start.
+         *
+         *     ``category``/``confidence``/``method`` are the stored verdict verbatim —
+         *     ``classified_as``, ``classification_confidence``, ``classification_method``
+         *     — so a reader can see WHAT was decided and HOW, which is the difference
+         *     between "the machine says applied" and "a rule matched at 0.71".
+         *
+         *     ``category`` carries the enum's own value (``"applied"``, ``"needs_review"``
+         *     …), the same lowercase vocabulary ``?category=`` accepts and
+         *     ``POST /review/{message_id}/classify`` takes back. One vocabulary end to
+         *     end, so a value read here can be sent straight back as a correction.
+         */
+        MailMessageResponse: {
+            /** Message Id */
+            message_id: string;
+            /** Thread Id */
+            thread_id?: string | null;
+            /** Subject */
+            subject?: string | null;
+            /** Sender Name */
+            sender_name?: string | null;
+            /** Sender Email */
+            sender_email?: string | null;
+            /** Received At */
+            received_at?: string | null;
+            /** Snippet */
+            snippet?: string | null;
+            /** Category */
+            category?: string | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Method */
+            method?: string | null;
+            /**
+             * User Corrected
+             * @default false
+             */
+            user_corrected: boolean;
+            /**
+             * Is Reviewed
+             * @default false
+             */
+            is_reviewed: boolean;
+            /** Application Id */
+            application_id?: number | null;
+            /** Company */
+            company?: string | null;
+            /** Gmail Link */
+            gmail_link?: string | null;
+        };
+        /**
          * MessageRefResponse
          * @description One underlying email surfaced in the click-through detail view.
          */
@@ -1531,6 +1673,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StatusVocabularyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mail_listing_cloud_applications_mail_get: {
+        parameters: {
+            query?: {
+                /** @description 1-based page number. */
+                page?: number;
+                /** @description Rows per page (capped so a single response stays bounded). */
+                page_size?: number;
+                /** @description Filter to one stored verdict. Does not affect `category_counts`. */
+                category?: components["schemas"]["EmailCategory"] | null;
+                /** @description Case-insensitive substring match on subject/sender. */
+                q?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MailListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -138,6 +138,35 @@ export function getReviewQueue(): Promise<ApiCallResult> {
   return call(`/applications/review`, { method: "GET" });
 }
 
+/** The query parameters `/applications/mail` accepts. Nothing else is forwarded. */
+const MAIL_QUERY_PARAMS = ["page", "page_size", "category", "q"] as const;
+
+/**
+ * GET /applications/mail — every stored message, whatever the verdict.
+ *
+ * The counterpart to `getReviewQueue`, and the reason it exists: the review
+ * queue filters to `needs_review AND unlinked AND not-yet-reviewed`, so a
+ * verdict becomes unreachable the moment it is touched. This lists the user's
+ * mail regardless of review state or linkage, which is what makes a wrong
+ * verdict correctable more than once. Metadata only — bodies never leave the
+ * backend.
+ *
+ * Values are forwarded as strings and validated by FastAPI, which already
+ * answers a precise 422 naming the offending parameter. A second parser here
+ * would be a second thing to drift. The keys ARE allowlisted: only the four
+ * the endpoint declares travel, so this proxy cannot be used to reach
+ * parameters the backend adds later without a deliberate change here.
+ */
+export function getMail(search: URLSearchParams): Promise<ApiCallResult> {
+  const forwarded = new URLSearchParams();
+  for (const key of MAIL_QUERY_PARAMS) {
+    const value = search.get(key)?.trim();
+    if (value) forwarded.set(key, value);
+  }
+  const query = forwarded.toString();
+  return call(`/applications/mail${query ? `?${query}` : ""}`, { method: "GET" });
+}
+
 /**
  * POST /applications/review/{messageId}/classify — classify + persist + train.
  *

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -253,6 +253,11 @@ router = APIRouter(
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGE_SIZE = 500
 
+# The mail listing pages smaller than the board does: a message row carries a
+# subject and a snippet, so 50 of them is already a heavier response than 100
+# applications. Same MAX_PAGE_SIZE ceiling.
+DEFAULT_MAIL_PAGE_SIZE = 50
+
 # How recent an application counts as "this week" for the summary tile. Kept
 # in one place so the backend aggregate and the frontend's array-based
 # `summarize()` fold agree on the window (7 days).
@@ -409,6 +414,63 @@ class ReviewQueueResponse(BaseModel):
 
     items: list[ReviewItemResponse]
     total: int
+
+
+class MailMessageResponse(BaseModel):
+    """One stored message in the full mail listing.
+
+    Deliberately METADATA ONLY. ``snippet`` is the persisted ``body_snippet``
+    and there is no field for ``body_text`` or ``body_html``: the cloud sync
+    never fetches a body and this listing is not the place to start.
+
+    ``category``/``confidence``/``method`` are the stored verdict verbatim —
+    ``classified_as``, ``classification_confidence``, ``classification_method``
+    — so a reader can see WHAT was decided and HOW, which is the difference
+    between "the machine says applied" and "a rule matched at 0.71".
+
+    ``category`` carries the enum's own value (``"applied"``, ``"needs_review"``
+    …), the same lowercase vocabulary ``?category=`` accepts and
+    ``POST /review/{message_id}/classify`` takes back. One vocabulary end to
+    end, so a value read here can be sent straight back as a correction.
+    """
+
+    message_id: str
+    thread_id: str | None = None
+    subject: str | None = None
+    sender_name: str | None = None
+    sender_email: str | None = None
+    received_at: str | None = None
+    snippet: str | None = None
+    category: str | None = None
+    confidence: float | None = None
+    method: str | None = None
+    user_corrected: bool = False
+    is_reviewed: bool = False
+    application_id: int | None = None
+    # The linked application's employer, resolved in ONE query for the whole
+    # page (never per row). ``None`` when the message is not filed against an
+    # application — which most needs-review mail is not.
+    company: str | None = None
+    gmail_link: str | None = None
+
+
+class MailListResponse(BaseModel):
+    """A page of the user's stored mail, plus the counts the chips need.
+
+    ``total`` is the size of the CURRENT query — it respects both ``category``
+    and ``q``, because it is the number ``page``/``page_size`` walk.
+
+    ``category_counts`` is deliberately different: it respects ``q`` but NOT
+    ``category``, so each filter chip can show its own total while one of them
+    is active. Counting only the filtered set would make every chip but the
+    selected one read zero.
+    """
+
+    messages: list[MailMessageResponse]
+    total: int
+    page: int
+    page_size: int
+    category_counts: dict[str, int]
 
 
 class ReviewClassifyRequest(BaseModel):
@@ -2524,6 +2586,188 @@ async def application_statuses_cloud() -> StatusVocabularyResponse:
             for category, status in CATEGORY_TO_STATUS.items()
         },
         classifier_categories=list(pipeline.CANONICAL_CATEGORIES),
+    )
+
+
+@router.get("/mail", response_model=MailListResponse)
+async def mail_listing_cloud(
+    user_id: uuid.UUID = Depends(current_user),
+    page: int = Query(1, ge=1, description="1-based page number."),
+    page_size: int = Query(
+        DEFAULT_MAIL_PAGE_SIZE,
+        ge=1,
+        le=MAX_PAGE_SIZE,
+        description="Rows per page (capped so a single response stays bounded).",
+    ),
+    category: EmailCategory | None = Query(
+        None,
+        description=(
+            "Filter to one stored verdict. Does not affect `category_counts`."
+        ),
+    ),
+    q: str | None = Query(
+        None, description="Case-insensitive substring match on subject/sender."
+    ),
+) -> MailListResponse:
+    """Every message this user has stored, whatever the classifier decided.
+
+    Declared ABOVE ``GET /{application_id}`` deliberately: FastAPI matches in
+    declaration order and would otherwise try ``"mail"`` as an int path param
+    and answer 422. Same pattern as ``/summary``, ``/review`` and ``/statuses``.
+
+    WHY THIS EXISTS
+    ---------------
+    ``/review`` is the only other listing of classified mail, and it filters to
+    ``needs_review AND unlinked AND not-yet-reviewed``. That is the right set
+    for a work queue and the wrong set for a correction surface, because those
+    three predicates make a verdict unreachable the moment it is touched:
+
+    * a message already reviewed once drops out for good — emails 58 and 59 of
+      the owner's account sit at ``needs_review`` with ``is_reviewed = true``
+      and no endpoint in the product could name them, so no screen could
+      change them;
+    * a message linked to an application drops out too, so a ``rejection``
+      filed as ``applied`` is a wrong stored verdict a user can see on the
+      board and never correct at its source;
+    * and for an account whose mail all classified confidently, ``/review``
+      returns zero rows and the review UI never renders at all.
+
+    The write path never had that restriction — :func:`classify_review_item`
+    selects on ``(user_id, message_id)`` alone — so correcting any of these
+    already worked. What was missing was a way to *find* them. This is that
+    read, and nothing more: no new write, no body, no state change.
+
+    SHAPE
+    -----
+    Newest first with an ``id`` tiebreak, for the same reason the applications
+    listing has one: a sync writes a batch of rows carrying identical
+    ``received_at`` values, tied rows are free to come back in a different
+    order per request on Postgres, and paging a partial order drops some rows
+    and repeats others.
+
+    One entry per MESSAGE — unlike ``/review``, which collapses a thread to its
+    newest message because being asked the same question twice is duplicated
+    work. Here the user is auditing what is stored, and every stored row is
+    correctable individually, so hiding siblings would hide exactly the rows
+    this endpoint exists to reach.
+    """
+
+    # Two filter sets, and the difference is the contract: `total` counts the
+    # query being paged (category + q), while the chips' counts must ignore
+    # `category` or every chip but the active one reads zero.
+    base_filters = [Email.user_id == user_id]
+    needle = (q or "").strip()
+    if needle:
+        like = f"%{needle}%"
+        base_filters.append(
+            or_(
+                Email.subject.ilike(like),
+                Email.sender_name.ilike(like),
+                Email.sender_email.ilike(like),
+            )
+        )
+
+    page_filters = list(base_filters)
+    if category is not None:
+        page_filters.append(Email.classified_as == category)
+
+    offset = (page - 1) * page_size
+
+    async with get_session() as session:
+        total = (
+            await session.exec(
+                select(func.count()).select_from(Email).where(*page_filters)
+            )
+        ).one()
+
+        grouped = (
+            await session.exec(
+                select(Email.classified_as, func.count())
+                .where(*base_filters)
+                .group_by(Email.classified_as)
+            )
+        ).all()
+
+        stmt = (
+            select(Email)
+            .where(*page_filters)
+            # The tiebreak, and it has to be here. A sync writes a batch of
+            # rows inside the same second, so `received_at` alone leaves them
+            # tied and Postgres may return them in a different order per
+            # request — which drops and repeats rows across pages.
+            .order_by(Email.received_at.desc(), Email.id.desc())
+            .offset(offset)
+            .limit(page_size)
+        )
+        rows = (await session.exec(stmt)).all()
+
+        # ONE query for the whole page's employers, not one per row. Scoped to
+        # the owner as well as the id set: a linked id is only ever this user's,
+        # and re-asserting it here means a stale link cannot read across users.
+        linked_ids = {e.application_id for e in rows if e.application_id is not None}
+        company_by_application: dict[int, str] = {}
+        if linked_ids:
+            pairs = (
+                await session.exec(
+                    select(Application.id, Application.company).where(
+                        Application.id.in_(linked_ids),
+                        Application.user_id == user_id,
+                    )
+                )
+            ).all()
+            company_by_application = dict(pairs)
+
+    category_counts: dict[str, int] = {}
+    for stored_category, count in grouped:
+        if stored_category is None:
+            # An unclassified row is real, but it has no chip to land on and
+            # `dict[str, int]` has no key for it. Counted nowhere rather than
+            # under a made-up name; `total` still includes it.
+            continue
+        key = (
+            stored_category.value
+            if hasattr(stored_category, "value")
+            else str(stored_category)
+        )
+        category_counts[key] = count
+
+    account_email = await _connected_account_email(user_id)
+    messages = [
+        MailMessageResponse(
+            message_id=e.message_id,
+            thread_id=e.thread_id,
+            subject=e.subject,
+            sender_name=e.sender_name,
+            sender_email=e.sender_email,
+            received_at=e.received_at.isoformat() if e.received_at else None,
+            # `body_snippet` — the stored preview. Never `body_text`/`body_html`.
+            snippet=e.body_snippet,
+            category=e.classified_as.value if e.classified_as else None,
+            confidence=e.classification_confidence,
+            method=e.classification_method,
+            user_corrected=e.user_corrected,
+            is_reviewed=e.is_reviewed,
+            application_id=e.application_id,
+            company=(
+                company_by_application.get(e.application_id)
+                if e.application_id is not None
+                else None
+            ),
+            gmail_link=pipeline.gmail_deeplink(
+                thread_id=e.thread_id,
+                message_id=e.message_id,
+                account_email=account_email,
+            ),
+        )
+        for e in rows
+    ]
+
+    return MailListResponse(
+        messages=messages,
+        total=total,
+        page=page,
+        page_size=page_size,
+        category_counts=category_counts,
     )
 
 

--- a/backend/tests/test_mail_listing.py
+++ b/backend/tests/test_mail_listing.py
@@ -1,0 +1,740 @@
+"""``GET /applications/mail`` — every stored verdict must be reachable.
+
+Why this file exists
+--------------------
+
+``/applications/review`` was the product's only listing of classified mail, and
+it filters to ``needs_review AND application_id IS NULL AND is_reviewed = false``.
+Those three predicates make a verdict unreachable the moment it is touched. In
+the owner's production database:
+
+* emails 58 and 59 sit at ``needs_review`` with ``is_reviewed = true`` (58 is
+  linked to application 67). No endpoint could name them, so no screen could
+  show them and no screen could change them — permanently stuck at a verdict
+  the user disagreed with;
+* the same query returns **0 rows** for that account overall, so the review UI
+  never rendered at all;
+* meanwhile the write path, :func:`classify_review_item`, selects on
+  ``(user_id, message_id)`` with no such constraint — correcting any of these
+  already worked. Only the *read* was missing.
+
+So the case that matters most here is the boring-looking one: a reviewed email
+appears. That single assertion is the whole point of the endpoint, and it is
+the one a re-added ``is_reviewed == False`` filter would break.
+
+Proven to fail
+--------------
+
+Every assertion below was checked by breaking the thing it covers and watching
+it go red (see the report accompanying the change). The mutations and their
+results are recorded next to each test.
+
+The fixtures are guarded: :func:`test_the_fixture_set_is_what_the_tests_assume`
+runs first and pins the seeded corpus against the literals the other tests use,
+because a test that seeds nothing and asserts over nothing is green.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import time
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+
+JWT_SECRET = "mail-listing-test-jwt-secret-at-least-32-bytes-long-hs256"
+OWNER = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+STRANGER = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+
+# Nearly every row carries the SAME timestamp on purpose: that is the state a
+# sync leaves behind, and the only state in which the `id` tiebreak matters.
+TIED_AT = datetime(2026, 8, 11, 9, 30, 0)
+# One row is genuinely newer, so "newest first" is falsifiable rather than
+# vacuously true over a set of ties.
+NEWEST_AT = TIED_AT + timedelta(days=1)
+
+# Seeded into `body_text`/`body_html` on every row. Bodies are never fetched by
+# the cloud sync and must never leave the backend; asserting on this string
+# rather than on the absence of a field name is what makes the check able to
+# fail (a response model with no `body_text` field cannot ever contain the
+# literal "body_text", so that assertion would pass no matter what).
+BODY_SENTINEL = "SENTINEL-BODY-MUST-NOT-LEAVE-THE-BACKEND"
+
+CRUSOE = "Crusoe Energy"
+NORTHWIND = "Northwind Systems"
+
+
+# (message_id, subject, sender_name, sender_email, category, is_reviewed, link)
+# `link` is a company name to file the message under, or None for unlinked.
+OWNER_MAIL: tuple[tuple[str, str, str, str, str, bool, str | None], ...] = (
+    # The two rows this endpoint exists for. Both already reviewed once, so
+    # `/review` can never list them again; one is linked to an application
+    # (email 58's shape), one is not (email 59's).
+    (
+        "m-58",
+        "Crusoe | Application Received",
+        "Crusoe Recruiting",
+        "recruiting@crusoe.ai",
+        "needs_review",
+        True,
+        CRUSOE,
+    ),
+    (
+        "m-59",
+        "Crusoe | Application Received",
+        "Crusoe Recruiting",
+        "recruiting@crusoe.ai",
+        "needs_review",
+        True,
+        None,
+    ),
+    # Matches q="crusoe" on the SENDER only — its subject says nothing.
+    (
+        "m-sender",
+        "Thanks for your interest",
+        "Talent Team",
+        "jobs@crusoe.ai",
+        "applied",
+        False,
+        None,
+    ),
+    # Matches q="crusoe" on the SUBJECT only — its sender is a job board.
+    (
+        "m-subject",
+        "Your Crusoe application",
+        "Greenhouse",
+        "noreply@greenhouse.io",
+        "applied",
+        False,
+        None,
+    ),
+    ("n-1", "Thanks for applying", "Northwind", "careers@northwind.test", "applied", False, NORTHWIND),
+    ("n-2", "Application received", "Northwind", "careers@northwind.test", "applied", False, NORTHWIND),
+    ("n-3", "We got your application", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-4", "Application submitted", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-5", "Received: Backend Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-6", "Received: Data Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-7", "Received: Platform Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    # The newest row, and not an application at all.
+    ("m-other", "Your weekly newsletter", "Substack", "no-reply@substack.test", "other", False, None),
+)
+
+# A second account whose mail must never appear in the first one's listing —
+# including a row that would match every filter the tests apply.
+STRANGER_MAIL: tuple[tuple[str, str, str, str, str, bool, str | None], ...] = (
+    ("s-1", "Crusoe | Application Received", "Crusoe Recruiting", "recruiting@crusoe.ai", "needs_review", True, None),
+    ("s-2", "Thanks for applying", "Someone Else", "careers@elsewhere.test", "applied", False, None),
+    ("s-3", "Your weekly newsletter", "Substack", "no-reply@substack.test", "other", False, None),
+)
+
+# Hardcoded so a mistake in the table above cannot quietly redefine what the
+# tests prove; `test_the_fixture_set_is_what_the_tests_assume` reconciles the
+# two. (Derived-only expectations agree with any corpus, including an empty one.)
+EXPECTED_TOTAL = 12
+EXPECTED_COUNTS = {"applied": 9, "needs_review": 2, "other": 1}
+Q_NEEDLE = "crusoe"
+EXPECTED_Q_MATCHES = {"m-58", "m-59", "m-sender", "m-subject"}
+EXPECTED_Q_COUNTS = {"applied": 2, "needs_review": 2}
+LINKED_MESSAGES = {"m-58": CRUSOE, "n-1": NORTHWIND, "n-2": NORTHWIND}
+
+
+def _token_for(user_id: str) -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {"sub": user_id, "aud": "authenticated", "iat": now, "exp": now + 300},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+async def cloud_app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Any]:
+    """The cloud app over the in-memory SQLite test DB (see test_user_id_scoping)."""
+
+    monkeypatch.setenv("JOBTRACKER_DEPLOYMENT", "cloud")
+    monkeypatch.setenv("JOBTRACKER_ENVIRONMENT", "test")
+    monkeypatch.setenv("JOBTRACKER_SUPABASE_JWT_SECRET", JWT_SECRET)
+
+    import jobtracker.config as config_module
+    import jobtracker.database.connection as connection_module
+
+    importlib.reload(config_module)
+    connection_module._engine = None
+
+    import jobtracker.auth.supabase_jwt as auth_module
+
+    importlib.reload(auth_module)
+
+    import jobtracker.cloud.applications as cloud_apps_module
+
+    importlib.reload(cloud_apps_module)
+
+    import jobtracker.main_cloud as main_cloud_module
+
+    importlib.reload(main_cloud_module)
+
+    from jobtracker.database import init_db
+
+    await init_db()
+
+    yield main_cloud_module.app
+
+    if connection_module._engine is not None:
+        await connection_module._engine.dispose()
+    connection_module._engine = None
+    monkeypatch.undo()
+    importlib.reload(config_module)
+
+
+async def _seed() -> dict[str, int]:
+    """Write both accounts' applications and mail. Returns app ids by company."""
+
+    from jobtracker.database.connection import get_session
+    from jobtracker.database.models import (
+        Application,
+        ApplicationStatus,
+        Email,
+        EmailCategory,
+        EmailSource,
+    )
+
+    app_ids: dict[str, int] = {}
+    async with get_session() as session:
+        for company in (CRUSOE, NORTHWIND):
+            row = Application(
+                user_id=uuid.UUID(OWNER),
+                company=company,
+                position="Software Engineer",
+                status=ApplicationStatus.APPLIED,
+            )
+            session.add(row)
+            await session.flush()
+            app_ids[company] = row.id
+
+        # The stranger holds an application at the same employer, so a
+        # cross-user company lookup would resolve to something plausible
+        # rather than to nothing.
+        stranger_app = Application(
+            user_id=uuid.UUID(STRANGER),
+            company=CRUSOE,
+            position="Software Engineer",
+            status=ApplicationStatus.APPLIED,
+        )
+        session.add(stranger_app)
+        await session.flush()
+
+        for owner, table in ((OWNER, OWNER_MAIL), (STRANGER, STRANGER_MAIL)):
+            for (
+                message_id,
+                subject,
+                sender_name,
+                sender_email,
+                category,
+                is_reviewed,
+                link,
+            ) in table:
+                session.add(
+                    Email(
+                        user_id=uuid.UUID(owner),
+                        source_account=EmailSource.GMAIL,
+                        message_id=message_id,
+                        thread_id=f"thread-{message_id}",
+                        subject=subject,
+                        sender_name=sender_name,
+                        sender_email=sender_email,
+                        received_at=NEWEST_AT if message_id == "m-other" else TIED_AT,
+                        body_text=f"{BODY_SENTINEL} plain",
+                        body_html=f"<p>{BODY_SENTINEL} html</p>",
+                        body_snippet=f"snippet for {message_id}",
+                        classified_as=EmailCategory(category),
+                        classification_confidence=0.71,
+                        classification_method="rules",
+                        user_corrected=is_reviewed,
+                        is_reviewed=is_reviewed,
+                        application_id=app_ids[link] if link and owner == OWNER else None,
+                    )
+                )
+        await session.commit()
+
+    return app_ids
+
+
+async def _get(cloud_app, user: str = OWNER, **params: Any) -> Any:
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            "/applications/mail",
+            params=params,
+            headers={"Authorization": f"Bearer {_token_for(user)}"},
+        )
+
+
+# =============================================================================
+# The premise guard — run this before believing anything below it
+# =============================================================================
+
+
+async def test_the_fixture_set_is_what_the_tests_assume(cloud_app):
+    """Reconcile the seeded corpus with the literals the other tests use.
+
+    A previous test in this repo reported "3 passed, 4 skipped" because its
+    table names were wrong and every case skipped itself into green. Assertions
+    over an empty or mis-shaped fixture set are worth nothing, so this pins the
+    fixture set itself before anything asserts over it.
+    """
+
+    app_ids = await _seed()
+    assert set(app_ids) == {CRUSOE, NORTHWIND}
+
+    assert len(OWNER_MAIL) == EXPECTED_TOTAL, "the owner's corpus changed size"
+    assert len({row[0] for row in OWNER_MAIL}) == EXPECTED_TOTAL, "duplicate message ids"
+
+    derived: dict[str, int] = {}
+    for row in OWNER_MAIL:
+        derived[row[4]] = derived.get(row[4], 0) + 1
+    assert derived == EXPECTED_COUNTS
+
+    derived_q = {row[0] for row in OWNER_MAIL if Q_NEEDLE in (row[1] + row[3]).lower()}
+    assert derived_q == EXPECTED_Q_MATCHES
+
+    derived_links = {row[0]: row[6] for row in OWNER_MAIL if row[6] is not None}
+    assert derived_links == LINKED_MESSAGES
+    assert len(LINKED_MESSAGES) >= 2, (
+        "the N+1 check needs at least two linked rows on one page, otherwise "
+        "'one query' and 'one query per row' are the same number"
+    )
+
+    # And the rows really landed in the database.
+    from sqlmodel import select
+
+    from jobtracker.database.connection import get_session
+    from jobtracker.database.models import Email
+
+    async with get_session() as session:
+        stored = (await session.exec(select(Email))).all()
+    assert len(stored) == len(OWNER_MAIL) + len(STRANGER_MAIL)
+
+
+# =============================================================================
+# The gap this endpoint closes
+# =============================================================================
+
+
+async def test_a_reviewed_email_is_listed(cloud_app):
+    """Emails 58 and 59: reviewed, and therefore invisible to ``/review``.
+
+    THE POINT OF THE ENDPOINT. A verdict the user already touched once stays
+    correctable, instead of being frozen wherever the classifier left it.
+
+    Mutation: re-adding ``Email.is_reviewed == False`` to the page filters →
+    this test fails (both ids missing).
+    """
+
+    await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["messages"], "the listing returned nothing to assert over"
+    by_id = {m["message_id"]: m for m in body["messages"]}
+
+    for message_id in ("m-58", "m-59"):
+        assert message_id in by_id, (
+            f"{message_id} is reviewed needs-review mail and is unreachable "
+            "again — this is the exact state emails 58/59 are stuck in"
+        )
+        assert by_id[message_id]["is_reviewed"] is True
+        assert by_id[message_id]["category"] == "needs_review"
+
+    # 59 is unlinked; the review queue would additionally have dropped 58 for
+    # being filed against an application.
+    assert by_id["m-59"]["application_id"] is None
+    assert by_id["m-58"]["application_id"] is not None
+
+
+async def test_a_linked_email_carries_its_company(cloud_app):
+    """A filed message names its employer, and an unfiled one names nothing.
+
+    Mutation: adding ``Email.application_id.is_(None)`` to the page filters →
+    fails (m-58 missing). Returning ``company=None`` unconditionally → fails.
+    """
+
+    app_ids = await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    by_id = {m["message_id"]: m for m in res.json()["messages"]}
+    assert by_id, "the listing returned nothing to assert over"
+
+    for message_id, company in LINKED_MESSAGES.items():
+        assert by_id[message_id]["application_id"] == app_ids[company]
+        assert by_id[message_id]["company"] == company
+
+    assert by_id["m-59"]["company"] is None
+    assert by_id["m-other"]["company"] is None
+
+
+async def test_company_resolution_is_one_query_not_one_per_row(cloud_app):
+    """Three linked rows on the page must cost ONE applications SELECT.
+
+    Reads the statements handed to the driver, so it measures the query the
+    database actually receives rather than the shape of the Python.
+
+    Mutation: resolving the company inside the per-row loop → 3 statements,
+    this fails.
+    """
+
+    await _seed()
+
+    import jobtracker.database.connection as connection_module
+
+    engine = connection_module._engine
+    assert engine is not None, "the fixture should have built an engine"
+
+    statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        statements.append(statement)
+
+    try:
+        res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+        assert res.status_code == 200, res.text
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    linked = [m for m in res.json()["messages"] if m["application_id"] is not None]
+    assert len(linked) == len(LINKED_MESSAGES), "the page did not contain the linked rows"
+
+    against_applications = [s for s in statements if "FROM applications" in s]
+    assert len(against_applications) <= 1, (
+        "the company lookup is running per row: "
+        f"{len(against_applications)} SELECTs against applications for "
+        f"{len(linked)} linked messages"
+    )
+
+
+async def test_another_users_mail_is_never_listed(cloud_app):
+    """Owner-scoped rows, owner-scoped counts.
+
+    Mutation: dropping ``Email.user_id == user_id`` from the page filters →
+    fails (the stranger's ids appear and the totals inflate).
+    """
+
+    await _seed()
+
+    mine = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert mine.status_code == 200, mine.text
+    mine_body = mine.json()
+    mine_ids = {m["message_id"] for m in mine_body["messages"]}
+    assert mine_ids == {row[0] for row in OWNER_MAIL}
+    assert mine_body["total"] == EXPECTED_TOTAL
+    assert mine_body["category_counts"] == EXPECTED_COUNTS
+
+    theirs = await _get(cloud_app, user=STRANGER, page_size=EXPECTED_TOTAL)
+    assert theirs.status_code == 200, theirs.text
+    theirs_body = theirs.json()
+    theirs_ids = {m["message_id"] for m in theirs_body["messages"]}
+    assert theirs_ids == {row[0] for row in STRANGER_MAIL}
+    assert theirs_ids, "the stranger's own listing came back empty"
+    assert not (theirs_ids & mine_ids)
+    assert theirs_body["total"] == len(STRANGER_MAIL)
+
+    # And the stranger's Crusoe application must not surface on their mail
+    # either — s-1 is unlinked, so it names no employer.
+    assert all(m["company"] is None for m in theirs_body["messages"])
+
+
+async def test_bodies_never_leave_the_backend(cloud_app):
+    """The stored body is on disk; it is not in the response.
+
+    Asserts on a SENTINEL seeded into ``body_text``/``body_html``, not on the
+    absence of a field name — the response model has no body field, so
+    ``"body_text" not in response`` is a check that cannot fail.
+
+    Mutation: ``snippet=e.body_text`` → fails.
+    """
+
+    await _seed()
+    res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["messages"], "the listing returned nothing to assert over"
+    assert BODY_SENTINEL not in res.text, "a stored email body reached the client"
+    # The snippet is still there — this is not passing because the payload is
+    # empty of content.
+    assert all(m["snippet"] for m in body["messages"])
+    assert body["messages"][0]["snippet"].startswith("snippet for ")
+
+
+# =============================================================================
+# Filtering
+# =============================================================================
+
+
+async def test_category_filters_the_page(cloud_app):
+    """``?category=`` narrows the listing and ``total`` follows it.
+
+    Mutation: dropping the ``category`` filter from the page filters → fails
+    (12 rows come back for a filter that should return 2).
+    """
+
+    await _seed()
+
+    res = await _get(cloud_app, category="needs_review", page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert {m["message_id"] for m in body["messages"]} == {"m-58", "m-59"}
+    assert body["total"] == EXPECTED_COUNTS["needs_review"]
+
+    applied = await _get(cloud_app, category="applied", page_size=EXPECTED_TOTAL)
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["total"] == EXPECTED_COUNTS["applied"]
+    assert all(m["category"] == "applied" for m in applied.json()["messages"])
+
+    # The wire vocabulary is the enum's VALUES, lowercase — the same words
+    # `POST /review/{message_id}/classify` accepts, so a category read here can
+    # be sent straight back as a correction. An unknown one is a visible 422,
+    # not a silently empty page.
+    assert (await _get(cloud_app, category="NEEDS_REVIEW")).status_code == 422
+    assert (await _get(cloud_app, category="banana")).status_code == 422
+
+
+async def test_q_matches_subject_and_sender(cloud_app):
+    """``?q=`` is a case-insensitive substring over subject AND sender.
+
+    The corpus contains a row that matches on the sender only and a row that
+    matches on the subject only, so dropping either half of the OR fails.
+
+    Mutation: dropping the ``q`` filter → fails (12 rows for a 4-row query).
+    """
+
+    await _seed()
+
+    res = await _get(cloud_app, q=Q_NEEDLE, page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert {m["message_id"] for m in body["messages"]} == EXPECTED_Q_MATCHES
+    assert body["total"] == len(EXPECTED_Q_MATCHES)
+
+    # Case-insensitive: the corpus spells it "Crusoe".
+    upper = await _get(cloud_app, q="CRUSOE", page_size=EXPECTED_TOTAL)
+    assert {m["message_id"] for m in upper.json()["messages"]} == EXPECTED_Q_MATCHES
+
+    # A needle that matches nothing returns an honest empty page, not everything.
+    empty = await _get(cloud_app, q="zzz-no-such-mail", page_size=EXPECTED_TOTAL)
+    assert empty.json()["total"] == 0
+    assert empty.json()["messages"] == []
+
+
+async def test_category_counts_ignore_category_but_respect_q(cloud_app):
+    """The chips must show their own totals while one of them is selected.
+
+    This is the asymmetry in the contract: ``total`` is the current query,
+    ``category_counts`` deliberately is not.
+
+    Mutations: counting over the page filters instead of the base filters →
+    fails (the counts collapse to the selected chip); dropping ``q`` from the
+    counts query → fails (the counts stay at the unfiltered totals).
+    """
+
+    await _seed()
+
+    unfiltered = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert unfiltered.json()["category_counts"] == EXPECTED_COUNTS
+
+    # Selecting a chip must NOT change what the other chips say.
+    filtered = await _get(cloud_app, category="needs_review", page_size=EXPECTED_TOTAL)
+    assert filtered.json()["category_counts"] == EXPECTED_COUNTS, (
+        "the counts collapsed to the selected category — every other chip "
+        "would read zero the moment one was clicked"
+    )
+    assert filtered.json()["total"] == EXPECTED_COUNTS["needs_review"]
+
+    # A search DOES change them: the chips describe the searched set.
+    searched = await _get(cloud_app, q=Q_NEEDLE, page_size=EXPECTED_TOTAL)
+    assert searched.json()["category_counts"] == EXPECTED_Q_COUNTS
+    assert searched.json()["category_counts"] != EXPECTED_COUNTS
+
+    # Both at once: counts follow `q` only.
+    both = await _get(
+        cloud_app, category="applied", q=Q_NEEDLE, page_size=EXPECTED_TOTAL
+    )
+    assert both.json()["category_counts"] == EXPECTED_Q_COUNTS
+    assert both.json()["total"] == EXPECTED_Q_COUNTS["applied"]
+    assert {m["message_id"] for m in both.json()["messages"]} == {"m-sender", "m-subject"}
+
+
+# =============================================================================
+# Ordering and paging
+# =============================================================================
+
+
+async def test_newest_first(cloud_app):
+    """``m-other`` is a day newer than everything else, so it leads.
+
+    Mutation: ``.asc()`` instead of ``.desc()`` on ``received_at`` → fails.
+    """
+
+    await _seed()
+    res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    body = res.json()
+    assert body["messages"], "the listing returned nothing to assert over"
+    assert body["messages"][0]["message_id"] == "m-other"
+
+    stamps = [m["received_at"] for m in body["messages"]]
+    assert stamps == sorted(stamps, reverse=True), "the page is not newest-first"
+
+
+async def test_paging_returns_every_row_exactly_once(cloud_app):
+    """Walk every page over a corpus of tied timestamps and rebuild the set.
+
+    Proves the offset/limit arithmetic and the ``page``/``page_size`` echo.
+    It does NOT prove the ordering: SQLite returns tied rows in rowid order, so
+    it is stable here whether or not the tiebreak exists. That half is
+    :func:`test_the_listing_asks_the_database_for_a_total_order` — see the
+    module docstring of ``test_listing_order_is_deterministic.py`` for why the
+    split is necessary rather than belt-and-braces.
+    """
+
+    await _seed()
+
+    page_size = 5
+    collected: list[str] = []
+    page = 1
+    while True:
+        res = await _get(cloud_app, page=page, page_size=page_size)
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["total"] == EXPECTED_TOTAL
+        assert body["page"] == page
+        assert body["page_size"] == page_size
+        got = [m["message_id"] for m in body["messages"]]
+        if not got:
+            break
+        assert len(got) <= page_size
+        collected.extend(got)
+        if len(collected) >= body["total"]:
+            break
+        page += 1
+
+    assert len(collected) == EXPECTED_TOTAL, "paging dropped or duplicated rows"
+    assert len(set(collected)) == EXPECTED_TOTAL, "a row appeared on two pages"
+    assert set(collected) == {row[0] for row in OWNER_MAIL}
+
+    # Past the end: an empty page, not an error and not a wrapped-around one.
+    over = await _get(cloud_app, page=99, page_size=page_size)
+    assert over.status_code == 200
+    assert over.json()["messages"] == []
+    assert over.json()["total"] == EXPECTED_TOTAL
+
+
+async def test_the_same_page_twice_is_the_same_page(cloud_app):
+    """A second identical read must not reshuffle a page of tied timestamps."""
+
+    await _seed()
+    first = await _get(cloud_app, page=1, page_size=5)
+    second = await _get(cloud_app, page=1, page_size=5)
+    assert first.status_code == second.status_code == 200
+    assert [m["message_id"] for m in first.json()["messages"]] == [
+        m["message_id"] for m in second.json()["messages"]
+    ]
+
+
+async def test_the_listing_asks_the_database_for_a_total_order(cloud_app):
+    """The emitted SQL must order by ``received_at`` AND ``id``.
+
+    The assertion that catches the tiebreak being deleted. SQLite cannot show
+    the bug — it returns tied rows in rowid order — so this reads the statement
+    handed to the driver instead of the row order it happens to produce, which
+    is what Postgres would receive in production.
+
+    Mutation: deleting ``Email.id.desc()`` → fails here, and only here.
+    """
+
+    await _seed()
+
+    import jobtracker.database.connection as connection_module
+
+    engine = connection_module._engine
+    assert engine is not None, "the fixture should have built an engine"
+
+    statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        statements.append(statement)
+
+    try:
+        res = await _get(cloud_app, page=1, page_size=5)
+        assert res.status_code == 200, res.text
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    # The count and GROUP BY queries also read `emails` and carry no ORDER BY;
+    # this picks out the one that pages.
+    ordered = [
+        s for s in statements if "FROM emails" in s and "ORDER BY" in s.upper()
+    ]
+    assert ordered, f"no ordered SELECT against emails was issued: {statements}"
+
+    order_clause = re.split(r"ORDER BY", ordered[-1], flags=re.IGNORECASE)[1]
+    lowered = order_clause.lower()
+
+    assert "received_at" in lowered, f"received_at is not in the ORDER BY: {order_clause}"
+    assert re.search(r"\bid\b", lowered), (
+        "the mail listing no longer breaks ties on id — rows sharing a "
+        "received_at are free to reorder per request on Postgres, which drops "
+        f"and repeats them across pages. ORDER BY was: {order_clause}"
+    )
+    assert lowered.index("received_at") < lowered.rindex("id"), (
+        "id must come after received_at, otherwise it is the primary sort and "
+        f"the newest-first contract is broken. ORDER BY was: {order_clause}"
+    )
+
+
+async def test_page_size_is_bounded(cloud_app):
+    """``page_size`` is capped by the router's MAX_PAGE_SIZE, and it is a 422."""
+
+    await _seed()
+    import jobtracker.cloud.applications as cloud_apps_module
+
+    over = await _get(cloud_app, page_size=cloud_apps_module.MAX_PAGE_SIZE + 1)
+    assert over.status_code == 422
+    at_cap = await _get(cloud_app, page_size=cloud_apps_module.MAX_PAGE_SIZE)
+    assert at_cap.status_code == 200
+    assert at_cap.json()["page_size"] == cloud_apps_module.MAX_PAGE_SIZE
+
+
+async def test_the_listing_requires_a_token(cloud_app):
+    """No bearer token, no mail — the router-level dependency covers this route."""
+
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        res = await client.get("/applications/mail")
+    assert res.status_code == 401
+
+
+async def test_mail_is_not_swallowed_by_the_application_id_route(cloud_app):
+    """``/applications/mail`` must not be parsed as ``/applications/{id}``.
+
+    FastAPI matches in declaration order. Declared below ``/{application_id}``
+    this returns 422 ("mail" is not an int) — the same trap ``/summary``,
+    ``/review`` and ``/statuses`` are each declared above it to avoid.
+    """
+
+    await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    assert "messages" in res.json(), (
+        "the mail route was shadowed by /applications/{application_id}"
+    )


### PR DESCRIPTION
## The gap

A user can see a classifier verdict but, in most cases, can never correct it.

`GET /applications/review` is the product's only listing of classified mail, and
it filters to `classified_as = NEEDS_REVIEW AND application_id IS NULL AND
is_reviewed = false`. Those three predicates make a verdict unreachable the
moment it is touched. Verified against the production database:

- **Emails 58 and 59** are stored `needs_review` with `is_reviewed = true` (58 is
  linked to application 67). No endpoint in the product can list them, so no
  screen can show or change them. They are stuck at a wrong verdict permanently.
- A message linked to an application drops out too — a rejection filed as
  `applied` is visibly wrong on the board and uncorrectable at its source.
- For the real user that query returns **0 rows**, so the review UI never
  renders at all. The account holds 32 stored emails (29 applied, 2 needs-review,
  1 other).

The write path was never the problem. `classify_review_item` selects the email by
`user_id + message_id` with no constraint on `is_reviewed` or `application_id`,
so correcting any of these already worked. **What was missing was a read.**

## The fix

`GET /applications/mail?page=1&page_size=50&category=<optional>&q=<optional>`

```jsonc
{
  "messages": [{
    "message_id", "thread_id", "subject", "sender_name", "sender_email",
    "received_at", "snippet", "category", "confidence", "method",
    "user_corrected", "is_reviewed", "application_id", "company", "gmail_link"
  }],
  "total": 32,
  "page": 1,
  "page_size": 50,
  "category_counts": { "applied": 29, "needs_review": 2, "other": 1 }
}
```

No new write endpoint, no state change, no body ever leaves the backend.

- **`total` vs `category_counts`.** `total` is the size of the current query — it
  respects both `category` and `q`, because it is the number `page`/`page_size`
  walk. `category_counts` deliberately respects `q` but **not** `category`, so a
  filter chip can still show its own total while another chip is selected.
  Counting the filtered set would make every chip but the active one read zero.
- **Deterministic order.** Newest first by `received_at` with an `id` tiebreak.
  A sync writes a batch of rows sharing one timestamp, and Postgres is free to
  return ties in a different order per request — paging a partial order drops
  some rows and repeats others. Same reasoning, and same test technique, as
  `backend/tests/test_listing_order_is_deterministic.py`.
- **No N+1.** The company for every linked message on the page is resolved in one
  `id IN (...)` query, scoped to the owner as well as to the id set.
- **Metadata only.** `snippet` is `body_snippet`. There is no field for
  `body_text` or `body_html`.
- **One entry per message**, unlike `/review`, which collapses a thread to its
  newest message. Here the user is auditing what is stored and every row is
  individually correctable, so collapsing would hide exactly the rows this
  endpoint exists to reach.
- **Declared above `GET /{application_id}`**, alongside `/summary`, `/review` and
  `/statuses` — otherwise FastAPI parses `"mail"` as an int path param and
  answers 422.

Plus the Next.js proxy `apps/web/app/api/applications/mail/route.ts` and its
`getMail()` helper in `lib/applications/server.ts`, which attaches the Supabase
JWT server-side and allowlists the four query parameters. No React component is
touched.

### One deviation from the drafted contract, and why

The contract sketch showed `category_counts` keyed `APPLIED` / `NEEDS_REVIEW` /
`OTHER`. Those are the enum **names**, which is how the values appear when you
query Postgres directly — SQLAlchemy persists `sa.Enum` members by name. They are
not this product's wire vocabulary. Every existing endpoint emits
`EmailCategory.<X>.value` (lowercase), the already-generated
`components["schemas"]["EmailCategory"]` type is
`"applied" | ... | "needs_review" | "other"`, and that is exactly what both
`?category=` and `POST /review/{message_id}/classify` accept.

So this emits lowercase, and a `category` read from the listing can be sent
straight back as a correction with no case mapping. `?category=NEEDS_REVIEW` is a
visible 422 rather than a silently empty page, and there is a test pinning that.

## Verification

**Backend suite: 539 passed, 0 skipped, 0 failed** (523 before this change, 16
new). The 11 testcontainers RLS tests really executed rather than skipping into
green — a throwaway `postgres:16` started and their 11 dots are in the run.
(`docker info` returned non-zero on the very first check of the session and 0 on
every check after, so the daemon was still coming up; it was up for every test
run reported here.)

The pre-change baseline on `4198884` is **523 collected, 523 passed** with the
pinned 3.11 interpreter — not the 538 the task stated. I could not account for
the 15-test gap: `test_rls_postgres.py` uses `pytestmark = skipif`, so its tests
are collected either way, and a grep found no `importorskip`,
`skip(allow_module_level=True)` or `collect_ignore` anywhere under
`backend/tests/`, which are the only mechanisms that remove tests from the
collected count. The delta that matters is same-tree: 523 → 539, +16, no new
failures, no skips either side.

**Every new test was proven able to fail.** 17 mutations were applied one at a
time to the endpoint, each reverted afterwards; every one turned exactly the
intended test red:

| Mutation | Result |
| --- | --- |
| delete the `id` tiebreaker from the ORDER BY | 1 failed, 15 passed — the SQL-shape test |
| order `asc` instead of `desc` | 1 failed, 15 passed — newest-first |
| re-add `is_reviewed == False` (the `/review` filter) | 8 failed — incl. the reviewed-email (58/59) test |
| re-add `application_id IS NULL` | 8 failed — incl. the linked-company test |
| drop the `user_id` scoping | 6 failed — incl. the other-user test |
| make `total` ignore the `category` filter | 2 failed, 14 passed |
| count categories over the page filters | 1 failed, 15 passed — counts-ignore-category |
| drop `q` from the counts query | 1 failed, 15 passed — counts-respect-q |
| ignore the `category` parameter | 2 failed, 14 passed |
| ignore the `q` parameter | 2 failed, 14 passed |
| serve `body_text` as the snippet | 1 failed, 15 passed — the body sentinel |
| serve `body_html` as the snippet | 1 failed, 15 passed — the body sentinel |
| always return `company=None` | 1 failed, 15 passed |
| resolve the company one query per row (N+1) | 1 failed, 15 passed |
| emit the enum NAME instead of its value | 2 failed, 14 passed |
| declare `/mail` **below** `/{application_id}` | 14 failed, 2 passed — route-order |

The body test asserts on a sentinel seeded into `body_text`/`body_html`, not on
the absence of a field name: the response model has no body field, so
`"body_text" not in response` could never have failed. `test_the_fixture_set_is_
what_the_tests_assume` runs first and reconciles the seeded corpus against the
literals the other tests use, so nothing here can pass by asserting over an empty
set.

**Web:** `tsc --noEmit` clean, `eslint` clean, 121 node unit tests pass.

**Schema drift gate:** `scripts/generate_api_schema.sh` was re-run with the
pinned 3.11 interpreter after committing, and `git diff --exit-code
apps/web/lib/api/schema.d.ts` is clean — the committed `schema.d.ts` is
byte-identical to a fresh regeneration.

**Not run here:** Playwright/e2e and the Next.js production build.
