### PR TITLE
feat(web): redesign the signed-in surface — worklist dashboard, filed-mail review, settings rebuilt

### DIFF
--- a/apps/web/app/(app)/dashboard/loading.tsx
+++ b/apps/web/app/(app)/dashboard/loading.tsx
@@ -1,6 +1,10 @@
 export default function DashboardLoading() {
   return (
-    <section className="space-y-6" aria-busy="true" aria-label="Loading dashboard">
+    <section
+      className="flex flex-col gap-4 lg:min-h-0 lg:flex-1"
+      aria-busy="true"
+      aria-label="Loading dashboard"
+    >
       {/* Header: title + subtitle line, sync cluster */}
       <div className="flex items-end justify-between gap-3">
         <div className="space-y-2">
@@ -10,11 +14,19 @@ export default function DashboardLoading() {
         <div className="h-9 w-40 animate-pulse rounded-lg bg-surface-2" />
       </div>
 
-      {/* Board columns — the page's one big block now (no tiles, no funnel) */}
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-64 animate-pulse rounded-xl border border-line-soft bg-surface" />
-        ))}
+      {/* Spine + worklist — the same geometry the loaded board renders into,
+          so the swap from skeleton to rows never reflows the page. */}
+      <div className="flex min-h-0 flex-1 gap-5">
+        <div className="hidden w-52 shrink-0 flex-col gap-2 lg:flex">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded-lg bg-surface-2" />
+          ))}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-2 overflow-hidden">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div key={i} className="h-10 animate-pulse rounded-lg border border-line-soft bg-surface" />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -10,7 +10,12 @@ import { ReviewQueue, type ReviewItem } from "@/components/dashboard/ReviewQueue
 import { RebuildWindowButton, SyncBar, type SyncGmailState } from "@/components/dashboard/SyncBar";
 import { getReviewQueue } from "@/lib/applications/server";
 import { getGmailStatus } from "@/lib/gmail/server";
-import { summarizeCounts, type Application, type PipelineSummary } from "@/lib/dashboard/summary";
+import {
+  stageCountsOf,
+  summarizeCounts,
+  type Application,
+  type PipelineSummary,
+} from "@/lib/dashboard/summary";
 import { readNotificationPrefs } from "@/lib/settings/notifications";
 import { getCurrentUser } from "@/lib/supabase/auth";
 
@@ -366,10 +371,17 @@ export default async function DashboardPage() {
           (`layout="rail"`), after the list below it — the hidden copy leaves
           the accessibility tree with `display: none`, so the signals are never
           announced twice. */}
+      {/* `total` and `stageTotals` both come from the summary endpoint, and the
+          board's prop type makes them inseparable: the spine states the
+          ACCOUNT's per-stage counts (a `GROUP BY status` in the database), not
+          the shape of the page that happened to load. Past BOARD_PAGE_SIZE the
+          two differ, and a spine summing to the page while this subtitle says
+          the account is exactly the contradiction the scope note exists for. */}
       <PipelineBoard
         variant="locked"
         applications={state.applications}
         total={state.total}
+        stageTotals={stageCountsOf(state.summary)}
         rail={
           <PipelinePulse
             layout="rail"

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -18,19 +18,27 @@ import { getCurrentUser } from "@/lib/supabase/auth";
  * The signed-in product: a work surface, not a metrics poster.
  *
  * The page answers exactly two questions, in this order: "what needs me?"
- * (the review queue) and "where does everything stand?" (the board). One
- * honest line of state — the subtitle — carries the totals; the board columns
- * carry the per-stage counts. Nothing on the page restates either. The stat
- * tiles, the classifier-context strip, the distribution bars and the
- * recent-activity feed are gone: each was a second (or sixth) rendering of a
- * number already on screen, and the classifier strip was CI provenance shown
- * to somebody trying to find a job.
+ * (the review queue) and "where does everything stand?" (the worklist). One
+ * honest line of state — the subtitle — carries the totals; the board's stage
+ * spine carries the per-stage counts. Nothing on the page restates either.
  *
- * The pulse strip (`PipelinePulse`) is not those coming back: every cell on it
- * is DERIVED signal the subtitle and the columns cannot express — filed-per-
- * week momentum, the age distribution of open rows, and how much of the board
- * the classifier built / is holding — each computed once, in `lib/dashboard/
- * age.ts`, from the same rows the board renders.
+ * The geometry is viewport-locked at desktop: the shell is one screen tall,
+ * this page fills its pane exactly (`lg:min-h-0 lg:flex-1`), and the ONLY
+ * thing that scrolls is the worklist inside `PipelineBoard`. Header, notice
+ * lines and the spine hold still — the dashboard reads as an instrument, not
+ * a document. Below `lg` the lock releases and the page flows normally.
+ *
+ * The notice zone under the SyncBar is deliberately one line box per notice
+ * (`truncate`, no wrapping): the "what changed since you last looked" summary
+ * (PR #113, `SinceLastLook`) is designed to land in this same zone as another
+ * single line, so nothing that appears after hydration can ever shift the
+ * board.
+ *
+ * The pulse's four derived signals — filed-per-week momentum, the age
+ * distribution of open rows, deadlines, and how much of the board the
+ * classifier built / is holding — render inside the board's spine at desktop
+ * (`layout="rail"`), where they read as the pipeline's instrument panel, and
+ * as the horizontal strip after the list on smaller screens.
  *
  * Data path unchanged: the counts come from the O(1) `GET
  * /applications/summary`, the board from one bounded page of
@@ -323,46 +331,67 @@ export default async function DashboardPage() {
     ) : null;
 
   return (
-    <section className="space-y-6">
+    <section className="flex flex-col gap-4 lg:min-h-0 lg:flex-1">
       <SyncBar subtitle={subtitle} gmail={gmail}>
         <AddApplicationForm compact />
       </SyncBar>
 
-      {/* The three signals the rows carry that the board can't show as
-          columns: momentum over time, how the open pipeline is ageing, and
-          what the classifier built/held (see PipelinePulse). */}
-      <PipelinePulse
-        applications={state.applications}
-        total={state.total}
-        needsReview={state.needsReview}
-      />
-
-      {/* The in-app weekly digest — pref-gated, and only when there is a week
-          to report. The review half of the old NotificationCues banner is gone:
-          the queue itself now sits where the banner pointed. */}
+      {/* The notice zone: single-line notices only, so nothing here can shift
+          the board. The in-app weekly digest — pref-gated, and only when there
+          is a week to report — is the first tenant; `SinceLastLook` (PR #113)
+          is designed to stack here as another one-line element. */}
       {notifPrefs.weekly && summary.total > 0 && summary.thisWeek > 0 ? (
-        <div
+        <p
           role="status"
-          className="rounded-xl border border-line-soft bg-surface px-4 py-3 text-[13px] text-muted"
+          className="truncate border-l-2 border-line-strong pl-3 text-[13px] leading-snug text-muted"
         >
           <span className="text-strong">This week</span> · {summary.thisWeek} new application
           {summary.thisWeek === 1 ? "" : "s"} · {summary.inMotion} in motion · {summary.offers}{" "}
           offer{summary.offers === 1 ? "" : "s"}
-        </div>
+        </p>
       ) : null}
 
-      {/* "Needs review alerts" now decides whether held mail interrupts the
-          board (above) or waits under it (below) — the quiet-board promise the
-          Settings toggle describes, kept real. */}
-      {notifPrefs.reviewAlerts ? queue : null}
+      {/* The worklist owns the rest of the pane. `total` is the account's true
+          count, not the page's: past BOARD_PAGE_SIZE the board says which slice
+          it is showing, so the subtitle's "250 filed" and a list summing to 200
+          stop contradicting each other.
 
-      {/* `total` is the account's true count, not the page's: past
-          BOARD_PAGE_SIZE the board says which slice it is showing, so the
-          subtitle's "250 filed" and four columns summing to 200 stop
-          contradicting each other. */}
-      <PipelineBoard applications={state.applications} total={state.total} />
+          "Needs review alerts" decides whether held mail interrupts the list
+          (above the rows) or waits under it — the quiet-board promise the
+          Settings toggle describes, kept real. Both placements live INSIDE the
+          list's scroll context, so an eight-item queue can never starve the
+          worklist of its viewport.
 
-      {!notifPrefs.reviewAlerts ? queue : null}
+          The pulse renders once per breakpoint: in the spine at `lg`+
+          (`layout="rail"`), after the list below it — the hidden copy leaves
+          the accessibility tree with `display: none`, so the signals are never
+          announced twice. */}
+      <PipelineBoard
+        variant="locked"
+        applications={state.applications}
+        total={state.total}
+        rail={
+          <PipelinePulse
+            layout="rail"
+            applications={state.applications}
+            total={state.total}
+            needsReview={state.needsReview}
+          />
+        }
+        beforeList={notifPrefs.reviewAlerts ? queue : null}
+        afterList={
+          <>
+            {!notifPrefs.reviewAlerts ? queue : null}
+            <div className="lg:hidden">
+              <PipelinePulse
+                applications={state.applications}
+                total={state.total}
+                needsReview={state.needsReview}
+              />
+            </div>
+          </>
+        }
+      />
     </section>
   );
 }

--- a/apps/web/app/(app)/inbox/page.tsx
+++ b/apps/web/app/(app)/inbox/page.tsx
@@ -4,31 +4,76 @@ import type { Metadata } from "next";
 import { BetaCard } from "@/components/beta/BetaCard";
 import { ConnectGmailButton } from "@/components/gmail/ConnectGmailButton";
 import { InboxWorkbench } from "@/components/gmail/InboxWorkbench";
+import { FiledMailList } from "@/components/mail/FiledMailList";
+import { getMail } from "@/lib/applications/server";
 import { getGmailStatus } from "@/lib/gmail/server";
+import { FILED_PAGE_SIZE, readFiledMailPage } from "@/lib/mail/filed";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
-  title: "Classified inbox",
-  description: "Mine your Gmail for your real job-search pipeline, one classifier verdict per message.",
+  title: "Inbox",
+  description:
+    "Everything Applied has read and how it judged it — plus a live, read-only mine of your Gmail.",
 };
 
 /**
- * The honest end of the pipeline: real mail from the connected Gmail account,
- * one classifier verdict each. The server render only resolves the *connection*
- * state (cheap `/auth/gmail/status`); the actual high-volume, filterable mine
- * runs in the client {@link InboxWorkbench}, which pages the backend and shows
- * the pipeline (category summary + follow-up flags). Bodies are never fetched.
+ * The mail section, in two views. This is where "where do I review the filed
+ * mail?" is answered — with a PLACE, not a transient interrupt:
  *
- * Every non-connected path says so plainly and offers a way forward — connect,
- * the beta invite, or the no-OAuth import fallback — never a raw error.
+ *   - **Filed** (default) — every message the sync has stored, whatever the
+ *     classifier decided and wherever the message went: linked to a board
+ *     row, resolved as noise, held for review, already reviewed. Each row
+ *     shows the verdict (category, confidence against the gate) and carries a
+ *     correction control, because the backend accepts a re-classification for
+ *     any owned message — the needs-review queue was the only correction
+ *     surface before, and it hides a verdict forever the moment it is
+ *     touched.
+ *   - **Live scan** — the existing workbench: a read-only, on-demand mine of
+ *     the connected Gmail that can file what it finds. It reads Google, not
+ *     the store, so it stays its own view rather than pretending to be a
+ *     record.
+ *
+ * The Filed view is driven entirely by the URL (`category`, `q`, `page`), so
+ * the chips and pager are links, a filter state is shareable, and the server
+ * renders the truth on every visit — no client cache to go stale.
  */
+
+type SearchParams = Promise<{
+  view?: string;
+  category?: string;
+  q?: string;
+  page?: string;
+}>;
+
+function ViewSwitch({ scan }: { scan: boolean }) {
+  const tab = (active: boolean) =>
+    cn(
+      "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+      active ? "bg-strong text-background" : "text-muted hover:text-strong",
+    );
+  return (
+    <nav aria-label="Inbox views" className="inline-flex rounded-lg border border-line-soft bg-surface p-0.5">
+      <Link href="/inbox" aria-current={!scan ? "page" : undefined} className={tab(!scan)}>
+        Filed
+      </Link>
+      <Link
+        href="/inbox?view=scan"
+        aria-current={scan ? "page" : undefined}
+        className={tab(scan)}
+      >
+        Live scan
+      </Link>
+    </nav>
+  );
+}
 
 function ImportFallback() {
   return (
     <div className="rounded-xl border border-line-soft bg-surface p-5">
       <h2 className="text-base font-medium text-strong">See it on your own mail — right now</h2>
       <p className="mt-1.5 text-sm text-muted">
-        You don&apos;t have to wait for a beta seat. Export your mail from Google Takeout (or grab a
-        single <span className="font-mono text-dim">.eml</span>) and classify it{" "}
+        No beta seat needed: export from Google Takeout (or one{" "}
+        <span className="font-mono text-dim">.eml</span>) and classify it{" "}
         <span className="text-strong">entirely in your browser</span> — no upload, no OAuth.
       </p>
       <Link
@@ -41,140 +86,132 @@ function ImportFallback() {
   );
 }
 
-function InboxShell({
-  children,
-  lede,
-}: {
-  children?: React.ReactNode;
-  lede: React.ReactNode;
-}) {
-  // Measure capped for readability, but aligned to the shell's shared left
-  // edge (no `mx-auto`): every authed page starts at the same x.
+/** The scan view's non-connected states — connect, the beta seat, or the
+ *  no-OAuth import path. Every branch routes forward; none is a dead end. */
+function ScanFallback({ configured }: { configured: boolean }) {
+  if (!configured) return <ImportFallback />;
   return (
-    <section className="max-w-3xl space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-strong">Classified inbox</h1>
-        <p className="mt-1 text-sm text-muted">{lede}</p>
-      </header>
-      {children}
-    </section>
+    <>
+      <div className="rounded-xl border border-line-soft bg-surface p-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="text-base font-medium text-strong">Connect Gmail to scan live</h2>
+            <p className="mt-1.5 text-sm text-muted">
+              Read-only, on Google&apos;s own consent screen. The classifier labels your job-search
+              mail — it <span className="text-strong">cannot</span> send, delete, or modify anything.
+            </p>
+          </div>
+          <ConnectGmailButton className="shrink-0" />
+        </div>
+        <p className="mt-4 border-t border-line-soft pt-4 text-sm text-muted">
+          The full scopes-and-safeguards breakdown lives in{" "}
+          <Link href="/settings" className="text-strong underline-offset-4 hover:underline">
+            Settings
+          </Link>
+          .
+        </p>
+      </div>
+      <BetaCard />
+      <ImportFallback />
+    </>
   );
 }
 
-export default async function InboxPage() {
-  const result = await getGmailStatus();
+export default async function InboxPage({ searchParams }: { searchParams: SearchParams }) {
+  const params = await searchParams;
+  const scan = params.view === "scan";
 
-  // --- Signed out --------------------------------------------------------
-  if (result.kind === "unauthenticated") {
+  // --- Live scan ------------------------------------------------------------
+  if (scan) {
+    const result = await getGmailStatus();
+    const connected = result.kind === "ok" && result.status.configured && result.status.connected;
     return (
-      <InboxShell
-        lede={
-          <>
-            Sign in to view your classified inbox — or{" "}
-            <Link href="/import" className="text-strong underline-offset-4 hover:underline">
-              import your mail
-            </Link>{" "}
-            with no sign-in.
-          </>
-        }
-      >
-        <ImportFallback />
-      </InboxShell>
-    );
-  }
-
-  // --- Backend answered: branch on configured / connected ----------------
-  if (result.kind === "ok") {
-    const { configured, connected, email } = result.status;
-
-    if (configured && connected) {
-      // The connected inbox is a data surface: it spans the shell's full
-      // column like the dashboard board does (the capped reading measure is
-      // for the prose/CTA states below). Header voice matches every tab —
-      // h1 + one quiet line of state.
-      return (
-        <section className="space-y-6">
-          <header>
-            <h1 className="text-2xl font-semibold tracking-tight text-strong">Classified inbox</h1>
-            <p className="mt-1 text-[13px] text-muted">
-              read-only mine · one verdict per message · unanswered applications get flagged
-            </p>
-          </header>
-          <InboxWorkbench email={email} />
-        </section>
-      );
-    }
-
-    if (configured && !connected) {
-      return (
-        <InboxShell
-          lede={
-            <>
-              This is where your real, classified mail lands. Connect Gmail read-only and it fills with
-              live verdicts — or preview the classifier first, no connection needed.
-            </>
-          }
-        >
+      <section className="space-y-5">
+        <header>
+          <h1 className="text-2xl font-semibold tracking-tight text-strong">Inbox</h1>
+          <p className="mt-1 text-[13px] text-muted">
+            live scan · read-only mine of your Gmail · one verdict per message
+          </p>
+        </header>
+        <ViewSwitch scan />
+        {connected ? (
+          <InboxWorkbench email={result.status.email} />
+        ) : result.kind === "auth" ? (
           <div className="rounded-xl border border-line-soft bg-surface p-5">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-              <div className="min-w-0">
-                <h2 className="text-base font-medium text-strong">Connect Gmail to fill this inbox</h2>
-                <p className="mt-1.5 text-sm text-muted">
-                  Read-only, on Google&apos;s own consent screen. The classifier reads your job-search
-                  mail to label it — it <span className="text-strong">cannot</span> send, delete, or
-                  modify anything.
-                </p>
-              </div>
-              <ConnectGmailButton className="shrink-0" />
-            </div>
-            <p className="mt-4 border-t border-line-soft pt-4 text-sm text-muted">
-              Want the full breakdown of scopes and safeguards first? See{" "}
-              <Link href="/settings" className="text-strong underline-offset-4 hover:underline">
-                Settings
-              </Link>
-              .
+            <p className="text-sm text-muted">
+              Your session couldn&apos;t be verified for the mail backend
+              {" "}(<span className="font-mono text-dim">{result.status}</span>).
             </p>
+            <Link
+              href="/login?redirect=/inbox"
+              className="mt-3 inline-flex items-center gap-2 rounded-lg bg-strong px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+            >
+              Sign in again <span aria-hidden>→</span>
+            </Link>
           </div>
-          <BetaCard />
-          <ImportFallback />
-        </InboxShell>
-      );
-    }
-
-    // Backend reachable but Gmail not configured on this deploy.
-    return (
-      <InboxShell lede={<>The Gmail connection isn&apos;t enabled on this deployment yet.</>}>
-        <ImportFallback />
-      </InboxShell>
+        ) : result.kind === "backend" ? (
+          <div className="rounded-xl border border-line-soft bg-surface p-5 text-sm text-muted">
+            The mail backend is temporarily unavailable — this view fills in the moment it answers.
+          </div>
+        ) : (
+          <ScanFallback configured={result.kind === "ok" && result.status.configured} />
+        )}
+      </section>
     );
   }
 
-  // --- Honest failure states (never a raw error) -------------------------
-  const lede =
-    result.kind === "auth" ? (
-      <>Your session couldn&apos;t be verified for the mail backend. Signing in again usually fixes it.</>
-    ) : result.kind === "unavailable" ? (
-      <>The Gmail connection isn&apos;t enabled on this deployment yet.</>
-    ) : (
-      <>The mail backend is temporarily unavailable — this page fills in the moment it answers.</>
-    );
+  // --- Filed (default) --------------------------------------------------------
+  const category = params.category?.trim() || null;
+  const q = params.q?.trim() || null;
+  const requested = Number(params.page);
+  const pageNum = Number.isInteger(requested) && requested > 1 ? requested : 1;
+
+  const search = new URLSearchParams();
+  search.set("page", String(pageNum));
+  search.set("page_size", String(FILED_PAGE_SIZE));
+  if (category) search.set("category", category);
+  if (q) search.set("q", q);
+  const result = await getMail(search);
+  const page = result.ok ? readFiledMailPage(result.data) : null;
 
   return (
-    <InboxShell lede={lede}>
-      {result.kind === "auth" ? (
-        <div className="rounded-xl border border-line-soft bg-surface p-5">
-          <Link
-            href="/login?redirect=/inbox"
-            className="inline-flex items-center gap-2 rounded-lg bg-strong px-4 py-2 text-sm font-medium text-background hover:opacity-90"
-          >
-            Sign in again <span aria-hidden>→</span>
-          </Link>
-          <p className="mt-3 text-xs text-dim">
-            reference: backend responded <span className="font-mono">{result.status}</span>
+    <section className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-strong">Inbox</h1>
+        <p className="mt-1 text-[13px] text-muted">
+          {page
+            ? `everything Applied has read · ${page.total} message${page.total === 1 ? "" : "s"}${
+                category || q ? " in this view" : " stored"
+              } · every verdict correctable`
+            : "everything Applied has read, and how it judged it"}
+        </p>
+      </header>
+      <ViewSwitch scan={false} />
+      {page ? (
+        <FiledMailList page={page} activeCategory={category} q={q} />
+      ) : (
+        // Honest failure — never an empty inbox that reads as "no mail". The
+        // distinct next step per status mirrors the dashboard's rule.
+        <div role="alert" className="rounded-xl border border-reject/40 bg-surface p-6">
+          <p className="label-caps text-reject-ink">couldn&apos;t load</p>
+          <h2 className="mt-2 text-base font-medium text-strong">
+            Your stored mail didn&apos;t load.
+          </h2>
+          <p className="mt-1.5 text-sm text-muted">
+            {result.status === 401 || result.status === 403
+              ? "The backend rejected this session — signing in again usually clears it."
+              : `The backend answered ${result.status}. Nothing is lost — the list renders the moment it responds.`}
           </p>
+          {result.status === 401 || result.status === 403 ? (
+            <Link
+              href="/login?redirect=/inbox"
+              className="mt-3 inline-block text-xs text-dim underline-offset-4 hover:text-strong hover:underline"
+            >
+              sign in again →
+            </Link>
+          ) : null}
         </div>
-      ) : null}
-      <ImportFallback />
-    </InboxShell>
+      )}
+    </section>
   );
 }

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -7,6 +7,7 @@ import { DataSection } from "@/components/settings/DataSection";
 import { GmailConnectionCard } from "@/components/settings/GmailConnectionCard";
 import { NotificationsSection } from "@/components/settings/NotificationsSection";
 import { ProfileSection } from "@/components/settings/ProfileSection";
+import { SettingsNav } from "@/components/settings/SettingsNav";
 import { DEFAULT_GATE_PREFERENCE, GATE_MAX, GATE_MIN } from "@/lib/dashboard/model";
 import { getGmailStatus } from "@/lib/gmail/server";
 import { readNotificationPrefs } from "@/lib/settings/notifications";
@@ -24,6 +25,17 @@ export const metadata: Metadata = {
  * metadata; Appearance is a device-local theme; Data exports through the
  * server-side proxy; Account signs out or deletes via the admin route. The
  * `(app)` layout guarantees an authenticated user before this renders.
+ *
+ * Layout: a sticky section rail beside the sections at desktop, so seven
+ * cards stop being one blind scroll — the rail is the page's table of
+ * contents, and the shell's scroll pane honours the anchor jumps. The copy
+ * across the sections is cut to one working line per control; the long-form
+ * reference material (Gmail safeguards, the restricted-scope scale story)
+ * survives in disclosures on the Gmail card.
+ *
+ * These same sections render publicly on `/demo/settings` over the simulated
+ * settings transport — that twin is where their e2e coverage executes,
+ * because this route needs a session CI does not have.
  */
 
 const FLAG_BANNERS: Record<string, { tone: "ok" | "warn" | "error"; text: string }> = {
@@ -78,7 +90,7 @@ export default async function SettingsPage({
   // Measure capped for form readability, but aligned to the shell's shared
   // left edge (no `mx-auto`): every authed page starts at the same x.
   return (
-    <section className="max-w-3xl space-y-6">
+    <section className="space-y-6">
       <header>
         <h1 className="text-2xl font-semibold tracking-tight text-strong">Settings</h1>
         <p className="mt-1 text-[13px] text-muted">Your account, appearance, mail, and data.</p>
@@ -87,19 +99,24 @@ export default async function SettingsPage({
       {banner ? (
         <div
           role="status"
-          className={`rounded-xl border bg-surface px-4 py-3 text-sm ${TONE_CLASS[banner.tone]}`}
+          className={`max-w-3xl rounded-xl border bg-surface px-4 py-3 text-sm ${TONE_CLASS[banner.tone]}`}
         >
           {banner.text}
         </div>
       ) : null}
 
-      <ProfileSection initialName={displayName} email={email} memberSince={memberSince} />
-      <AppearanceSection />
-      <GmailConnectionCard result={gmailResult} />
-      <NotificationsSection initial={readNotificationPrefs(meta)} />
-      <ClassificationSection initialGate={clampGate(meta.gate_threshold)} />
-      <DataSection />
-      <AccountSection email={email} />
+      <div className="lg:grid lg:grid-cols-[10rem_minmax(0,48rem)] lg:gap-8">
+        <SettingsNav />
+        <div className="max-w-3xl space-y-6 lg:max-w-none">
+          <ProfileSection initialName={displayName} email={email} memberSince={memberSince} />
+          <AppearanceSection />
+          <GmailConnectionCard result={gmailResult} />
+          <NotificationsSection initial={readNotificationPrefs(meta)} />
+          <ClassificationSection initialGate={clampGate(meta.gate_threshold)} />
+          <DataSection />
+          <AccountSection email={email} />
+        </div>
+      </div>
     </section>
   );
 }

--- a/apps/web/app/api/applications/mail/route.ts
+++ b/apps/web/app/api/applications/mail/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { getMail } from "@/lib/applications/server";
+
+/**
+ * Same-origin proxy for the full mail listing — every message the sync stored,
+ * whatever the classifier decided and whether or not it has been reviewed.
+ *
+ * The Supabase JWT is attached server-side; the listing is user-scoped. Only
+ * `page`, `page_size`, `category` and `q` are forwarded (see `getMail`), and
+ * the backend validates them, so a bad value comes back as its own 422 rather
+ * than being silently dropped here.
+ *
+ * This is the read `/applications/review` never was: that queue hides a verdict
+ * as soon as it is reviewed or filed, which left corrected-once messages
+ * unreachable from every screen in the product even though the correction
+ * endpoint would still accept them.
+ */
+export async function GET(request: NextRequest) {
+  const r = await getMail(new URL(request.url).searchParams);
+  return NextResponse.json(r.data ?? {}, { status: r.status });
+}

--- a/apps/web/app/demo/inbox/page.tsx
+++ b/apps/web/app/demo/inbox/page.tsx
@@ -17,70 +17,77 @@ export const metadata: Metadata = {
  * (precomputed offline by the shipped int8-ONNX pipeline; layer 1 also runs
  * live in the browser). This is the zero-connection twin of the signed-in
  * `/inbox`, which classifies the visitor's actual Gmail once connected.
+ *
+ * Pinned dark with the rest of the demo family. <main> carries the ground and
+ * an inner div carries the measure, not the other way round: `data-theme` on a
+ * `max-w-3xl` element would paint a dark column between the visitor's own
+ * light gutters at desktop.
  */
 export default function DemoInboxPage() {
   return (
-    <main className="mx-auto min-h-screen w-full max-w-3xl px-6 pb-20">
-      <header className="flex min-h-14 flex-wrap items-center justify-between gap-y-2 border-b border-line-soft py-2">
-        <div className="flex flex-wrap items-center gap-3">
+    <main data-theme="dark" className="min-h-screen w-full bg-background text-foreground">
+      <div className="mx-auto w-full max-w-3xl px-6 pb-20">
+        <header className="flex min-h-14 flex-wrap items-center justify-between gap-y-2 border-b border-line-soft py-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/"
+              aria-label="Applied — home"
+              className="brand-logo-link min-h-11 items-center text-strong"
+            >
+              <Logo className="h-6 w-auto" />
+            </Link>
+            <span className="whitespace-nowrap rounded-full border border-line px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-muted">
+              sample inbox · real verdicts · no inbox read
+            </span>
+          </div>
           <Link
-            href="/"
-            aria-label="Applied — home"
-            className="brand-logo-link min-h-11 items-center text-strong"
+            href="/demo"
+            className="inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest text-muted transition-colors hover:text-strong"
           >
-            <Logo className="h-6 w-auto" />
+            ← demo
           </Link>
-          <span className="whitespace-nowrap rounded-full border border-line px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-muted">
-            sample inbox · real verdicts · no inbox read
-          </span>
-        </div>
-        <Link
-          href="/demo"
-          className="inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest text-muted transition-colors hover:text-strong"
-        >
-          ← demo
-        </Link>
-      </header>
+        </header>
 
-      <section className="mt-8 space-y-3">
-        <h1 className="text-2xl font-semibold tracking-tight text-strong">Sample inbox</h1>
-        <p className="max-w-2xl text-muted">
-          Eleven realistic job-search emails, each run through the actual Applied classifier. Click
-          any message to trace its path through the three layers and see where it lands against the
-          0.85 auto-file gate.
-        </p>
-        <div
-          role="note"
-          className="rounded-xl border border-line-soft bg-surface px-4 py-3 text-sm text-muted"
-        >
-          <span className="text-strong">How these verdicts are produced.</span> The emails are
-          synthetic — invented companies, no real mail is read. The verdicts are not: each is the exact
-          output of the shipped 3-layer classifier (the same quantized int8 ONNX pipeline running on
-          the{" "}
-          <a
-            href="https://huggingface.co/spaces/yadava5/jobtracker-classifier"
-            target="_blank"
-            rel="noreferrer"
-            className="text-strong underline-offset-4 hover:underline"
+        <section className="mt-8 space-y-3">
+          <h1 className="text-2xl font-semibold tracking-tight text-strong">Sample inbox</h1>
+          <p className="max-w-2xl text-muted">
+            Eleven realistic job-search emails, each run through the actual Applied classifier. Click
+            any message to trace its path through the three layers and see where it lands against the
+            0.85 auto-file gate.
+          </p>
+          <div
+            role="note"
+            className="rounded-xl border border-line-soft bg-surface px-4 py-3 text-sm text-muted"
           >
-            Hugging Face Space ↗
-          </a>
-          ). Layers 2–3 (the 23 MB model) are precomputed offline; layer 1 (regex rules) is recomputed
-          live in your browser below each trace. Nothing here is hand-tuned.
+            <span className="text-strong">How these verdicts are produced.</span> The emails are
+            synthetic — invented companies, no real mail is read. The verdicts are not: each is the exact
+            output of the shipped 3-layer classifier (the same quantized int8 ONNX pipeline running on
+            the{" "}
+            <a
+              href="https://huggingface.co/spaces/yadava5/jobtracker-classifier"
+              target="_blank"
+              rel="noreferrer"
+              className="text-strong underline-offset-4 hover:underline"
+            >
+              Hugging Face Space ↗
+            </a>
+            ). Layers 2–3 (the 23 MB model) are precomputed offline; layer 1 (regex rules) is recomputed
+            live in your browser below each trace. Nothing here is hand-tuned.
+          </div>
+        </section>
+
+        <div className="mt-8">
+          <SampleInbox />
         </div>
-      </section>
 
-      <div className="mt-8">
-        <SampleInbox />
+        <p className="mt-10 text-center text-xs leading-relaxed text-dim">
+          Want this on your own mail?{" "}
+          <Link href="/login" className="text-muted underline-offset-4 hover:text-strong hover:underline">
+            Sign in
+          </Link>{" "}
+          and connect Gmail read-only — the same classifier labels your real inbox.
+        </p>
       </div>
-
-      <p className="mt-10 text-center text-xs leading-relaxed text-dim">
-        Want this on your own mail?{" "}
-        <Link href="/login" className="text-muted underline-offset-4 hover:text-strong hover:underline">
-          Sign in
-        </Link>{" "}
-        and connect Gmail read-only — the same classifier labels your real inbox.
-      </p>
     </main>
   );
 }

--- a/apps/web/app/demo/page.tsx
+++ b/apps/web/app/demo/page.tsx
@@ -42,7 +42,18 @@ export const dynamic = "force-dynamic";
  * The decision trace stays as the demo's own second act — it is the showcase
  * the landing links to, not a dashboard component.
  */
-export default function DemoPage() {
+export default async function DemoPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ pipeline?: string }>;
+}) {
+  // `?pipeline=early` renders the same twin over the early-search projection —
+  // every row at `applied`, the measured shape of the real production account
+  // (29 live rows, one stage). The healthy seed spread literally cannot show
+  // the distribution the worklist redesign exists for, so the skewed case gets
+  // its own reviewable, testable URL.
+  const { pipeline } = await searchParams;
+  const early = pipeline === "early";
   return (
     <main data-theme="dark" className="min-h-screen w-full bg-background text-foreground">
       <div className="mx-auto w-full max-w-6xl px-6 pb-16">
@@ -69,7 +80,7 @@ export default function DemoPage() {
 
         {/* --- the dashboard, verbatim ------------------------------------ */}
         <div className="mt-8">
-          <DemoDashboard />
+          <DemoDashboard pipeline={early ? "early" : "seed"} />
         </div>
 
         {/* --- the decision trace ----------------------------------------- */}

--- a/apps/web/app/demo/settings/page.tsx
+++ b/apps/web/app/demo/settings/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { Logo } from "@/components/brand/Logo";
+import { AccountSection } from "@/components/settings/AccountSection";
+import { AppearanceSection } from "@/components/settings/AppearanceSection";
+import { ClassificationSection } from "@/components/settings/ClassificationSection";
+import { DataSection } from "@/components/settings/DataSection";
+import { GmailConnectionCard } from "@/components/settings/GmailConnectionCard";
+import { NotificationsSection } from "@/components/settings/NotificationsSection";
+import { ProfileSection } from "@/components/settings/ProfileSection";
+import { SettingsNav } from "@/components/settings/SettingsNav";
+import { DEFAULT_GATE_PREFERENCE } from "@/lib/dashboard/model";
+import type { GmailStatusResult } from "@/lib/gmail/server";
+
+export const metadata: Metadata = {
+  title: "Settings demo",
+  description: "The Applied settings surface on fixture data. Nothing is saved, read, or deleted.",
+};
+
+/**
+ * The Settings twin — the REAL settings sections over the simulated settings
+ * transport (`lib/settings/transport.ts`), the same contract `/demo` holds
+ * for the dashboard: only the transport is simulated, every control runs its
+ * genuine state machine. It exists because `/settings` needs a session that
+ * neither CI nor a local checkout has, so without this page the entire
+ * settings surface had no executing e2e coverage and nothing reviewable.
+ *
+ * Deliberately NOT theme-forced (unlike `/demo`, which pins dark): the
+ * Appearance switch here is the real mechanism writing the real `data-theme`,
+ * and demonstrating it is half this page's value.
+ *
+ * Per-request rendering for the same reason as `/demo`: the fixture
+ * `last_sync_at` below is relative to now, and a prerendered copy would age
+ * ("last synced 34 minutes ago" is only honest if the page is rendered when
+ * you ask for it).
+ */
+export const dynamic = "force-dynamic";
+
+function fixtureGmail(): GmailStatusResult {
+  return {
+    kind: "ok",
+    status: {
+      configured: true,
+      connected: true,
+      email: "demo@applied.example",
+      last_sync_at: new Date(Date.now() - 34 * 60 * 1000).toISOString(),
+      has_cursor: true,
+      sync_status: "idle",
+      sync_error: null,
+    },
+  };
+}
+
+export default function DemoSettingsPage() {
+  return (
+    <main className="min-h-screen w-full bg-background text-foreground">
+      <div className="mx-auto w-full max-w-6xl px-6 pb-16">
+        <header className="flex min-h-14 flex-wrap items-center justify-between gap-y-2 border-b border-line-soft py-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/"
+              className="brand-logo-link inline-flex min-h-11 items-center text-strong"
+              aria-label="Applied — go to landing"
+            >
+              <Logo className="h-6 w-auto" />
+            </Link>
+            <span className="whitespace-nowrap rounded-full border border-line px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-widest text-muted">
+              demo · fixture account · nothing is saved
+            </span>
+          </div>
+          <Link
+            href="/demo"
+            className="inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest text-muted transition-colors hover:text-strong"
+          >
+            ← dashboard demo
+          </Link>
+        </header>
+
+        <section className="mt-8 space-y-6">
+          <header>
+            <h1 className="text-2xl font-semibold tracking-tight text-strong">Settings</h1>
+            <p className="mt-1 text-[13px] text-muted">
+              Your account, appearance, mail, and data — on a simulated account.
+            </p>
+          </header>
+
+          <div className="lg:grid lg:grid-cols-[10rem_minmax(0,48rem)] lg:gap-8">
+            <SettingsNav />
+            <div className="max-w-3xl space-y-6 lg:max-w-none">
+              <ProfileSection
+                mode="demo"
+                initialName="Sam Fixture"
+                email="demo@applied.example"
+                memberSince="March 3, 2026"
+              />
+              {/* The one live control on this page — Appearance is device-local
+                  by design, so the demo IS the product here. */}
+              <AppearanceSection />
+              <GmailConnectionCard result={fixtureGmail()} demo />
+              <NotificationsSection mode="demo" initial={{ weekly: true, reviewAlerts: true }} />
+              <ClassificationSection mode="demo" initialGate={DEFAULT_GATE_PREFERENCE} />
+              <DataSection mode="demo" />
+              <AccountSection mode="demo" email="demo@applied.example" />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/demo/settings/page.tsx
+++ b/apps/web/app/demo/settings/page.tsx
@@ -26,9 +26,15 @@ export const metadata: Metadata = {
  * neither CI nor a local checkout has, so without this page the entire
  * settings surface had no executing e2e coverage and nothing reviewable.
  *
- * Deliberately NOT theme-forced (unlike `/demo`, which pins dark): the
- * Appearance switch here is the real mechanism writing the real `data-theme`,
- * and demonstrating it is half this page's value.
+ * Theme-forced dark, like the rest of `/demo`. It used to honour the visitor's
+ * saved theme so the Appearance switch below could be seen working — but the
+ * demo is one journey, and `/demo` and `/` pin dark deliberately (the always-
+ * dark product narrative, documented at globals.css `[data-theme="dark"]`), so
+ * a light-theme visitor watched the whole page flip as they moved between the
+ * board and settings. The family is one ground now, and the Appearance control
+ * carries `mode="demo"`, which says plainly that the preview will not change
+ * colour. The switch is still the real mechanism writing the real
+ * `data-theme` — what it stops doing is pretending this page is the proof.
  *
  * Per-request rendering for the same reason as `/demo`: the fixture
  * `last_sync_at` below is relative to now, and a prerendered copy would age
@@ -54,7 +60,7 @@ function fixtureGmail(): GmailStatusResult {
 
 export default function DemoSettingsPage() {
   return (
-    <main className="min-h-screen w-full bg-background text-foreground">
+    <main data-theme="dark" className="min-h-screen w-full bg-background text-foreground">
       <div className="mx-auto w-full max-w-6xl px-6 pb-16">
         <header className="flex min-h-14 flex-wrap items-center justify-between gap-y-2 border-b border-line-soft py-2">
           <div className="flex flex-wrap items-center gap-3">
@@ -94,9 +100,11 @@ export default function DemoSettingsPage() {
                 email="demo@applied.example"
                 memberSince="March 3, 2026"
               />
-              {/* The one live control on this page — Appearance is device-local
-                  by design, so the demo IS the product here. */}
-              <AppearanceSection />
+              {/* Appearance is device-local by design, so the demo IS the
+                  product here — but this page is pinned dark with the rest of
+                  the demo, and `mode="demo"` is what says so on the control
+                  instead of leaving it looking inert. */}
+              <AppearanceSection mode="demo" />
               <GmailConnectionCard result={fixtureGmail()} demo />
               <NotificationsSection mode="demo" initial={{ weekly: true, reviewAlerts: true }} />
               <ClassificationSection mode="demo" initialGate={DEFAULT_GATE_PREFERENCE} />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -73,9 +73,12 @@
 
 /* Explicit dark re-assertion. `:root` already defaults to dark, but that only
  * covers the top of the cascade — a subtree that forces `data-theme="dark"`
- * on itself (the landing page, `/demo`: both are the product's own
- * always-dark narrative, regardless of the visitor's saved Appearance
- * setting) sits *inside* `<html>`, and `[data-theme="light"]` below is a bare
+ * on itself (the landing page and the whole `/demo` family — `/demo`,
+ * `/demo/settings`, `/demo/inbox`: all of it is the product's own always-dark
+ * narrative, regardless of the visitor's saved Appearance setting, and a demo
+ * that changed ground halfway through the journey was worse than one that
+ * ignores the setting honestly) sits *inside* `<html>`, and
+ * `[data-theme="light"]` below is a bare
  * attribute selector with no ancestor scoping, so it happily overrides `:root`
  * from `<html data-theme="light">` right through a nested `data-theme="dark"`
  * element with nothing to stop it. Mirroring `[data-theme="light"]` with an

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -60,6 +60,10 @@
    * Re-measured: 9.25:1 / APCA Lc 63.5 solid on surface-2; the 55% card-border
    * wash lands at 3.62:1 (vs 2.56:1 for the --text-muted accent it replaced). */
   --stage-applied: #b3b9c2;
+  /* The keyboard focus indicator, in one place — see the block below the type
+   * helpers for what it replaced and how it was measured. 12.52 / 12.05 /
+   * 11.56:1 on background / surface / surface-2. */
+  --focus-ring: #c9ced6;
   /* Data-viz sub-palette — the three classifier layers get their own
    * categorical hues so the pipeline reads as data, not just mono text. */
   --viz-rules: #38bdf8; /* layer 1 — regex rules, instant */
@@ -96,6 +100,7 @@
   --red: #f87171;
   --red-ink: #fca5a5;
   --stage-applied: #b3b9c2;
+  --focus-ring: #c9ced6;
   --viz-rules: #38bdf8;
   --viz-embeddings: #a78bfa;
   --viz-setfit: #34d399;
@@ -147,6 +152,11 @@
   /* Ink counterpart of the dark ramp's #b3b9c2 — measured 9.93:1 on white,
    * 9.03:1 on the paper surface-2 (APCA Lc 93 / 87). */
   --stage-applied: #3f434b;
+  /* Ink focus ring. The dark theme's #c9ced6 measures 1.51 / 1.58 / 1.44:1 on
+   * these paper grounds — a ring declared in white is invisible here, which is
+   * why the token is re-grounded rather than shared. Measured 9.51 / 9.93 /
+   * 9.03:1 on background / surface / surface-2. */
+  --focus-ring: #3f434b;
   --viz-rules: #0284c7;
   --viz-embeddings: #7c3aed;
   --viz-setfit: #059669;
@@ -221,6 +231,47 @@ body {
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Keyboard focus indicator — one definition for the whole app.
+ *
+ * It used to be a per-component decision: `focus-visible:outline-none` plus a
+ * 1px Tailwind ring in `--line-strong`. Measured in Chrome, that ring was
+ * 1.83:1 on `--surface` and 1.87:1 on `--surface-2` in dark, 1.78:1 on paper —
+ * under the 3:1 floor WCAG 2.2 SC 1.4.11 sets for a non-text indicator. The
+ * one piece of UI a keyboard-only user cannot work without was the faintest
+ * thing on the page. Native controls had it worse: a <select> that sets
+ * `outline-none` and answers focus by moving its border from 6% to 20% white
+ * (the worklist's stage picker) measured 1.16:1 — no indicator in practice.
+ * (WCAG ratios, not APCA: the APCA pass on this file tuned TEXT, and Lc has no
+ * threshold for a 2px rule of colour.)
+ *
+ * So the indicator stops being per-component. `--focus-ring` is measured
+ * against every ground it can land on — the numbers are with each theme's
+ * token — and the 1px offset puts the page's own ground between the ring and a
+ * light control (`bg-strong` buttons), which is what an offset ring is for.
+ *
+ * Unlayered on purpose. `focus-visible:outline-none` is a utility, and an
+ * unlayered rule outranks any layered one whatever the specificity — the same
+ * cascade fact `.brand-logo-link`'s `display` relies on (see the note in
+ * TopBar). That is what lets ONE rule reach every control, including files
+ * this change does not touch. The per-component `ring-line-strong` rings are
+ * still declared in those files; they now sit inside this outline rather than
+ * standing in for it.
+ * ------------------------------------------------------------------------- */
+:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* The one deliberate variation: primary navigation, the brand mark and the
+ * beta actions have always focused in classifier cyan. They re-point the token
+ * instead of restating a ring, so there is still exactly one indicator. */
+@layer components {
+  .focus-accent {
+    --focus-ring: var(--viz-rules);
   }
 }
 
@@ -412,10 +463,10 @@ body {
 }
 
 /* ---- signature ending choreography (full-bleed bottom band) -------------- */
-/* The whole band replays on click; focus ring inset so it stays visible on
- * the full-bleed edge. */
+/* The whole band replays on click; the shared focus ring, inset so it stays
+ * visible on the full-bleed edge (an outward offset would be cropped there). */
 .sig-band:focus-visible {
-  outline: 2px solid var(--line-strong);
+  outline: 2px solid var(--focus-ring);
   outline-offset: -2px;
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -926,36 +926,24 @@ body {
 }
 
 /* ---------------------------------------------------------------------------
- * Board column widths (components/dashboard/PipelineBoard.tsx). At desktop,
- * space follows content: the component writes per-column tracks into
- * `--board-cols` (populated 3fr, empty a compressed readable floor), because
- * a real search is one heavy column and three near-empty ones — an even
- * four-way split starves the only column that holds cards. Below `lg` the
- * Tailwind sm:grid-cols-2 flow applies and this rule is inert.
+ * Worklist drag-and-drop (components/dashboard/PipelineBoard.tsx). The dragged
+ * row dims in place; a stage being hovered as a drop target — a spine stage or
+ * a stage group in the list — raises its border and washes its surface. Pure
+ * state styling — no keyframes, so there is nothing to collapse under reduced
+ * motion.
  * ------------------------------------------------------------------------- */
-@media (min-width: 64rem) {
-  .board-grid {
-    grid-template-columns: var(--board-cols, repeat(4, minmax(0, 1fr)));
-  }
-}
-
-/* ---------------------------------------------------------------------------
- * Board drag-and-drop (components/dashboard/PipelineBoard.tsx). The dragged
- * card dims in place; a column being hovered as a drop target raises its
- * border and washes its surface. Pure state styling — no keyframes, so there
- * is nothing to collapse under reduced motion.
- * ------------------------------------------------------------------------- */
-.board-col[data-drop="true"] {
+.board-col[data-drop="true"],
+.spine-stage[data-drop="true"] {
   border-color: var(--line-strong);
   background: var(--surface-2);
 }
-.board-card[data-dragging="true"] {
+.board-row[data-dragging="true"] {
   opacity: 0.4;
 }
-.board-card[draggable="true"] {
+.board-row[draggable="true"] {
   cursor: grab;
 }
-.board-card[draggable="true"]:active {
+.board-row[draggable="true"]:active {
   cursor: grabbing;
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1007,6 +1007,18 @@ body {
 .board-row[data-dragging="true"] {
   opacity: 0.4;
 }
+/* A COLLAPSED employer set (components/dashboard/EmployerSetRow.tsx) wears a
+ * small deck: two card edges peek out beneath it, each narrower and fainter
+ * than the last, so "several applications live here" reads before any copy
+ * does. Solid box-shadows in the hairline tokens — both themes get it from the
+ * cascade, it follows the card's own radius, and it takes no layout space, so
+ * a set header and a single row keep identical geometry. The class comes off
+ * when the set is open: the member rows are the deck then. */
+.board-stack {
+  box-shadow:
+    0 3px 0 -1px var(--line-strong),
+    0 6px 0 -2px var(--line);
+}
 .board-row[draggable="true"] {
   cursor: grab;
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -271,11 +271,24 @@ body {
 
 /* The one deliberate variation: primary navigation, the brand mark and the
  * beta actions have always focused in classifier cyan. They re-point the token
- * instead of restating a ring, so there is still exactly one indicator. */
+ * instead of restating a ring, so there is still exactly one indicator. Layered
+ * safely, because it only sets the token the unlayered rule above reads. */
 @layer components {
   .focus-accent {
     --focus-ring: var(--viz-rules);
   }
+}
+
+/* Rows that run the full width of a card that clips. The landing inbox scene
+ * and the decision trace both sit in `overflow-hidden` cards, so an outward
+ * offset is cropped: measured, the landing row lost its left, right and bottom
+ * edges and showed a single horizontal line, and the trace row lost both
+ * sides. Drawing the ring inside their own box keeps all four edges, and these
+ * rows are wide enough that 2px in reads as a ring rather than a border. It has
+ * to be unlayered — a `-outline-offset-2` utility would be a layered rule, and
+ * the offset above outranks it. */
+.focus-inset:focus-visible {
+  outline-offset: -2px;
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/components/beta/BetaBanner.tsx
+++ b/apps/web/components/beta/BetaBanner.tsx
@@ -123,7 +123,7 @@ export function BetaBanner() {
             <div className="mt-3 flex flex-col gap-2">
               <a
                 href={BETA_MAILTO}
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-strong px-3 py-2 text-sm font-medium text-background outline-none transition-transform hover:-translate-y-px focus-visible:ring-2 focus-visible:ring-viz-rules"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-strong px-3 py-2 text-sm font-medium text-background outline-none transition-transform hover:-translate-y-px focus-accent"
               >
                 <span aria-hidden>✉</span>
                 {BETA_CTA_LABEL}
@@ -131,7 +131,7 @@ export function BetaBanner() {
               <Link
                 href={SAMPLE_INBOX_HREF}
                 onClick={() => setOpen(false)}
-                className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-line px-3 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-visible:ring-2 focus-visible:ring-viz-rules"
+                className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-line px-3 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-accent"
               >
                 {BETA_SAMPLE_LABEL}
                 <span aria-hidden>→</span>
@@ -150,7 +150,7 @@ export function BetaBanner() {
             aria-expanded={open}
             aria-controls="beta-banner-panel"
             onClick={() => setOpen((v) => !v)}
-            className="flex items-center gap-2 rounded-full py-0.5 pr-1 text-xs outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+            className="flex items-center gap-2 rounded-full py-0.5 pr-1 text-xs focus-accent"
           >
             <span className="beta-dot" aria-hidden />
             <span className="font-mono font-semibold uppercase tracking-widest text-strong">Beta</span>
@@ -163,7 +163,7 @@ export function BetaBanner() {
             type="button"
             onClick={dismiss}
             aria-label="Dismiss beta notice"
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-dim outline-none transition-colors hover:bg-surface-2 hover:text-strong focus-visible:ring-2 focus-visible:ring-viz-rules"
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-dim outline-none transition-colors hover:bg-surface-2 hover:text-strong focus-accent"
           >
             <span aria-hidden className="text-sm leading-none">
               ×

--- a/apps/web/components/beta/BetaCard.tsx
+++ b/apps/web/components/beta/BetaCard.tsx
@@ -52,21 +52,21 @@ export function BetaCard({ className = "" }: { className?: string }) {
           <div className="mt-4 flex flex-wrap items-center gap-3">
             <a
               href={BETA_MAILTO}
-              className="beta-cta inline-flex items-center gap-2 rounded-lg bg-strong px-4 py-2 text-sm font-medium text-background outline-none transition-transform hover:-translate-y-px focus-visible:ring-2 focus-visible:ring-viz-rules"
+              className="beta-cta inline-flex items-center gap-2 rounded-lg bg-strong px-4 py-2 text-sm font-medium text-background outline-none transition-transform hover:-translate-y-px focus-accent"
             >
               <span aria-hidden>✉</span>
               {BETA_CTA_LABEL}
             </a>
             <Link
               href={IMPORT_HREF}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-visible:ring-2 focus-visible:ring-viz-rules"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-accent"
             >
               {BETA_IMPORT_LABEL}
               <span aria-hidden>→</span>
             </Link>
             <Link
               href={SAMPLE_INBOX_HREF}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-visible:ring-2 focus-visible:ring-viz-rules"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-line px-4 py-2 text-sm text-foreground outline-none transition-colors hover:border-line-strong hover:text-strong focus-accent"
             >
               {BETA_SAMPLE_LABEL}
               <span aria-hidden>→</span>

--- a/apps/web/components/dashboard/ApplicationRow.tsx
+++ b/apps/web/components/dashboard/ApplicationRow.tsx
@@ -31,6 +31,12 @@ import { statusOptions, statusSelectValue } from "@/lib/dashboard/status";
 import { type Application, STAGES, stageOf } from "@/lib/dashboard/summary";
 import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transport";
 
+/** The honest slot for the 8-in-29 case: a row whose mail never named a role
+ *  says so, in the same words the detail sheet and the review picker already
+ *  use — instead of rendering shorter than its neighbours and making the
+ *  whole list ragged. */
+export const NO_ROLE_LABEL = "role not captured";
+
 /**
  * The stage control — label and `<select>` together — behind `memo`, and that
  * memo is load-bearing rather than a performance nicety.
@@ -39,7 +45,7 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  * that touches its fiber: `commitUpdate` → `updateProperties` → `updateOptions`
  * re-selects the option matching the `value` prop, and React 19 reads that prop
  * unconditionally — there is no "did value change?" guard on that path. So any
- * re-render of the surrounding card, for any reason, re-writes the control's
+ * re-render of the surrounding row, for any reason, re-writes the control's
  * DOM value.
  *
  * That is invisible until a re-render lands between the moment the browser sets
@@ -51,15 +57,15 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  * silently discarded: no request, no error, no visible failure.
  *
  * That is exactly what the reader's-day swap made reproducible. `useLocalToday`
- * re-renders every card once, tens of milliseconds after hydration (see
+ * re-renders every row once, tens of milliseconds after hydration (see
  * `useLocalToday.ts`), and a stage change chosen in that window vanished.
- * Isolating the control means a card re-render that changes nothing ABOUT THE
+ * Isolating the control means a row re-render that changes nothing ABOUT THE
  * CONTROL — a re-dating, a sibling's move, a filter — bails out here, the
  * `<select>` fiber is never committed, and nothing can overwrite a choice in
  * flight.
  *
  * `memo` only bails out on shallow-equal props, so `onChange` has to be
- * referentially stable (`useCallback` in the card) — a fresh closure per render
+ * referentially stable (`useCallback` in the row) — a fresh closure per render
  * defeats the whole thing. Nothing but the row's identity, its shown stage and
  * its in-flight state may be passed in; `today` deliberately is NOT, because
  * the day changing is precisely the re-render this must survive.
@@ -108,17 +114,26 @@ const StageSelect = memo(function StageSelect({
  * One pipeline row — clickable, correctable, and no longer able to lose an
  * application to a single click.
  *
+ * This is the worklist form of what used to be `ApplicationCard`: the same
+ * state machine over a full-width, fixed-skeleton line. Everything a row can
+ * say lives on ONE line — company · role slot on the left, then the meta
+ * cluster (deadline, filed stamp, stage control, Gmail link, actions) pinned
+ * right — so a row missing its role renders exactly as tall as one that has
+ * it (the raggedness complaint was 8 of 29 live rows with no role line). The
+ * role slot never collapses: an absent role prints {@link NO_ROLE_LABEL} in
+ * the dim rank, the same words the detail sheet uses.
+ *
  * Three behaviours here are load-bearing:
  *
  *  1. **Removal is recoverable.** "Not an application" no longer fires
- *     anything: the card becomes a tombstone with an Undo for
+ *     anything: the row becomes a tombstone with an Undo for
  *     `UNDO_WINDOW_SECONDS`, and only when that expires does it POST the
  *     backend's *soft* dismiss (row + emails stay on disk, restorable).
  *     Undo is a cancelled timer — nothing was sent, so there is nothing to
  *     reverse and no training example written and then written over. The hard
  *     `DELETE` — which erases the row and its linked mail, and which no layer
  *     can undo — is a separate item behind an inline confirm.
- *  2. **The stage control is optimistic.** The chosen stage (and the card's
+ *  2. **The stage control is optimistic.** The chosen stage (and the row's
  *     stage accent) change on click instead of after the round trip, with an
  *     in-flight state on the control; a failure rolls the value back visibly
  *     and says what it tried, what the row still is, and why.
@@ -131,7 +146,7 @@ const StageSelect = memo(function StageSelect({
  * in-memory one so this exact component runs on fixtures) and, on success,
  * `router.refresh()` re-renders the server board from fresh data.
  */
-export function ApplicationCard({
+export function ApplicationRow({
   app,
   columnLabel,
   today = todayISO(),
@@ -144,26 +159,26 @@ export function ApplicationCard({
   transport = liveBoardTransport,
 }: {
   app: Application;
-  /** The heading of the column this card is rendered in (see `board.ts`). */
+  /** The heading of the stage group this row is rendered in (see `board.ts`). */
   columnLabel?: string;
   /** Today's calendar day — the board threads one read of the clock down so
-   *  every card's age tag and deadline state derive from the same instant
+   *  every row's age tag and deadline state derive from the same instant
    *  (`useLocalToday`: UTC for the server pass, the reader's own day once
-   *  mounted). The UTC default only stands in for a caller that renders a card
+   *  mounted). The UTC default only stands in for a caller that renders a row
    *  outside the board; the board always passes its own. */
   today?: string;
-  /** Opens the detail sheet (the mail behind this card). */
+  /** Opens the detail sheet (the mail behind this row). */
   onOpenDetail?: (app: Application) => void;
   /**
-   * How many OTHER applications share this company. A card is an application,
+   * How many OTHER applications share this company. A row is an application,
    * not a company — one employer can hold several — so this is a light
    * affordance ("+3 at Amazon"), never a merge. The board passes 0 while its
    * active filter already IS this company.
    */
   sameCompanyCount?: number;
-  /** Filters the board to this card's company (opens the set view). */
+  /** Filters the board to this row's company (opens the set view). */
   onFilterCompany?: (company: string) => void;
-  /** True while this card is the one being dragged. */
+  /** True while this row is the one being dragged. */
   dragging?: boolean;
   onDragStart?: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd?: () => void;
@@ -190,8 +205,8 @@ export function ApplicationCard({
 
   // Server data caught up (to our value or to a different one): drop the
   // overlay and show the truth. Both arms matter — without the second, a
-  // backend that answered with something else would leave the card asserting a
-  // stage the row is not at, forever.
+  // backend that answered with something else would leave the row asserting a
+  // stage it is not at, forever.
   if (optimistic && (app.status === optimistic.to || app.status !== optimistic.from)) {
     setOptimistic(null);
   }
@@ -220,7 +235,7 @@ export function ApplicationCard({
       setBusy("status");
       const result = await transport.changeStatus(app.id, next);
       // Cleared on success AND on failure: the old code left `busy` latched on
-      // success, so a change that did not move the card to another column (it
+      // success, so a change that did not move the row to another group (it
       // stays mounted, and `router.refresh()` preserves client state) left the
       // control disabled and the spinner turning until a full reload.
       setBusy(null);
@@ -324,8 +339,8 @@ export function ApplicationCard({
   // --- Pending removal: the row is still here, and one click keeps it --------
   if (removalPending) {
     return (
-      <div className="rounded-lg border border-dashed border-line bg-surface-2/60 p-3">
-        <p role="status" className="text-xs leading-snug text-muted">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-dashed border-line bg-surface-2/60 px-3 py-2">
+        <p role="status" className="min-w-0 flex-1 text-xs leading-snug text-muted">
           {removalPendingMessage(app.company, secondsLeft ?? 0)}
         </p>
         <button
@@ -335,7 +350,7 @@ export function ApplicationCard({
             refocusTrigger.current = true;
             setSecondsLeft(null);
           }}
-          className="mt-2 inline-flex items-center gap-1.5 rounded border border-line px-2 py-1 text-xs text-strong transition-colors hover:border-line-strong hover:bg-surface"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded border border-line px-2 py-1 text-xs text-strong transition-colors hover:border-line-strong hover:bg-surface"
         >
           <Undo2 className="h-3.5 w-3.5" aria-hidden />
           {UNDO_LABEL}
@@ -348,7 +363,7 @@ export function ApplicationCard({
   // WHICH of the two happened — one is still on disk, the other is gone. -----
   if (removed) {
     return (
-      <div className="rounded-lg border border-dashed border-line-soft bg-surface-2/40 p-3">
+      <div className="rounded-lg border border-dashed border-line-soft bg-surface-2/40 px-3 py-2">
         <p role="status" className="text-xs text-dim">
           {removed === "deleted" ? deletedMessage(app.company) : removedMessage(app.company)}
         </p>
@@ -358,6 +373,35 @@ export function ApplicationCard({
 
   const role = app.position.trim();
 
+  const identity = (
+    <>
+      <span className="flex min-w-0 max-w-[16rem] shrink-0 items-center gap-2 text-sm font-medium text-strong">
+        <span className="truncate underline-offset-2 group-hover/row:underline">{app.company}</span>
+        {qualifier && (
+          <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
+            {qualifier}
+          </span>
+        )}
+      </span>
+      {/* The role WRAPS (two lines) instead of ellipsizing when it must: a job
+          title's discriminating part is its tail — "…, AWS Data Services -
+          2026" — which is exactly what a one-line truncate eats. At the row's
+          full-width measure this almost never fires; `title` stays the floor,
+          not the fix. An absent role prints the slot's honest placeholder so
+          the line's shape never changes. */}
+      {role ? (
+        <span
+          title={role}
+          className="line-clamp-2 min-w-0 break-words text-[13px] leading-snug text-foreground"
+        >
+          {role}
+        </span>
+      ) : (
+        <span className="text-[13px] leading-snug text-dim">{NO_ROLE_LABEL}</span>
+      )}
+    </>
+  );
+
   return (
     <div
       aria-busy={busy !== null}
@@ -365,81 +409,43 @@ export function ApplicationCard({
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       data-dragging={dragging || undefined}
-      className="board-card group/card relative rounded-lg border border-line-soft bg-surface-2 p-3 transition-colors hover:border-line-strong"
+      className="board-row group/row relative flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-1.5 transition-colors hover:border-line-strong"
       style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
     >
-      <div className="flex items-start justify-between gap-2">
-        {/* A card is an APPLICATION: company anchors it, the role discriminates
-            it (four Amazon cards must read as four different rows), and the
-            block itself opens the mail behind the card. */}
-        {onOpenDetail ? (
-          <button
-            type="button"
-            onClick={() => onOpenDetail(app)}
-            aria-label={`Open ${app.company}${role ? ` — ${role}` : ""}`}
-            className="min-w-0 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
-          >
-            <span className="flex min-w-0 items-center gap-2 text-sm font-medium text-strong">
-              <span className="truncate underline-offset-2 group-hover/card:underline">
-                {app.company}
-              </span>
-              {qualifier && (
-                <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
-                  {qualifier}
-                </span>
-              )}
-            </span>
-            {/* The role WRAPS (two lines) instead of ellipsizing: a job title's
-                discriminating part is its tail — "…, AWS Data Services - 2026"
-                — which is exactly what a one-line truncate eats. Four real
-                Amazon roles measured 244–353px against a 198px box and
-                rendered as identical text. `title` is the floor, not the fix:
-                the board must read without hovering. */}
-            {role ? (
-              <span title={role} className="line-clamp-2 break-words text-[13px] leading-snug text-foreground">
-                {role}
-              </span>
-            ) : null}
-          </button>
-        ) : (
-          <div className="min-w-0">
-            <p className="flex min-w-0 items-center gap-2 text-sm font-medium text-strong">
-              <span className="truncate">{app.company}</span>
-              {qualifier && (
-                <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
-                  {qualifier}
-                </span>
-              )}
-            </p>
-            {role ? (
-              <p title={role} className="line-clamp-2 break-words text-[13px] leading-snug text-foreground">
-                {role}
-              </p>
-            ) : null}
-          </div>
-        )}
-        <div className="flex shrink-0 items-center gap-1">
-          {busy !== null || optimistic ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin text-dim" aria-hidden />
-          ) : null}
-          <RowActionsMenu
-            label={`Row actions for ${app.company}${role ? ` — ${role}` : ""}`}
-            items={menuItems}
-            disabled={busy !== null}
-            triggerRef={triggerRef}
+      {/* A row is an APPLICATION: company anchors it, the role discriminates
+          it (four Amazon rows must read as four different lines), and the
+          block itself opens the mail behind the row. */}
+      {onOpenDetail ? (
+        <button
+          type="button"
+          onClick={() => onOpenDetail(app)}
+          aria-label={`Open ${app.company}${role ? ` — ${role}` : ""}`}
+          className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+        >
+          {identity}
+        </button>
+      ) : (
+        <div className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5">{identity}</div>
+      )}
+
+      {/* The meta cluster — every fact pinned right, in one fixed order, so
+          the eye can read a column of rows like a table. `max-w-full` (never
+          `shrink-0`): an unshrinkable cluster refuses the wrap and pushes the
+          row past a phone's viewport instead of taking its own line. */}
+      <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-x-2 gap-y-1">
+        {sameCompanyCount > 0 && onFilterCompany ? (
+          <SameCompanyChip
+            company={app.company}
+            count={sameCompanyCount}
+            onFilter={onFilterCompany}
           />
-        </div>
-      </div>
-
-      {sameCompanyCount > 0 && onFilterCompany ? (
-        <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
-      ) : null}
-
-      {/* Renders nothing unless the row carries a due_at — the tag never
-          prompts, and never guesses (see DeadlineTag). */}
-      <DeadlineTag dueAt={app.due_at} today={today} />
-
-      <div className="mt-2 flex items-center justify-between gap-2">
+        ) : null}
+        {/* Renders nothing unless the row carries a due_at — the tag never
+            prompts, and never guesses (see DeadlineTag). */}
+        <DeadlineTag dueAt={app.due_at} today={today} />
+        {busy !== null || optimistic ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-dim motion-reduce:animate-none" aria-hidden />
+        ) : null}
         <StageSelect
           id={app.id}
           company={app.company}
@@ -449,24 +455,30 @@ export function ApplicationCard({
           onChange={onStatusChange}
         />
         <FiledStamp filed={filed} status={shownStatus} today={today} />
+        {app.url ? (
+          <a
+            href={app.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open the mail behind ${app.company} in Gmail`}
+            title="open in gmail"
+            className="grid h-6 w-6 place-items-center rounded text-dim transition-colors hover:bg-surface hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          </a>
+        ) : null}
+        <RowActionsMenu
+          label={`Row actions for ${app.company}${role ? ` — ${role}` : ""}`}
+          items={menuItems}
+          disabled={busy !== null}
+          triggerRef={triggerRef}
+        />
       </div>
 
       {busy === "status" || optimistic ? (
-        <p role="status" className="mt-1 text-[11px] text-dim">
+        <p role="status" className="basis-full text-[11px] text-dim">
           {busy === "status" ? `moving to ${shownStatus}…` : "board updating…"}
         </p>
-      ) : null}
-
-      {app.url ? (
-        <a
-          href={app.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-1.5 inline-flex items-center gap-1 text-[11px] text-dim underline-offset-2 hover:text-strong hover:underline"
-        >
-          <ExternalLink className="h-3 w-3" aria-hidden />
-          open in gmail
-        </a>
       ) : null}
 
       {/* The one action nothing can undo, so the one that asks first. Inline
@@ -482,7 +494,7 @@ export function ApplicationCard({
             setConfirmingDelete(false);
             triggerRef.current?.focus();
           }}
-          className="mt-2 rounded border border-reject/50 bg-reject/10 p-2"
+          className="basis-full rounded border border-reject/50 bg-reject/10 p-2"
         >
           {/* The stakes are wired to BOTH buttons rather than announced once as
               an alert: focus lands in here, so whichever button the user is on
@@ -518,7 +530,7 @@ export function ApplicationCard({
       {error ? (
         <p
           role="alert"
-          className="mt-2 flex items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
+          className="flex basis-full items-start gap-1.5 rounded border border-reject/50 bg-reject/10 px-2 py-1.5 text-xs leading-snug text-strong"
         >
           <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-reject-ink" aria-hidden />
           <span>{error}</span>

--- a/apps/web/components/dashboard/ApplicationRow.tsx
+++ b/apps/web/components/dashboard/ApplicationRow.tsx
@@ -98,7 +98,15 @@ const StageSelect = memo(function StageSelect({
         disabled={disabled}
         aria-busy={busy}
         onChange={(e) => onChange(e.target.value)}
-        className="max-w-[8.5rem] rounded border border-line-soft bg-surface px-1.5 py-0.5 text-[11px] text-muted outline-none transition-colors hover:border-line focus:border-line-strong disabled:opacity-50"
+        // `w-[8.5rem]`, not max-w: an intrinsic-width select is as wide as its
+        // current value, so 17 rows put the board's main control on four
+        // different x positions (a 78px spread, measured). Fixed width + a
+        // fixed-width tail after it (see the meta cluster) is what makes the
+        // selects a column. `h-6` matches the cluster's other controls (the
+        // Gmail slot, the menu trigger), so a card with a select and a card
+        // without one — the employer set header — compute the same height;
+        // the select's intrinsic height was a measured 1px taller.
+        className="h-6 w-[8.5rem] rounded border border-line-soft bg-surface px-1.5 text-[11px] text-muted outline-none transition-colors hover:border-line focus:border-line-strong disabled:opacity-50"
       >
         {statusOptions(value).map((option) => (
           <option key={option.value} value={option.value} disabled={option.disabled}>
@@ -115,13 +123,24 @@ const StageSelect = memo(function StageSelect({
  * application to a single click.
  *
  * This is the worklist form of what used to be `ApplicationCard`: the same
- * state machine over a full-width, fixed-skeleton line. Everything a row can
- * say lives on ONE line — company · role slot on the left, then the meta
- * cluster (deadline, filed stamp, stage control, Gmail link, actions) pinned
- * right — so a row missing its role renders exactly as tall as one that has
- * it (the raggedness complaint was 8 of 29 live rows with no role line). The
- * role slot never collapses: an absent role prints {@link NO_ROLE_LABEL} in
- * the dim rank, the same words the detail sheet uses.
+ * state machine over a full-width, fixed-skeleton line. At `sm` and up
+ * everything a row can say lives on ONE line — company · role slot on the
+ * left, then the meta cluster (chip, deadline, filed stamp, stage control,
+ * Gmail link, actions) pinned right — so a row missing its role renders
+ * exactly as tall as one that has it (the raggedness complaint was 8 of 29
+ * live rows with no role line). The role slot never collapses: an absent role
+ * prints {@link NO_ROLE_LABEL} in the dim rank, the same words the detail
+ * sheet uses.
+ *
+ * Below `sm` the row is an explicit stack instead of a flex-wrap accident:
+ * company + filed stamp on the first line, the role slot on the second, the
+ * controls on the third, all anchored left. The wrap-based layout put the
+ * chip/select cluster right-aligned on its own line — a dead gutter down the
+ * left of every row — and any row carrying both a chip and a "quiet Nd" tag
+ * wrapped its date onto a third line (measured: two row heights at 375px,
+ * 69px and 96px, predicted exactly by chip+quiet). The stamp now lives on the
+ * company line at phone width, so the controls line has a fixed population
+ * and rows keep one shape.
  *
  * Three behaviours here are load-bearing:
  *
@@ -151,7 +170,9 @@ export function ApplicationRow({
   columnLabel,
   today = todayISO(),
   onOpenDetail,
+  inSet = false,
   sameCompanyCount = 0,
+  sameCompanyLabel,
   onFilterCompany,
   dragging = false,
   onDragStart,
@@ -169,13 +190,22 @@ export function ApplicationRow({
   today?: string;
   /** Opens the detail sheet (the mail behind this row). */
   onOpenDetail?: (app: Application) => void;
+  /** True for a member of an employer set: the set's header already names the
+   *  company, so the row leads with its role — repeating the employer three
+   *  times under a header that says it is the duplication grouping removes.
+   *  The accessible name keeps the company; only the visible lead changes. */
+  inSet?: boolean;
   /**
    * How many OTHER applications share this company. A row is an application,
    * not a company — one employer can hold several — so this is a light
-   * affordance ("+3 at Amazon"), never a merge. The board passes 0 while its
-   * active filter already IS this company.
+   * affordance, never a merge. The board passes 0 while its active filter
+   * already IS this company, and for member rows inside an employer set
+   * (the set's header owns the affordance there).
    */
   sameCompanyCount?: number;
+  /** Stage-aware chip text ("+1 in interviewing") when the board groups by
+   *  employer; without it the chip says "+N at {company}" (search view). */
+  sameCompanyLabel?: string | null;
   /** Filters the board to this row's company (opens the set view). */
   onFilterCompany?: (company: string) => void;
   /** True while this row is the one being dragged. */
@@ -373,15 +403,49 @@ export function ApplicationRow({
 
   const role = app.position.trim();
 
-  const identity = (
+  const identity = inSet ? (
+    // Set member: the role IS the line (the header names the employer). The
+    // qualifier survives — a `closed` set's members must each say rejected /
+    // withdrawn / ghosted for themselves.
+    <span className="flex min-w-0 flex-1 items-baseline gap-2">
+      {role ? (
+        <span
+          title={role}
+          className="line-clamp-2 min-w-0 break-words text-sm leading-snug text-foreground underline-offset-2 group-hover/row:underline"
+        >
+          {role}
+        </span>
+      ) : (
+        <span className="text-sm leading-snug text-dim underline-offset-2 group-hover/row:underline">
+          {NO_ROLE_LABEL}
+        </span>
+      )}
+      {qualifier && (
+        <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
+          {qualifier}
+        </span>
+      )}
+      <span className="ml-auto shrink-0 sm:hidden">
+        <FiledStamp filed={filed} status={shownStatus} today={today} />
+      </span>
+    </span>
+  ) : (
     <>
-      <span className="flex min-w-0 max-w-[16rem] shrink-0 items-center gap-2 text-sm font-medium text-strong">
-        <span className="truncate underline-offset-2 group-hover/row:underline">{app.company}</span>
+      <span className="flex min-w-0 items-baseline gap-2 text-sm font-medium text-strong sm:max-w-[16rem] sm:shrink-0">
+        <span className="min-w-0 truncate underline-offset-2 group-hover/row:underline">
+          {app.company}
+        </span>
         {qualifier && (
           <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
             {qualifier}
           </span>
         )}
+        {/* Below `sm` the filed stamp rides the company line (pinned right),
+            which is what keeps the controls line one fixed shape — see the
+            component note. Above `sm` its twin renders in the meta cluster. */}
+        <span className="ml-auto shrink-0 font-normal sm:hidden">
+          <FiledStamp filed={filed} status={shownStatus} today={today} />
+        </span>
       </span>
       {/* The role WRAPS (two lines) instead of ellipsizing when it must: a job
           title's discriminating part is its tail — "…, AWS Data Services -
@@ -409,7 +473,7 @@ export function ApplicationRow({
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       data-dragging={dragging || undefined}
-      className="board-row group/row relative flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-1.5 transition-colors hover:border-line-strong"
+      className="board-row group/row relative flex flex-col gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3 sm:pr-1.5"
       style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
     >
       {/* A row is an APPLICATION: company anchors it, the role discriminates
@@ -420,23 +484,31 @@ export function ApplicationRow({
           type="button"
           onClick={() => onOpenDetail(app)}
           aria-label={`Open ${app.company}${role ? ` — ${role}` : ""}`}
-          className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+          className="flex min-w-0 flex-col gap-y-0.5 text-left sm:flex-1 sm:basis-56 sm:flex-row sm:items-baseline sm:gap-x-2.5"
         >
           {identity}
         </button>
       ) : (
-        <div className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5">{identity}</div>
+        <div className="flex min-w-0 flex-col gap-y-0.5 sm:flex-1 sm:basis-56 sm:flex-row sm:items-baseline sm:gap-x-2.5">
+          {identity}
+        </div>
       )}
 
-      {/* The meta cluster — every fact pinned right, in one fixed order, so
-          the eye can read a column of rows like a table. `max-w-full` (never
-          `shrink-0`): an unshrinkable cluster refuses the wrap and pushes the
-          row past a phone's viewport instead of taking its own line. */}
-      <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-x-2 gap-y-1">
+      {/* The meta cluster — every fact in one fixed order, pinned right from
+          `sm` up so the eye can read a column of rows like a table. The order
+          puts the variable-width pieces (chip, deadline, stamp) BEFORE the
+          fixed-width tail (select · Gmail slot · menu): with the tail constant,
+          every select shares one x position, which the old order — stamp and a
+          conditional link after the select — measurably broke (78px spread).
+          `max-w-full` (never `shrink-0`): an unshrinkable cluster refuses the
+          wrap and pushes the row past a phone's viewport instead of taking its
+          own line. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 sm:ml-auto sm:max-w-full sm:justify-end">
         {sameCompanyCount > 0 && onFilterCompany ? (
           <SameCompanyChip
             company={app.company}
             count={sameCompanyCount}
+            label={sameCompanyLabel ?? undefined}
             onFilter={onFilterCompany}
           />
         ) : null}
@@ -446,6 +518,9 @@ export function ApplicationRow({
         {busy !== null || optimistic ? (
           <Loader2 className="h-3.5 w-3.5 animate-spin text-dim motion-reduce:animate-none" aria-hidden />
         ) : null}
+        <span className="hidden sm:inline">
+          <FiledStamp filed={filed} status={shownStatus} today={today} />
+        </span>
         <StageSelect
           id={app.id}
           company={app.company}
@@ -454,7 +529,6 @@ export function ApplicationRow({
           busy={busy === "status"}
           onChange={onStatusChange}
         />
-        <FiledStamp filed={filed} status={shownStatus} today={today} />
         {app.url ? (
           <a
             href={app.url}
@@ -462,11 +536,17 @@ export function ApplicationRow({
             rel="noopener noreferrer"
             aria-label={`Open the mail behind ${app.company} in Gmail`}
             title="open in gmail"
-            className="grid h-6 w-6 place-items-center rounded text-dim transition-colors hover:bg-surface hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+            className="grid h-6 w-6 place-items-center rounded text-dim transition-colors hover:bg-surface hover:text-strong"
           >
             <ExternalLink className="h-3.5 w-3.5" aria-hidden />
           </a>
-        ) : null}
+        ) : (
+          // A rowed-up board needs this slot even when there is no mail to
+          // open — a hole here shifts the select column 32px on manual rows.
+          // Phone rows drop it: the controls line is left-anchored, not a
+          // column, and the space matters more.
+          <span className="hidden h-6 w-6 sm:block" aria-hidden="true" />
+        )}
         <RowActionsMenu
           label={`Row actions for ${app.company}${role ? ` — ${role}` : ""}`}
           items={menuItems}

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -107,21 +107,30 @@ export function DeadlineTag({
 }
 
 /**
- * The same-company affordance: "+N at Amazon" opens the employer's set view
- * (the board filters to the company and the `CompanyBand` names the set).
- * The accessible name stays "Show all applications at …" — the contract the
- * board's tests and muscle memory rely on. The caller suppresses it while the
- * active filter already IS this company (rendering "3 more at Amazon" inside
- * Amazon's own set view was the bug).
+ * The same-company affordance: opens the employer's set view (the board
+ * filters to the company and the `CompanyBand` names the set). The accessible
+ * name stays "Show all applications at …" — the contract the board's tests
+ * and muscle memory rely on. The caller suppresses it while the active filter
+ * already IS this company (rendering "3 more at Amazon" inside Amazon's own
+ * set view was the bug).
+ *
+ * The visible text is stage-aware when the board groups by employer: the
+ * caller passes `label` ("+1 in interviewing", built by `elsewhereLabel`) so
+ * the chip stops repeating the company name one word away from the row that
+ * already says it. Without a label (the dispersed search view) it falls back
+ * to the generic "+N at {company}".
  */
 export function SameCompanyChip({
   company,
   count,
+  label,
   onFilter,
 }: {
   company: string;
   /** How many OTHER applications share the company. */
   count: number;
+  /** Stage-aware visible text; the aria contract above is unaffected. */
+  label?: string;
   onFilter: (company: string) => void;
 }) {
   return (
@@ -129,9 +138,10 @@ export function SameCompanyChip({
       type="button"
       onClick={() => onFilter(company)}
       aria-label={`Show all applications at ${company}`}
-      className="inline-flex items-center gap-1 rounded border border-line-soft px-1.5 py-0.5 text-[11px] font-medium text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+      className="inline-flex items-center gap-1 rounded border border-line-soft px-1.5 py-0.5 text-[11px] font-medium text-muted transition-colors hover:border-line-strong hover:text-strong"
     >
-      <Layers className="h-3 w-3" aria-hidden />+{count} at {company}
+      <Layers className="h-3 w-3" aria-hidden />
+      {label ?? `+${count} at ${company}`}
     </button>
   );
 }

--- a/apps/web/components/dashboard/CardMeta.tsx
+++ b/apps/web/components/dashboard/CardMeta.tsx
@@ -8,9 +8,11 @@ import { dueInfo, duePhrase, type DueState } from "@/lib/dashboard/deadline";
 import { stageOf } from "@/lib/dashboard/summary";
 
 /**
- * The small shared pieces of a board card's anatomy, used by both the
- * interactive `ApplicationCard` and the read-only demo/sample card so the two
- * can never drift apart visually.
+ * The small shared pieces of a worklist row's anatomy, used by both the
+ * interactive `ApplicationRow` and the read-only demo/sample row so the two
+ * can never drift apart visually. Every piece is inline (no top margins):
+ * the row's meta cluster owns the spacing, so a tag can never push a row
+ * taller than its neighbours.
  */
 
 /**
@@ -91,7 +93,7 @@ export function DeadlineTag({
       data-testid="deadline-tag"
       data-due-state={due.state}
       title={`deadline ${longDate(dueAt)}`}
-      className={`tabular mt-2 inline-flex items-center gap-1.5 rounded border px-1.5 py-0.5 font-mono text-[10px] leading-snug ${DUE_TAG_CLASS[due.state]}`}
+      className={`tabular inline-flex items-center gap-1.5 rounded border px-1.5 py-0.5 font-mono text-[10px] leading-snug ${DUE_TAG_CLASS[due.state]}`}
     >
       <CalendarClock
         className={`h-3 w-3 shrink-0 ${due.state === "overdue" ? "text-reject-ink" : ""}`}
@@ -127,7 +129,7 @@ export function SameCompanyChip({
       type="button"
       onClick={() => onFilter(company)}
       aria-label={`Show all applications at ${company}`}
-      className="mt-1.5 inline-flex items-center gap-1 rounded border border-line-soft px-1.5 py-0.5 text-[11px] font-medium text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+      className="inline-flex items-center gap-1 rounded border border-line-soft px-1.5 py-0.5 text-[11px] font-medium text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
     >
       <Layers className="h-3 w-3" aria-hidden />+{count} at {company}
     </button>

--- a/apps/web/components/dashboard/CompanyBand.tsx
+++ b/apps/web/components/dashboard/CompanyBand.tsx
@@ -3,56 +3,47 @@
 import { Layers, X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
-import { filedAt, shortDate } from "@/lib/dashboard/dates";
-import { STAGES, stageOf, type Application } from "@/lib/dashboard/summary";
-
 /**
- * The employer-as-a-set header. When the board is filtered to one company,
- * this band names the set the cards below now form: how many applications the
- * employer holds, how they sit across the stages, and the span they were filed
- * over. Four Amazon applications stop being four unrelated cards — the board
- * gathers them (the cards glide together via the shared layout animation) and
- * this band states what the set is.
+ * The board's filter state, said once: *filtered to {company}*, plus the
+ * control that undoes it. A state indicator, not a header — deliberately
+ * quieter than the cards underneath it, and one line.
  *
- * Facts are computed from the company's rows ON THE BOARD, never the
- * search-narrowed subset — so the band keeps describing the employer while a
- * search narrows what is visible. It does NOT claim to describe the employer's
- * whole history: the signed-in board is one bounded page, and when that page
- * is a slice of a larger account `partial` makes the band say which rows it
- * counted rather than implying an older application never existed. The clear
- * control carries the same accessible name the old filter chip did ("Stop
- * filtering by …"), so the affordance's contract is unchanged.
+ * It used to be a header, and it restated three things the screen already
+ * showed: the employer's application count, the spread across stages, and the
+ * span they were filed over. You arrive here by clicking "+3 at Amazon" and
+ * land on four cards you can count at a glance; every card states its own
+ * stage and its own filed date; the spine states the distribution. So the band
+ * was a second rendering of numbers already on screen — the exact defect this
+ * dashboard has already removed twice, when the stat tiles, the classifier
+ * strip, the distribution bars and the recent-activity feed all went (see the
+ * page's own doc comment — "Nothing on the page restates either" — and the
+ * `metrics-poster surfaces stay dead` e2e test that keeps them gone).
+ *
+ * Treat that as the rule for anything added here: if a number belongs in this
+ * band, check first whether the cards or the spine are already saying it.
+ * They usually are.
+ *
+ * Two things are NOT redundant and must survive:
+ *   - The clear control, whose accessible name stays `Stop filtering by …`.
+ *     That string is the affordance's contract — the chip, the specs and
+ *     muscle memory all share it.
+ *   - `partial`. The signed-in board is ONE bounded page of a possibly larger
+ *     account, so a filtered view of it is a slice of a slice. Without the
+ *     caveat, an employer's set silently implies an older application never
+ *     existed. It says only that — the board's own `scopeNote` already states
+ *     which rows are loaded, so this does not restate the numbers either.
  */
 export function CompanyBand({
   company,
-  apps,
-  statusOf,
   partial = false,
   onClear,
 }: {
   company: string;
-  /** This company's rows as loaded on the board — not narrowed by search. */
-  apps: Application[];
-  /** Status resolver — the board passes its optimistic-overlay-aware one. */
-  statusOf: (app: Application) => string;
-  /** The board itself is truncated, so these facts cover the loaded rows only. */
+  /** The board itself is truncated, so this employer's set is loaded rows only. */
   partial?: boolean;
   onClear: () => void;
 }) {
   const reduceMotion = useReducedMotion();
-
-  const byStage = STAGES.map((stage) => ({
-    stage,
-    count: apps.filter((app) => stageOf(statusOf(app)) === stage.key).length,
-  })).filter(({ count }) => count > 0);
-
-  const filedDates = apps.map((app) => filedAt(app)).sort();
-  const earliest = filedDates[0];
-  const latest = filedDates[filedDates.length - 1];
-  const span =
-    apps.length > 1 && shortDate(earliest) !== shortDate(latest)
-      ? `filed ${shortDate(earliest)} – ${shortDate(latest)}`
-      : `filed ${shortDate(latest)}`;
 
   return (
     <motion.section
@@ -61,34 +52,23 @@ export function CompanyBand({
       initial={reduceMotion ? false : { opacity: 0, y: -4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
-      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-line-strong bg-surface px-4 py-3"
+      className="flex flex-wrap items-center gap-x-2.5 gap-y-1 rounded-lg border border-line-soft bg-surface-2/60 px-3 py-1.5 text-sm"
     >
-      <Layers className="h-4 w-4 shrink-0 text-muted" aria-hidden />
-      <div className="min-w-0">
-        <p className="truncate text-base font-medium leading-tight text-strong">{company}</p>
-        <p className="tabular text-xs text-dim">
-          {apps.length} application{apps.length === 1 ? "" : "s"} · {span}
-          {partial ? " · counted from the rows loaded on this board" : ""}
-        </p>
-      </div>
-      <ul className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1">
-        {byStage.map(({ stage, count }) => (
-          <li key={stage.key} className="flex items-center gap-1.5 text-xs">
-            <span
-              aria-hidden="true"
-              className="h-1.5 w-1.5 rounded-full"
-              style={{ background: stage.color }}
-            />
-            <span className="text-muted">{stage.label}</span>
-            <span className="tabular font-mono text-[11px] text-strong">{count}</span>
-          </li>
-        ))}
-      </ul>
+      <Layers className="h-3.5 w-3.5 shrink-0 text-dim" aria-hidden />
+      {/* Siblings, not a wrapping paragraph: the company name is then the one
+          element whose text IS the company, which is how the specs find it. */}
+      <span className="shrink-0 text-muted">filtered to</span>
+      <span className="min-w-0 truncate font-medium text-strong">{company}</span>
+      {partial ? (
+        <span className="min-w-0 text-xs text-dim">
+          · this employer may hold rows this board has not loaded
+        </span>
+      ) : null}
       <button
         type="button"
         onClick={onClear}
         aria-label={`Stop filtering by ${company}`}
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-line px-3 py-1 text-xs font-medium text-strong transition-colors hover:border-line-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+        className="ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-full border border-line px-2.5 py-0.5 text-xs font-medium text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
       >
         clear
         <X className="h-3 w-3" aria-hidden />

--- a/apps/web/components/dashboard/EmployerSetRow.tsx
+++ b/apps/web/components/dashboard/EmployerSetRow.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import { useId, type ReactNode } from "react";
+
+import { DeadlineTag, SameCompanyChip } from "@/components/dashboard/CardMeta";
+import { QUIET_AFTER_DAYS, daysBetween } from "@/lib/dashboard/age";
+import { filedAt, shortDate } from "@/lib/dashboard/dates";
+import type { BoardColumn } from "@/lib/dashboard/board";
+import type { Application } from "@/lib/dashboard/summary";
+import { cn } from "@/lib/utils";
+
+/**
+ * One employer's applications within one stage, folded into a single card
+ * that opens inline — the answer to "four cards all saying Amazon".
+ *
+ * This is a VIEW over the same rows the flat list would render (see
+ * `lib/dashboard/employerGroups.ts` for why it must never become a merge).
+ * The header claims nothing a member could contradict:
+ *
+ *   - it names the employer and counts the applications — the count in mono
+ *     because it is a figure, the word in the product voice;
+ *   - it shows the filing SPAN (oldest – newest), since one date would be
+ *     some member's date passed off as everyone's;
+ *   - it carries the set's most urgent deadline, because a deadline folded
+ *     out of sight until a click is a deadline missed — and the quiet tag of
+ *     its oldest member, the two signals a collapsed card may not swallow;
+ *   - it never shows a status qualifier or a stage control: members of a
+ *     `closed` set can be rejected AND withdrawn, and bulk stage moves are
+ *     not offered. Every member row keeps its own select, menu and mail.
+ *
+ * Collapsed, the card wears `.board-stack` — two card edges peeking out
+ * beneath it — so "several live here" is legible before any copy is read.
+ * Open, the members render as full rows on a hairline rail; the deck look
+ * goes away because the children are the deck.
+ *
+ * The cross-stage chip (rendered only when the employer holds rows in OTHER
+ * stages) keeps the company-filter affordance: expansion answers "what are
+ * the N here", the chip answers "everything at this employer, wherever it
+ * stands". Its accessible name stays `Show all applications at {company}`.
+ */
+export function EmployerSetRow({
+  company,
+  items,
+  column,
+  today,
+  open,
+  onToggle,
+  chip,
+  onFilterCompany,
+  children,
+}: {
+  company: string;
+  /** The member applications, in the stage group's own order. */
+  items: Application[];
+  /** The stage group this set lives in — its label, key and accent. */
+  column: BoardColumn;
+  /** The board's one clock read, threaded down (`useLocalToday`). */
+  today: string;
+  open: boolean;
+  onToggle: () => void;
+  /** Cross-stage affordance, prebuilt by the board: how many of this
+   *  employer's applications sit outside this stage, and where. */
+  chip: { count: number; label: string } | null;
+  onFilterCompany?: (company: string) => void;
+  /** The member rows (`BoardCell`-wrapped), rendered only while open. */
+  children: ReactNode;
+}) {
+  const listId = useId();
+
+  // The span and the quiet signal derive from the members' own filed dates —
+  // the same fields their FiledStamps render, so header and rows cannot
+  // disagree. String compare is safe: `filedAt` yields ISO dates/timestamps.
+  const filedDates = items.map((app) => filedAt(app));
+  const oldest = filedDates.reduce((a, b) => (b < a ? b : a));
+  const newest = filedDates.reduce((a, b) => (b > a ? b : a));
+  const oldestAge = daysBetween(oldest, today);
+  const quietAge =
+    column.key === "applied" && oldestAge !== null && oldestAge >= QUIET_AFTER_DAYS
+      ? oldestAge
+      : null;
+
+  // The set's most urgent deadline: the earliest due_at (an overdue one is by
+  // definition earliest). `DeadlineTag` derives the state and the phrase.
+  const urgentDue = items
+    .map((app) => app.due_at)
+    .filter((d): d is string => d != null)
+    .sort()[0];
+
+  const span = (
+    <span className="tabular font-mono text-[10px] text-dim">
+      {shortDate(oldest) === shortDate(newest)
+        ? shortDate(newest)
+        : `${shortDate(oldest)} – ${shortDate(newest)}`}
+      {quietAge !== null ? (
+        <span
+          className="text-review"
+          title={`oldest filed ${quietAge} days ago and still at applied`}
+        >
+          {" "}
+          · quiet {quietAge}d
+        </span>
+      ) : null}
+    </span>
+  );
+
+  const showChip = chip !== null && onFilterCompany !== undefined;
+  // The urgent tag exists so a COLLAPSED card cannot swallow a deadline; open,
+  // the owning member row shows its own and a second copy would double-claim.
+  const showUrgent = !open && urgentDue !== undefined;
+  const hasPhoneMeta = showChip || showUrgent;
+
+  return (
+    <div>
+      {/* Same skeleton as ApplicationRow — stacked lines below `sm`, one line
+          above — so a set header and a single row stay the same height. */}
+      <div
+        className={cn(
+          "board-row group/row relative flex flex-col gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3",
+          !open && "board-stack",
+        )}
+        style={{ borderLeft: `2px solid color-mix(in oklab, ${column.color} 55%, transparent)` }}
+      >
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls={open ? listId : undefined}
+          aria-label={`${company} — ${items.length} applications`}
+          onClick={onToggle}
+          className="flex min-w-0 flex-col gap-y-0.5 text-left sm:flex-1 sm:basis-56 sm:flex-row sm:items-baseline sm:gap-x-2.5"
+        >
+          <span className="flex min-w-0 items-baseline gap-2 text-sm font-medium text-strong sm:max-w-[16rem] sm:shrink-0">
+            <span className="min-w-0 truncate underline-offset-2 group-hover/row:underline">
+              {company}
+            </span>
+            {/* Below `sm` the span rides the company line; above it lives in
+                the meta cluster like every row's date does. */}
+            <span className="ml-auto shrink-0 font-normal sm:hidden">{span}</span>
+          </span>
+          {/* The role slot: for a set, the discriminator is the count. */}
+          <span className="flex min-w-0 items-center gap-1.5 text-[13px] leading-snug text-muted">
+            <span className="tabular font-mono text-xs text-strong">{items.length}</span>
+            applications
+            <ChevronRight
+              className={cn(
+                "h-3.5 w-3.5 shrink-0 text-dim transition-transform motion-reduce:transition-none",
+                open && "rotate-90",
+              )}
+              aria-hidden
+            />
+          </span>
+        </button>
+
+        <div
+          className={cn(
+            hasPhoneMeta ? "flex" : "hidden sm:flex",
+            "flex-wrap items-center gap-x-2 gap-y-1 sm:ml-auto sm:max-w-full sm:justify-end",
+          )}
+        >
+          {showChip ? (
+            <SameCompanyChip
+              company={company}
+              count={chip.count}
+              label={chip.label}
+              onFilter={onFilterCompany}
+            />
+          ) : null}
+          {showUrgent ? <DeadlineTag dueAt={urgentDue} today={today} /> : null}
+          <span className="hidden sm:inline">{span}</span>
+        </div>
+      </div>
+
+      {open ? (
+        <ul id={listId} className="ml-1 mt-1.5 space-y-1.5 border-l border-line-soft pl-3">
+          {children}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -9,9 +9,11 @@ import { ApplicationRow, NO_ROLE_LABEL } from "@/components/dashboard/Applicatio
 import { ApplicationDetail } from "@/components/dashboard/ApplicationDetail";
 import { DeadlineTag, FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { CompanyBand } from "@/components/dashboard/CompanyBand";
+import { EmployerSetRow } from "@/components/dashboard/EmployerSetRow";
 import { useLocalToday } from "@/lib/dashboard/useLocalToday";
 import { boardColumns, cardQualifier, type BoardColumn } from "@/lib/dashboard/board";
 import { filedAt } from "@/lib/dashboard/dates";
+import { elsewhereLabel, groupByEmployer } from "@/lib/dashboard/employerGroups";
 import { cn } from "@/lib/utils";
 import { type Application, STAGES, stageOf, type StageKey } from "@/lib/dashboard/summary";
 import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transport";
@@ -54,13 +56,26 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  *
  * A row is an APPLICATION, not a company: one employer can hold several rows
  * (four Amazon roles in one evening is the proven case), and the role is the
- * discriminator. Company stays an attribute — the company-level affordances
- * are the "+N at Amazon" chip on a row and the set view it opens: the list
- * filters to the employer and a `CompanyBand` states that filter — just the
+ * discriminator. But four rows all HEADED "Amazon" read as duplication, so the
+ * unfiltered list folds same-employer rows *within a stage group* into one
+ * employer card that opens inline (`EmployerSetRow`, membership from
+ * `lib/dashboard/employerGroups.ts`). Display only — each member keeps its own
+ * id, status, mail and controls; the stage headings and the spine keep
+ * counting applications, never cards; and the grouping is per stage on
+ * purpose, so an employer split across stages appears once under each — a
+ * cross-stage summary row would have to pick one stage to live in, which is
+ * the furthest-stage-wins display the old merge bug drew.
+ *
+ * The remaining company-level affordance is the cross-stage chip
+ * ("+1 in interviewing") on a set header or a singleton whose employer holds
+ * rows in other stages. It opens the set VIEW: the list filters to the
+ * employer — dispersed back into flat rows, one per application, each under
+ * its own stage heading — and a `CompanyBand` states that filter: just the
  * name and a clear, since the cards themselves already say how many there are
  * and what stage each one is in. While that filter is active the chip is
  * suppressed — "+3 at Amazon" inside Amazon's own set view was a bug, not
- * information.
+ * information. A search also disperses the sets: a match hidden inside a
+ * collapsed card would make search worse than no grouping at all.
  *
  * Motion (the `motion` library): every row cell is a `motion.li` with a
  * shared `layoutId`, so search/filter changes glide survivors into place, a
@@ -117,51 +132,103 @@ function StaticApplicationRow({
   app,
   columnLabel,
   today,
+  inSet = false,
   sameCompanyCount = 0,
+  sameCompanyLabel,
   onFilterCompany,
 }: {
   app: Application;
   columnLabel: string;
   today: string;
+  inSet?: boolean;
   sameCompanyCount?: number;
+  sameCompanyLabel?: string | null;
   onFilterCompany?: (company: string) => void;
 }) {
   const qualifier = cardQualifier(app.status, columnLabel);
   const stage = STAGES.find((s) => s.key === stageOf(app.status))!;
   const filed = filedAt(app);
   const role = app.position.trim();
+  const showChip = sameCompanyCount > 0 && onFilterCompany !== undefined;
   return (
+    // Same responsive skeleton as the interactive row: an explicit stack below
+    // `sm` (stamp on the company line, meta left-anchored), one line above it.
     <div
-      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong"
+      className="flex flex-col gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3"
       style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
     >
-      <div className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5">
-        <span className="flex min-w-0 max-w-[16rem] shrink-0 items-center gap-2 text-sm font-medium text-strong">
-          <span className="truncate">{app.company}</span>
-          {qualifier && (
-            <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
-              {qualifier}
+      <div className="flex min-w-0 flex-col gap-y-0.5 sm:flex-1 sm:basis-56 sm:flex-row sm:items-baseline sm:gap-x-2.5">
+        {inSet ? (
+          // Set member: role leads, employer stays on the header (see
+          // ApplicationRow — same rule, same reason).
+          <span className="flex min-w-0 flex-1 items-baseline gap-2">
+            {role ? (
+              <span
+                title={role}
+                className="line-clamp-2 min-w-0 break-words text-sm leading-snug text-foreground"
+              >
+                {role}
+              </span>
+            ) : (
+              <span className="text-sm leading-snug text-dim">{NO_ROLE_LABEL}</span>
+            )}
+            {qualifier && (
+              <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
+                {qualifier}
+              </span>
+            )}
+            <span className="ml-auto shrink-0 sm:hidden">
+              <FiledStamp filed={filed} status={app.status} today={today} />
             </span>
-          )}
-        </span>
-        {role ? (
-          <span
-            title={role}
-            className="line-clamp-2 min-w-0 break-words text-[13px] leading-snug text-foreground"
-          >
-            {role}
           </span>
         ) : (
-          <span className="text-[13px] leading-snug text-dim">{NO_ROLE_LABEL}</span>
+          <>
+            <span className="flex min-w-0 items-baseline gap-2 text-sm font-medium text-strong sm:max-w-[16rem] sm:shrink-0">
+              <span className="min-w-0 truncate">{app.company}</span>
+              {qualifier && (
+                <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
+                  {qualifier}
+                </span>
+              )}
+              <span className="ml-auto shrink-0 font-normal sm:hidden">
+                <FiledStamp filed={filed} status={app.status} today={today} />
+              </span>
+            </span>
+            {role ? (
+              <span
+                title={role}
+                className="line-clamp-2 min-w-0 break-words text-[13px] leading-snug text-foreground"
+              >
+                {role}
+              </span>
+            ) : (
+              <span className="text-[13px] leading-snug text-dim">{NO_ROLE_LABEL}</span>
+            )}
+          </>
         )}
       </div>
-      <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-x-2 gap-y-1">
-        {sameCompanyCount > 0 && onFilterCompany ? (
-          <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
+      {/* This row has no controls, so at phone width the meta line only exists
+          when it has something to say — an empty flex child would still spend
+          the stack's gap. */}
+      <div
+        className={cn(
+          showChip || app.due_at != null ? "flex" : "hidden sm:flex",
+          "flex-wrap items-center gap-x-2 gap-y-1 sm:ml-auto sm:max-w-full sm:justify-end",
+        )}
+      >
+        {showChip ? (
+          <SameCompanyChip
+            company={app.company}
+            count={sameCompanyCount}
+            label={sameCompanyLabel ?? undefined}
+            onFilter={onFilterCompany}
+          />
         ) : null}
         {/* Same rule as the interactive row: nothing unless the row has a due_at. */}
         <DeadlineTag dueAt={app.due_at} today={today} />
-        <FiledStamp filed={filed} status={app.status} today={today} />
+        <span className="hidden sm:inline">
+          <FiledStamp filed={filed} status={app.status} today={today} />
+        </span>
       </div>
     </div>
   );
@@ -169,15 +236,18 @@ function StaticApplicationRow({
 
 /**
  * One list cell: the layout-animated `li` around a row. `layoutId` is what
- * lets a row travel between stage groups as one continuous element;
- * `entering` gates the fade-in to post-hydration appearances only.
+ * lets a row travel between stage groups as one continuous element —
+ * `app-{id}` for an application (stable across grouping, so a member leaving
+ * a set glides out of it as itself), `set-{stage}-{company}` for an employer
+ * set's own cell. `entering` gates the fade-in to post-hydration appearances
+ * only.
  */
 function BoardCell({
-  id,
+  layoutKey,
   entering,
   children,
 }: {
-  id: number;
+  layoutKey: string;
   entering: boolean;
   children: ReactNode;
 }) {
@@ -198,7 +268,7 @@ function BoardCell({
   return (
     <motion.li
       layout={!reduceMotion}
-      layoutId={`app-${id}`}
+      layoutId={layoutKey}
       initial={entering && !reduceMotion ? { opacity: 0, y: 6 } : false}
       animate={{ opacity: 1, y: 0 }}
       transition={
@@ -327,12 +397,63 @@ export function PipelineBoard({
   });
 
   /**
+   * Employer grouping is the resting view only. A search or the company
+   * filter disperses the sets back into flat rows: a match hidden inside a
+   * collapsed card would defeat the search, and the set VIEW's whole point is
+   * one row per application under its own stage heading.
+   */
+  const grouping = !filterActive;
+
+  /** Which employer sets are open, keyed `${stage}:${company}`. Session state
+   *  — a set the user opened stays open across filters and refreshes of this
+   *  mount, and there is nothing worth persisting beyond it. */
+  const [openSets, setOpenSets] = useState<Record<string, boolean>>({});
+  const toggleSet = (key: string) =>
+    setOpenSets((s) => ({ ...s, [key]: !s[key] }));
+
+  /**
    * The chip is suppressed for the company the board is already filtered to —
    * "N more at Amazon" while looking at exactly Amazon's set was the bug this
    * argument exists to keep fixed.
    */
   const sameCompanyCount = (app: Application) =>
     companyFilter === app.company ? 0 : (companyCounts.get(app.company) ?? 1) - 1;
+
+  /** Each employer's loaded rows by stage — the SHOWN stage, so an optimistic
+   *  move updates the cross-stage chips in the same frame as the row itself.
+   *  Not memoized: it depends on `pendingMoves`, which changes exactly when a
+   *  re-render happens anyway, and the board holds one bounded page. */
+  const companyStages = new Map<string, Record<StageKey, number>>();
+  for (const app of applications) {
+    let counts = companyStages.get(app.company);
+    if (!counts) {
+      counts = { applied: 0, interviewing: 0, offered: 0, rejected: 0 };
+      companyStages.set(app.company, counts);
+    }
+    counts[stageOf(shownStatus(app))] += 1;
+  }
+
+  /**
+   * The cross-stage affordance for a row or set in `here`: how many of the
+   * employer's OTHER applications sit outside this stage, and the chip text
+   * naming where ("+1 in interviewing"). Null when the employer is wholly
+   * here — an employer set carrying "+0 elsewhere" would be noise.
+   */
+  const crossStageChip = (
+    company: string,
+    here: StageKey,
+    columns: BoardColumn[],
+  ): { count: number; label: string } | null => {
+    const counts = companyStages.get(company);
+    if (!counts) return null;
+    const others = columns.filter((c) => c.key !== here && counts[c.key] > 0);
+    const count = others.reduce((n, c) => n + counts[c.key], 0);
+    const label = elsewhereLabel(
+      count,
+      others.map((c) => c.label),
+    );
+    return label === null ? null : { count, label };
+  };
 
   async function moveTo(appId: number, stageKey: StageKey) {
     const app = applications.find((a) => a.id === appId);
@@ -424,6 +545,50 @@ export function PipelineBoard({
     );
 
   const locked = variant === "locked";
+
+  /** One application row in its animated cell. `inSet` rows sit inside an
+   *  employer set: the header owns the company-level affordance, so the
+   *  member's own chip is suppressed. */
+  const rowCell = (app: Application, column: BoardColumn, inSet = false) => {
+    const chip = inSet || !grouping ? null : crossStageChip(app.company, column.key, columns);
+    return (
+      <BoardCell key={`app-${app.id}`} layoutKey={`app-${app.id}`} entering={hydrated}>
+        {interactive ? (
+          <ApplicationRow
+            app={app}
+            columnLabel={column.label}
+            today={today}
+            transport={transport}
+            onOpenDetail={setDetailApp}
+            inSet={inSet}
+            sameCompanyCount={inSet ? 0 : sameCompanyCount(app)}
+            sameCompanyLabel={chip?.label ?? null}
+            onFilterCompany={setCompanyFilter}
+            dragging={draggingId === app.id}
+            onDragStart={(event) => {
+              event.dataTransfer.setData("text/plain", String(app.id));
+              event.dataTransfer.effectAllowed = "move";
+              setDraggingId(app.id);
+            }}
+            onDragEnd={() => {
+              setDraggingId(null);
+              setDropStage(null);
+            }}
+          />
+        ) : (
+          <StaticApplicationRow
+            app={app}
+            columnLabel={column.label}
+            today={today}
+            inSet={inSet}
+            sameCompanyCount={inSet ? 0 : sameCompanyCount(app)}
+            sameCompanyLabel={chip?.label ?? null}
+            onFilterCompany={setCompanyFilter}
+          />
+        )}
+      </BoardCell>
+    );
+  };
 
   const dropHandlers = (column: BoardColumn) =>
     interactive
@@ -558,8 +723,13 @@ export function PipelineBoard({
         </div>
       ) : null}
 
-      {/* --- The stage lens, compressed (below lg) -------------------------- */}
-      <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5 lg:hidden">
+      {/* --- The stage lens, compressed (below lg) --------------------------
+          `flex-wrap`, not a scroller: at 375px the horizontal scroller cut
+          "offered" to "offer" at the viewport edge and hid "closed" entirely,
+          with no affordance that anything was scrollable — a filter you cannot
+          see is a filter that does not exist. Two wrapped lines cost ~30px and
+          keep every stage visible. */}
+      <div className="flex flex-wrap items-center gap-1.5 lg:hidden">
         <button
           type="button"
           aria-label={`all stages — ${spineTotal}`}
@@ -671,40 +841,38 @@ export function PipelineBoard({
                       <li className="rounded-lg border border-dashed border-line-soft p-4 text-center text-xs text-dim">
                         {filterActive ? "none match" : "none yet"}
                       </li>
+                    ) : grouping ? (
+                      // One entry per employer within this stage: singletons
+                      // (most rows) render exactly as before; a multi-row
+                      // employer folds into a set that opens inline. The
+                      // heading above still counts `items` — applications,
+                      // never cards.
+                      groupByEmployer(items).map((entry) =>
+                        entry.kind === "single" ? (
+                          rowCell(entry.app, column)
+                        ) : (
+                          <BoardCell
+                            key={`set-${entry.company}`}
+                            layoutKey={`set-${column.key}-${entry.company}`}
+                            entering={hydrated}
+                          >
+                            <EmployerSetRow
+                              company={entry.company}
+                              items={entry.items}
+                              column={column}
+                              today={today}
+                              open={openSets[`${column.key}:${entry.company}`] === true}
+                              onToggle={() => toggleSet(`${column.key}:${entry.company}`)}
+                              chip={crossStageChip(entry.company, column.key, columns)}
+                              onFilterCompany={setCompanyFilter}
+                            >
+                              {entry.items.map((app) => rowCell(app, column, true))}
+                            </EmployerSetRow>
+                          </BoardCell>
+                        ),
+                      )
                     ) : (
-                      items.map((app) => (
-                        <BoardCell key={app.id} id={app.id} entering={hydrated}>
-                          {interactive ? (
-                            <ApplicationRow
-                              app={app}
-                              columnLabel={column.label}
-                              today={today}
-                              transport={transport}
-                              onOpenDetail={setDetailApp}
-                              sameCompanyCount={sameCompanyCount(app)}
-                              onFilterCompany={setCompanyFilter}
-                              dragging={draggingId === app.id}
-                              onDragStart={(event) => {
-                                event.dataTransfer.setData("text/plain", String(app.id));
-                                event.dataTransfer.effectAllowed = "move";
-                                setDraggingId(app.id);
-                              }}
-                              onDragEnd={() => {
-                                setDraggingId(null);
-                                setDropStage(null);
-                              }}
-                            />
-                          ) : (
-                            <StaticApplicationRow
-                              app={app}
-                              columnLabel={column.label}
-                              today={today}
-                              sameCompanyCount={sameCompanyCount(app)}
-                              onFilterCompany={setCompanyFilter}
-                            />
-                          )}
-                        </BoardCell>
-                      ))
+                      items.map((app) => rowCell(app, column))
                     )}
                   </ul>
                 </section>

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -5,24 +5,109 @@ import { LayoutGroup, motion, useReducedMotion } from "motion/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 
-import { ApplicationCard } from "@/components/dashboard/ApplicationCard";
+import { ApplicationRow, NO_ROLE_LABEL } from "@/components/dashboard/ApplicationRow";
 import { ApplicationDetail } from "@/components/dashboard/ApplicationDetail";
 import { DeadlineTag, FiledStamp, SameCompanyChip } from "@/components/dashboard/CardMeta";
 import { CompanyBand } from "@/components/dashboard/CompanyBand";
 import { useLocalToday } from "@/lib/dashboard/useLocalToday";
-import { boardColumns, cardQualifier } from "@/lib/dashboard/board";
+import { boardColumns, cardQualifier, type BoardColumn } from "@/lib/dashboard/board";
 import { filedAt } from "@/lib/dashboard/dates";
+import { cn } from "@/lib/utils";
 import { type Application, STAGES, stageOf, type StageKey } from "@/lib/dashboard/summary";
 import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transport";
 
 /**
- * Read-only card for the public demo + sample previews: no correction controls
- * (they would 401 without a session). Still honours the real received date and
- * the application-first anatomy (role under company) — and keeps the
- * same-company affordance, because filtering is not a mutation and the demo's
- * contract is to be the real thing.
+ * The pipeline worklist — the answer to "is a four-column kanban the right
+ * primary view?", and the answer is no.
+ *
+ * A kanban's geometry encodes stage, and it earns that only when items are
+ * distributed across stages. A personal job search is not distributed: it is
+ * one heavy resting state (applied, waiting) with a thin stream of
+ * transitions — the measured production account is 29 live rows, ALL of them
+ * in one column. Four columns rendered that reality as one starved strip and
+ * three tall boxes asserting emptiness. So stage is now a LENS, not geometry:
+ *
+ *   - the **stage spine** (left, desktop) draws the pipeline as an
+ *     instrument — every stage, its count, and a proportional meter. It is
+ *     the filter (press a stage to see only it), the drop target (drag a row
+ *     onto a stage to move it), and the one place emptiness is stated — as a
+ *     zero and an empty meter, which costs a line, not a quarter of the
+ *     screen. At 29-0-0-0 it reads as a young pipeline; at a healthy spread
+ *     it reads as a funnel. Below `lg` it compresses into a chip strip.
+ *   - the **worklist** (right) renders every application as one full-width
+ *     row with a fixed skeleton, grouped by stage in flow order. Rows are
+ *     even by construction: company and the role slot share one line, and a
+ *     missing role prints an honest placeholder instead of a shorter card
+ *     (8 of the 29 real rows have no role — that raggedness was half the
+ *     complaint; column starvation was the other half, and rows have no
+ *     columns to starve).
+ *
+ * Two geometries, one component:
+ *   - `variant="locked"` (the signed-in dashboard): the board fills the
+ *     shell's viewport-locked pane; the LIST is the only thing that scrolls,
+ *     with sticky group headers. Below `lg` the lock releases and the page
+ *     flows — pinning a phone's only content pane behind a nested scroller
+ *     helps nobody.
+ *   - `variant="flow"` (the /demo twin, the empty-state preview): natural
+ *     height, no nested scroller — the page is the scroll context, exactly
+ *     as before.
+ *
+ * A row is an APPLICATION, not a company: one employer can hold several rows
+ * (four Amazon roles in one evening is the proven case), and the role is the
+ * discriminator. Company stays an attribute — the company-level affordances
+ * are the "+N at Amazon" chip on a row and the set view it opens: the list
+ * filters to the employer and a `CompanyBand` names the set. While that
+ * filter is active the chip is suppressed — "3 more at Amazon" inside
+ * Amazon's own set view was a bug, not information.
+ *
+ * Motion (the `motion` library): every row cell is a `motion.li` with a
+ * shared `layoutId`, so search/filter changes glide survivors into place, a
+ * row dropped (or selected) into another stage visibly travels there, and
+ * clearing a filter gathers the list back. Entrances only run for rows that
+ * appear AFTER hydration (`entering` below) — server HTML is never hidden
+ * behind an animation — exits are instant (a filter must feel like a filter,
+ * not a curtain call), and `useReducedMotion` collapses the whole layer to
+ * static rendering.
+ *
+ * Stage changes have three working paths: drag a row onto a stage (spine or
+ * group heading — pointer), the per-row select (keyboard + the accessible
+ * path), and the same select in the detail sheet. Drops are optimistic — the
+ * row moves immediately, a failure rolls it back visibly and says why.
+ *
+ * `accepted` folds into the offered group, and the resolved group carries
+ * `rejected`/`withdrawn`/`ghosted`, so it is headed `closed` and every row in
+ * it states its own status (see `lib/dashboard/board.ts`).
+ *
+ * `interactive={false}` is the INERT board: the sample preview inside the
+ * dashboard's empty state, which sits under `pointer-events-none`. It renders
+ * read-only rows (mutations there would 401 without a session) and no search
+ * field — a search input a user cannot focus is chrome that invites typing and
+ * eats nothing. `/demo` is NOT that board: it renders this component fully
+ * interactive over fixtures, and only the transport is simulated, which is
+ * what gives the session-gated surfaces their executing e2e coverage.
+ *
+ * Scope honesty: the signed-in board is ONE bounded page of a possibly larger
+ * account, so it takes the account's true `total` and says which slice it is
+ * showing when the two differ. Everything derived from the loaded rows (the
+ * "+N at" chip, the company band, the spine counts) is then explicitly
+ * counted from that slice, never claimed as the whole.
  */
-function StaticApplicationCard({
+
+/** Below this many rows, search would be chrome without a job. */
+const SEARCH_AFTER = 5;
+
+/** The spine's filter vocabulary: every stage, or all of them. */
+type StageFilter = StageKey | "all";
+
+/**
+ * Read-only row for the public demo previews + sample boards: no correction
+ * controls (they would 401 without a session). Still honours the real received
+ * date and the application-first anatomy (company anchors, role discriminates,
+ * an absent role prints the honest placeholder) — and keeps the same-company
+ * affordance, because filtering is not a mutation and the demo's contract is
+ * to be the real thing.
+ */
+function StaticApplicationRow({
   app,
   columnLabel,
   today,
@@ -41,97 +126,45 @@ function StaticApplicationCard({
   const role = app.position.trim();
   return (
     <div
-      className="rounded-lg border border-line-soft bg-surface-2 p-3 transition-colors hover:border-line-strong"
+      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong"
       style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
     >
-      <p className="flex items-center gap-2 text-sm font-medium text-strong">
-        <span className="truncate">{app.company}</span>
-        {qualifier && (
-          <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
-            {qualifier}
+      <div className="flex min-w-0 flex-1 basis-56 items-baseline gap-x-2.5">
+        <span className="flex min-w-0 max-w-[16rem] shrink-0 items-center gap-2 text-sm font-medium text-strong">
+          <span className="truncate">{app.company}</span>
+          {qualifier && (
+            <span className="shrink-0 rounded-full border border-line px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-muted">
+              {qualifier}
+            </span>
+          )}
+        </span>
+        {role ? (
+          <span
+            title={role}
+            className="line-clamp-2 min-w-0 break-words text-[13px] leading-snug text-foreground"
+          >
+            {role}
           </span>
+        ) : (
+          <span className="text-[13px] leading-snug text-dim">{NO_ROLE_LABEL}</span>
         )}
-      </p>
-      {/* Wraps, never ellipsizes — the role's tail is the discriminator (see
-          ApplicationCard). */}
-      {role ? (
-        <p title={role} className="line-clamp-2 break-words text-[13px] leading-snug text-foreground">
-          {role}
-        </p>
-      ) : null}
-      {sameCompanyCount > 0 && onFilterCompany ? (
-        <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
-      ) : null}
-      {/* Same rule as the interactive card: nothing unless the row has a due_at. */}
-      <DeadlineTag dueAt={app.due_at} today={today} />
-      {app.notes && <p className="mt-1.5 line-clamp-2 text-[11px] leading-snug text-dim">{app.notes}</p>}
-      <p className="mt-2">
+      </div>
+      <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-x-2 gap-y-1">
+        {sameCompanyCount > 0 && onFilterCompany ? (
+          <SameCompanyChip company={app.company} count={sameCompanyCount} onFilter={onFilterCompany} />
+        ) : null}
+        {/* Same rule as the interactive row: nothing unless the row has a due_at. */}
+        <DeadlineTag dueAt={app.due_at} today={today} />
         <FiledStamp filed={filed} status={app.status} today={today} />
-      </p>
+      </div>
     </div>
   );
 }
 
 /**
- * Status-grouped pipeline board, designed for 200 applications rather than 15.
- *
- * A card is an APPLICATION, not a company: one employer can hold several cards
- * (four Amazon roles in one evening is the proven case), they can sit in
- * different columns simultaneously, and the role line is the discriminator.
- * Company stays an attribute — the company-level affordances are the "+N at
- * Amazon" chip on a card and the set view it opens: the board filters to the
- * employer and a `CompanyBand` names the set (count, stage spread, filing
- * span). While that filter is active the chip is suppressed — "3 more at
- * Amazon" inside Amazon's own set view was a bug, not information.
- *
- * Motion (the `motion` library): every card cell is a `motion.li` with a
- * shared `layoutId`, so search/filter changes glide survivors into place, a
- * card dropped (or selected) into another column visibly travels there, and
- * clearing a filter gathers the board back. Entrances only run for cards that
- * appear AFTER hydration (`entering` below) — server HTML is never hidden
- * behind an animation — exits are instant (a filter must feel like a filter,
- * not a curtain call), and `useReducedMotion` collapses the whole layer to
- * static rendering.
- *
- * Density rules, deliberately without a nested scroller: the page is the one
- * scroll context. A tall column shows its first {@link COLLAPSED_COUNT} cards
- * and a "show all N" expander that grows the page — no inner scrollbar
- * fighting the page's, no card ever clipped behind a fade, and a specific card
- * can actually be scrolled to. Search (company or role) and the company filter
- * cut 200 rows down to the ones being asked about.
- *
- * Stage changes have three working paths: drag a card to a column (pointer),
- * the per-card select (keyboard + the accessible path), and the same select in
- * the detail sheet. Drops are optimistic — the card moves immediately, a
- * failure rolls it back visibly and says why.
- *
- * `accepted` folds into the offered column, and the resolved column carries
- * `rejected`/`withdrawn`/`ghosted`, so it is headed `closed` and every card in
- * it states its own status (see `lib/dashboard/board.ts`).
- *
- * `interactive={false}` is the INERT board: the sample preview inside the
- * dashboard's empty state, which sits under `pointer-events-none`. It renders
- * read-only cards (mutations there would 401 without a session) and no search
- * field — a search input a user cannot focus is chrome that invites typing and
- * eats nothing. `/demo` is NOT that board: it renders this component fully
- * interactive over fixtures, and only the transport is simulated, which is
- * what gives the session-gated surfaces their executing e2e coverage.
- *
- * Scope honesty: the signed-in board is ONE bounded page of a possibly larger
- * account, so it takes the account's true `total` and says which slice it is
- * showing when the two differ — the same rule and phrasing as the pulse strip.
- * Everything derived from the loaded rows (the "+N at" chip, the company band)
- * is then explicitly counted from that slice, never claimed as the whole.
- */
-const COLLAPSED_COUNT = 8;
-
-/** Below this many rows, search would be chrome without a job. */
-const SEARCH_AFTER = 5;
-
-/**
- * One board cell: the layout-animated `li` around a card. `layoutId` is what
- * lets a card travel between columns as one continuous element; `entering`
- * gates the fade-in to post-hydration appearances only.
+ * One list cell: the layout-animated `li` around a row. `layoutId` is what
+ * lets a row travel between stage groups as one continuous element;
+ * `entering` gates the fade-in to post-hydration appearances only.
  */
 function BoardCell({
   id,
@@ -151,7 +184,7 @@ function BoardCell({
   // The differing tree shape shifts every descendant `useId`, and production
   // React does not repair a server-rendered `id` attribute — so
   // `RowActionsMenu`'s `aria-labelledby` pointed at an id that no longer existed
-  // on every card, for exactly the people reduced motion exists to serve.
+  // on every row, for exactly the people reduced motion exists to serve.
   //
   // Reduced motion is now expressed by neutralising the animation PROPS, which
   // changes nothing about the tree. `layout={false}` disables the shared-layout
@@ -175,7 +208,11 @@ export function PipelineBoard({
   applications,
   total,
   interactive = true,
+  variant = "flow",
   transport = liveBoardTransport,
+  rail,
+  beforeList,
+  afterList,
 }: {
   applications: Application[];
   /** The account's true row count, when the caller knows it and it can exceed
@@ -183,13 +220,26 @@ export function PipelineBoard({
    *  store, the sample fixtures) — then there is no slice to disclose. */
   total?: number;
   interactive?: boolean;
+  /** `locked` fills the shell's viewport pane and scrolls only the list;
+   *  `flow` renders natural height for pages that scroll themselves. */
+  variant?: "locked" | "flow";
   /** How mutations reach data — the live proxy by default, fixtures on /demo. */
   transport?: BoardTransport;
+  /** Rendered inside the desktop spine, under the stages — the dashboard puts
+   *  the pulse's derived signals here so the left rail reads as the
+   *  instrument panel and the right pane as the work. */
+  rail?: ReactNode;
+  /** Rendered inside the list pane, above the rows (e.g. the review queue
+   *  when alerts interrupt) — it scrolls with the list, so an interrupt can
+   *  never starve the worklist of its viewport. */
+  beforeList?: ReactNode;
+  /** Rendered inside the list pane, below the rows (the quiet placement). */
+  afterList?: ReactNode;
 }) {
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [companyFilter, setCompanyFilter] = useState<string | null>(null);
-  const [expanded, setExpanded] = useState<Partial<Record<StageKey, boolean>>>({});
+  const [stageFilter, setStageFilter] = useState<StageFilter>("all");
   const [detailApp, setDetailApp] = useState<Application | null>(null);
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropStage, setDropStage] = useState<StageKey | null>(null);
@@ -197,7 +247,7 @@ export function PipelineBoard({
   const [pendingMoves, setPendingMoves] = useState<Record<number, string>>({});
   const [moveError, setMoveError] = useState<string | null>(null);
   /** False for the server-rendered pass — entrance animations start only after
-   *  hydration, so no card is ever server-rendered invisible. Deferred off the
+   *  hydration, so no row is ever server-rendered invisible. Deferred off the
    *  effect body (house rule — no synchronous setState in an effect). */
   const [hydrated, setHydrated] = useState(false);
   useEffect(() => {
@@ -205,14 +255,14 @@ export function PipelineBoard({
     return () => window.clearTimeout(id);
   }, []);
 
-  /** One clock read per render — every card's age tag and deadline state
+  /** One clock read per render — every row's age tag and deadline state
    *  derives from it. UTC for the server pass, the reader's own day once
    *  mounted (see `useLocalToday`). */
   const today = useLocalToday();
 
   // Server data caught up with an optimistic move → drop the overlay entry and
   // let the row's own status speak. Render-adjustment (guarded, so it settles
-  // in one extra render), the same pattern ApplicationCard uses for its own
+  // in one extra render), the same pattern ApplicationRow uses for its own
   // optimistic stage.
   const settled = applications.filter(
     (app) => pendingMoves[app.id] !== undefined && app.status === pendingMoves[app.id],
@@ -225,14 +275,14 @@ export function PipelineBoard({
 
   /**
    * True when these rows are one page of a bigger account. Everything the
-   * board derives — the column counts, the "+N at" chip, the company band —
+   * board derives — the spine counts, the "+N at" chip, the company band —
    * then describes the LOADED rows only, and says so rather than passing
    * itself off as the account.
    */
   const truncated = total !== undefined && applications.length < total;
   const scopeNote = truncated ? `newest ${applications.length} of ${total}` : null;
 
-  /** How many OTHER cards share each company ON THIS BOARD — drives the "+N
+  /** How many OTHER rows share each company ON THIS BOARD — drives the "+N
    *  at" chip. Under truncation an employer can hold rows that never loaded,
    *  so the chip is a floor, not a census; the band states the same scope. */
   const companyCounts = useMemo(() => {
@@ -271,7 +321,7 @@ export function PipelineBoard({
     const app = applications.find((a) => a.id === appId);
     if (!app || stageOf(shownStatus(app)) === stageKey) return;
     // The stage keys are themselves canonical statuses the PATCH accepts; a
-    // drop into `closed` files as `rejected`, and the select is where the
+    // drop onto `closed` files as `rejected`, and the select is where the
     // finer words (withdrawn, ghosted) live.
     const target: string = stageKey;
     setMoveError(null);
@@ -299,28 +349,134 @@ export function PipelineBoard({
   // into.
   const showSearch = interactive && applications.length > SEARCH_AFTER;
 
-  // --- Column widths: space follows content --------------------------------
-  // A real search's board is one heavy column and three near-empty ones, and
-  // an even four-way split hands three quarters of the width to "none yet"
-  // while the column holding every card is the narrowest it can be — which is
-  // how four real Amazon roles ended up ellipsized into identical text.
-  // Populated columns take 3fr, empty ones compress to a readable floor
-  // (desktop only — `.board-grid` in globals.css; narrower widths keep the
-  // stacked/two-up flow). The weight is binary (has cards / hasn't) and reads
-  // the UNFILTERED counts, so typing a search or dragging between two
-  // populated columns never reflows the widths; only genuinely emptying or
-  // populating a column does.
-  const boardCols = boardColumns(STAGES)
-    .map((column) =>
-      applications.some((app) => stageOf(shownStatus(app)) === column.key)
-        ? "minmax(0, 3fr)"
-        : "minmax(8rem, 1fr)",
-    )
-    .join(" ");
+  const columns = boardColumns(STAGES);
+  /** Spine counts read the UNFILTERED rows (with the optimistic overlay), so
+   *  typing a search never reflows the pipeline's stated shape — the spine is
+   *  the account's distribution, the list is the current view. Recomputed per
+   *  render on purpose: one O(n) pass over an already-bounded page. */
+  const spineCounts: Record<StageKey, number> = {
+    applied: 0,
+    interviewing: 0,
+    offered: 0,
+    rejected: 0,
+  };
+  for (const app of applications) spineCounts[stageOf(shownStatus(app))] += 1;
+  const spineMax = Math.max(1, ...columns.map((c) => spineCounts[c.key]));
+
+  /** Groups actually rendered in the list: the selected stage (even empty, so
+   *  "none yet"/"none match" has a place to be said), or every stage that has
+   *  matching rows when the lens is `all` — an empty stage's emptiness is the
+   *  spine's line to speak, not a full-width box of nothing. */
+  const groups = columns
+    .map((column) => ({
+      column,
+      items: filtered.filter((a) => stageOf(shownStatus(a)) === column.key),
+    }))
+    .filter(({ column, items }) =>
+      stageFilter === "all" ? items.length > 0 : column.key === stageFilter,
+    );
+
+  const locked = variant === "locked";
+
+  const dropHandlers = (column: BoardColumn) =>
+    interactive
+      ? {
+          onDragOver:
+            draggingId !== null
+              ? (event: React.DragEvent) => {
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = "move";
+                  setDropStage(column.key);
+                }
+              : undefined,
+          onDrop: (event: React.DragEvent) => {
+            event.preventDefault();
+            const id = Number(event.dataTransfer.getData("text/plain"));
+            setDropStage(null);
+            setDraggingId(null);
+            if (Number.isInteger(id) && id > 0) void moveTo(id, column.key);
+          },
+        }
+      : {};
+
+  /** One stage entry — shared anatomy between the spine (vertical, metered)
+   *  and the chip strip (horizontal, compact). */
+  const stageButton = (column: BoardColumn, kind: "spine" | "chip") => {
+    const count = spineCounts[column.key];
+    const active = stageFilter === column.key;
+    const common = {
+      "aria-label": `${column.label} — ${count}`,
+      "aria-pressed": active,
+      onClick: () => setStageFilter(active ? "all" : column.key),
+    } as const;
+    if (kind === "chip") {
+      return (
+        <button
+          key={column.key}
+          type="button"
+          {...common}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+            active
+              ? "border-line-strong bg-surface-2 text-strong"
+              : "border-line-soft text-muted hover:text-strong",
+          )}
+        >
+          <span
+            className="h-1.5 w-1.5 rounded-full"
+            style={{ background: column.color }}
+            aria-hidden="true"
+          />
+          {column.label}
+          <span className="tabular font-mono text-[11px]">{count}</span>
+        </button>
+      );
+    }
+    return (
+      <button
+        key={column.key}
+        type="button"
+        {...common}
+        data-drop={dropStage === column.key || undefined}
+        {...dropHandlers(column)}
+        className={cn(
+          "spine-stage w-full rounded-lg border px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong",
+          active
+            ? "border-line-strong bg-surface-2"
+            : "border-transparent hover:border-line-soft hover:bg-surface-2/60",
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <span
+            className="h-1.5 w-1.5 shrink-0 rounded-full"
+            style={{ background: column.color }}
+            aria-hidden="true"
+          />
+          <span className={cn("text-xs font-medium", active ? "text-strong" : "text-muted")}>
+            {column.label}
+          </span>
+          <span className="tabular ml-auto font-mono text-[11px] text-strong">{count}</span>
+        </span>
+        {/* The meter: this stage's share of the loaded rows. An empty stage is
+            an empty track — a fact stated in 4px, not a tall box of nothing. */}
+        <span className="mt-1.5 block h-1 overflow-hidden rounded-full bg-surface-2" aria-hidden="true">
+          {count > 0 ? (
+            <span
+              className="block h-full rounded-full"
+              style={{ width: `${(count / spineMax) * 100}%`, background: column.color }}
+            />
+          ) : null}
+        </span>
+      </button>
+    );
+  };
 
   return (
-    <div className="space-y-3">
-      {/* --- Board filters ------------------------------------------------- */}
+    <div
+      data-testid="pipeline-board"
+      className={cn("flex flex-col gap-3", locked && "lg:min-h-0 lg:flex-1")}
+    >
+      {/* --- Toolbar: search + view state ---------------------------------- */}
       {showSearch || filterActive || scopeNote ? (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
           {showSearch ? (
@@ -344,9 +500,9 @@ export function PipelineBoard({
               {filtered.length} of {applications.length} shown
             </span>
           ) : null}
-          {/* The subtitle counts the whole account; these four columns can
-              only count what loaded. Without this line "250 filed" sat above
-              columns summing to 200 and neither number explained the other. */}
+          {/* The subtitle counts the whole account; this list can only count
+              what loaded. Without this line "250 filed" sat above a list
+              summing to 200 and neither number explained the other. */}
           {scopeNote ? (
             <span className="tabular text-xs text-dim">
               board shows the {scopeNote} · older rows aren&apos;t loaded
@@ -355,129 +511,169 @@ export function PipelineBoard({
         </div>
       ) : null}
 
-      {/* --- The employer's set, named ------------------------------------- */}
-      {companyFilter !== null && companySet !== null ? (
-        <CompanyBand
-          company={companyFilter}
-          apps={companySet}
-          statusOf={shownStatus}
-          partial={truncated}
-          onClear={() => setCompanyFilter(null)}
-        />
-      ) : null}
-
-      {moveError ? (
-        <p role="alert" className="text-xs text-reject-ink">
-          {moveError}
-        </p>
-      ) : null}
-
-      {/* --- Columns -------------------------------------------------------- */}
-      <LayoutGroup>
-        <div
-          className="board-grid grid items-start gap-3 sm:grid-cols-2"
-          style={{ ["--board-cols" as string]: boardCols }}
+      {/* --- The stage lens, compressed (below lg) -------------------------- */}
+      <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5 lg:hidden">
+        <button
+          type="button"
+          aria-label={`all stages — ${applications.length}`}
+          aria-pressed={stageFilter === "all"}
+          onClick={() => setStageFilter("all")}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+            stageFilter === "all"
+              ? "border-line-strong bg-surface-2 text-strong"
+              : "border-line-soft text-muted hover:text-strong",
+          )}
         >
-          {boardColumns(STAGES).map((column) => {
-            const items = filtered.filter((a) => stageOf(shownStatus(a)) === column.key);
-            const isExpanded = expanded[column.key] === true;
-            const visible = isExpanded ? items : items.slice(0, COLLAPSED_COUNT);
-            const hidden = items.length - visible.length;
-            return (
-              <section
-                key={column.key}
-                aria-label={`${column.label} — ${items.length}`}
-                data-drop={dropStage === column.key || undefined}
-                onDragOver={
-                  interactive && draggingId !== null
-                    ? (event) => {
-                        event.preventDefault();
-                        event.dataTransfer.dropEffect = "move";
-                        setDropStage(column.key);
-                      }
-                    : undefined
-                }
-                onDrop={
-                  interactive
-                    ? (event) => {
-                        event.preventDefault();
-                        const id = Number(event.dataTransfer.getData("text/plain"));
-                        setDropStage(null);
-                        setDraggingId(null);
-                        if (Number.isInteger(id) && id > 0) void moveTo(id, column.key);
-                      }
-                    : undefined
-                }
-                className="board-col flex flex-col rounded-xl border border-line-soft bg-surface p-3 transition-colors"
+          all
+          <span className="tabular font-mono text-[11px]">{applications.length}</span>
+        </button>
+        {columns.map((column) => stageButton(column, "chip"))}
+      </div>
+
+      {/* --- Body: spine + worklist ----------------------------------------- */}
+      <div className={cn("flex flex-col gap-4 lg:flex-row lg:gap-5", locked && "lg:min-h-0 lg:flex-1")}>
+        <aside
+          aria-label="Stages"
+          className={cn(
+            "hidden w-52 shrink-0 flex-col gap-1 lg:flex",
+            locked ? "lg:min-h-0 lg:overflow-y-auto" : "lg:sticky lg:top-5 lg:self-start",
+          )}
+        >
+          <p className="label-caps px-2.5 pb-1">stages</p>
+          <button
+            type="button"
+            aria-label={`all stages — ${applications.length}`}
+            aria-pressed={stageFilter === "all"}
+            onClick={() => setStageFilter("all")}
+            className={cn(
+              "w-full rounded-lg border px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong",
+              stageFilter === "all"
+                ? "border-line-strong bg-surface-2"
+                : "border-transparent hover:border-line-soft hover:bg-surface-2/60",
+            )}
+          >
+            <span className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  stageFilter === "all" ? "text-strong" : "text-muted",
+                )}
               >
-                <div className="mb-2 flex items-baseline justify-between px-1">
-                  <span className="label-caps inline-flex items-center gap-1.5 text-muted">
-                    <span
-                      className="h-1.5 w-1.5 rounded-full"
-                      style={{ background: column.color }}
-                      aria-hidden="true"
-                    />
-                    {column.label}
-                  </span>
-                  <span className="tabular font-mono text-xs text-muted">{items.length}</span>
-                </div>
-                <ul className="space-y-2">
-                  {items.length === 0 ? (
-                    <li className="rounded-lg border border-dashed border-line-soft p-3 text-center text-xs text-dim">
-                      {filterActive ? "none match" : "none yet"}
-                    </li>
-                  ) : (
-                    visible.map((app) => (
-                      <BoardCell key={app.id} id={app.id} entering={hydrated}>
-                        {interactive ? (
-                          <ApplicationCard
-                            app={app}
-                            columnLabel={column.label}
-                            today={today}
-                            transport={transport}
-                            onOpenDetail={setDetailApp}
-                            sameCompanyCount={sameCompanyCount(app)}
-                            onFilterCompany={setCompanyFilter}
-                            dragging={draggingId === app.id}
-                            onDragStart={(event) => {
-                              event.dataTransfer.setData("text/plain", String(app.id));
-                              event.dataTransfer.effectAllowed = "move";
-                              setDraggingId(app.id);
-                            }}
-                            onDragEnd={() => {
-                              setDraggingId(null);
-                              setDropStage(null);
-                            }}
-                          />
-                        ) : (
-                          <StaticApplicationCard
-                            app={app}
-                            columnLabel={column.label}
-                            today={today}
-                            sameCompanyCount={sameCompanyCount(app)}
-                            onFilterCompany={setCompanyFilter}
-                          />
-                        )}
-                      </BoardCell>
-                    ))
-                  )}
-                </ul>
-                {hidden > 0 || isExpanded ? (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setExpanded((e) => ({ ...e, [column.key]: !isExpanded }))
-                    }
-                    className="mt-2 rounded-lg border border-dashed border-line px-2 py-1.5 text-xs font-medium text-muted transition-colors hover:border-line-strong hover:text-strong"
+                all
+              </span>
+              <span className="tabular ml-auto font-mono text-[11px] text-strong">
+                {applications.length}
+              </span>
+            </span>
+          </button>
+          {columns.map((column) => stageButton(column, "spine"))}
+          {rail ? <div className="mt-4 border-t border-line-soft pt-4">{rail}</div> : null}
+        </aside>
+
+        <div className={cn("flex min-w-0 flex-1 flex-col gap-3", locked && "lg:min-h-0")}>
+          {/* --- The employer's set, named --------------------------------- */}
+          {companyFilter !== null && companySet !== null ? (
+            <CompanyBand
+              company={companyFilter}
+              apps={companySet}
+              statusOf={shownStatus}
+              partial={truncated}
+              onClear={() => setCompanyFilter(null)}
+            />
+          ) : null}
+
+          {moveError ? (
+            <p role="alert" className="text-xs text-reject-ink">
+              {moveError}
+            </p>
+          ) : null}
+
+          {/* --- The worklist ------------------------------------------------
+              In the locked variant this region is the dashboard's ONE scroll
+              context; sticky group headings keep the stage legible while the
+              rows underneath move. In flow it is ordinary page content. */}
+          <LayoutGroup>
+            <div className={cn("space-y-4", locked && "lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1")}>
+              {beforeList}
+              {groups.map(({ column, items }) => (
+                <section
+                  key={column.key}
+                  aria-label={`${column.label} — ${items.length}`}
+                  data-drop={dropStage === column.key || undefined}
+                  {...dropHandlers(column)}
+                  className="board-col rounded-xl transition-colors"
+                >
+                  <div
+                    className={cn(
+                      "mb-2 flex items-baseline gap-2 px-1",
+                      locked && "lg:sticky lg:top-0 lg:z-10 lg:bg-background lg:py-1",
+                    )}
                   >
-                    {isExpanded ? "show fewer" : `show all ${items.length}`}
-                  </button>
-                ) : null}
-              </section>
-            );
-          })}
+                    <span className="label-caps inline-flex items-center gap-1.5 text-muted">
+                      <span
+                        className="h-1.5 w-1.5 rounded-full"
+                        style={{ background: column.color }}
+                        aria-hidden="true"
+                      />
+                      {column.label}
+                    </span>
+                    <span className="tabular font-mono text-xs text-muted">{items.length}</span>
+                    <span className="h-px flex-1 bg-line-soft" aria-hidden="true" />
+                  </div>
+                  <ul className="space-y-1.5">
+                    {items.length === 0 ? (
+                      <li className="rounded-lg border border-dashed border-line-soft p-4 text-center text-xs text-dim">
+                        {filterActive ? "none match" : "none yet"}
+                      </li>
+                    ) : (
+                      items.map((app) => (
+                        <BoardCell key={app.id} id={app.id} entering={hydrated}>
+                          {interactive ? (
+                            <ApplicationRow
+                              app={app}
+                              columnLabel={column.label}
+                              today={today}
+                              transport={transport}
+                              onOpenDetail={setDetailApp}
+                              sameCompanyCount={sameCompanyCount(app)}
+                              onFilterCompany={setCompanyFilter}
+                              dragging={draggingId === app.id}
+                              onDragStart={(event) => {
+                                event.dataTransfer.setData("text/plain", String(app.id));
+                                event.dataTransfer.effectAllowed = "move";
+                                setDraggingId(app.id);
+                              }}
+                              onDragEnd={() => {
+                                setDraggingId(null);
+                                setDropStage(null);
+                              }}
+                            />
+                          ) : (
+                            <StaticApplicationRow
+                              app={app}
+                              columnLabel={column.label}
+                              today={today}
+                              sameCompanyCount={sameCompanyCount(app)}
+                              onFilterCompany={setCompanyFilter}
+                            />
+                          )}
+                        </BoardCell>
+                      ))
+                    )}
+                  </ul>
+                </section>
+              ))}
+              {stageFilter === "all" && groups.length === 0 ? (
+                <p className="rounded-lg border border-dashed border-line-soft p-4 text-center text-xs text-dim">
+                  {filterActive ? "none match" : "none yet"}
+                </p>
+              ) : null}
+              {afterList}
+            </div>
+          </LayoutGroup>
         </div>
-      </LayoutGroup>
+      </div>
 
       {interactive ? (
         <ApplicationDetail app={detailApp} onClose={() => setDetailApp(null)} transport={transport} />

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -56,9 +56,11 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  * (four Amazon roles in one evening is the proven case), and the role is the
  * discriminator. Company stays an attribute — the company-level affordances
  * are the "+N at Amazon" chip on a row and the set view it opens: the list
- * filters to the employer and a `CompanyBand` names the set. While that
- * filter is active the chip is suppressed — "3 more at Amazon" inside
- * Amazon's own set view was a bug, not information.
+ * filters to the employer and a `CompanyBand` states that filter — just the
+ * name and a clear, since the cards themselves already say how many there are
+ * and what stage each one is in. While that filter is active the chip is
+ * suppressed — "+3 at Amazon" inside Amazon's own set view was a bug, not
+ * information.
  *
  * Motion (the `motion` library): every row cell is a `motion.li` with a
  * shared `layoutId`, so search/filter changes glide survivors into place, a
@@ -88,9 +90,13 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  *
  * Scope honesty: the signed-in board is ONE bounded page of a possibly larger
  * account, so it takes the account's true `total` and says which slice it is
- * showing when the two differ. Everything derived from the loaded rows (the
- * "+N at" chip, the company band, the spine counts) is then explicitly
- * counted from that slice, never claimed as the whole.
+ * showing when the two differ. The SPINE is exempt because it does not derive
+ * from the rows at all — it reads the account's own per-stage counts off the
+ * summary endpoint (`stageTotals`), so its numbers are the account's however
+ * few rows loaded and however the list chooses to group them. Everything that
+ * genuinely is derived from the loaded rows (the "+N at" chip, the company
+ * band's `partial` caveat, the "N of M shown" line) says so rather than
+ * passing itself off as the whole.
  */
 
 /** Below this many rows, search would be chrome without a job. */
@@ -204,9 +210,30 @@ function BoardCell({
   );
 }
 
+/**
+ * What the caller knows about the ACCOUNT, as opposed to the page of rows it
+ * handed over. Either it knows both numbers or it knows neither — a caller
+ * that can say "250 filed" but not how those 250 sit across the stages would
+ * leave the spine quietly describing the loaded slice while the subtitle
+ * describes the account, which is the contradiction this pairing exists to
+ * make unrepresentable. Callers whose rows ARE the account (the /demo twin,
+ * the inert sample preview) pass neither and the board counts what it has.
+ */
+type BoardScope =
+  | {
+      /** The account's true row count — the sum of `stageTotals`, from
+       *  `GET /applications/summary`. */
+      total: number;
+      /** The account's true per-stage counts, computed by a `GROUP BY status`
+       *  in the database (dismissed rows excluded, as they are off the board). */
+      stageTotals: Record<StageKey, number>;
+    }
+  | { total?: undefined; stageTotals?: undefined };
+
 export function PipelineBoard({
   applications,
   total,
+  stageTotals,
   interactive = true,
   variant = "flow",
   transport = liveBoardTransport,
@@ -215,10 +242,6 @@ export function PipelineBoard({
   afterList,
 }: {
   applications: Application[];
-  /** The account's true row count, when the caller knows it and it can exceed
-   *  what was loaded. Omitted where the given rows ARE everything (the demo
-   *  store, the sample fixtures) — then there is no slice to disclose. */
-  total?: number;
   interactive?: boolean;
   /** `locked` fills the shell's viewport pane and scrolls only the list;
    *  `flow` renders natural height for pages that scroll themselves. */
@@ -235,7 +258,7 @@ export function PipelineBoard({
   beforeList?: ReactNode;
   /** Rendered inside the list pane, below the rows (the quiet placement). */
   afterList?: ReactNode;
-}) {
+} & BoardScope) {
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [companyFilter, setCompanyFilter] = useState<string | null>(null);
@@ -303,12 +326,6 @@ export function PipelineBoard({
     return true;
   });
 
-  /** The active employer's rows ON THIS BOARD — what the band describes. */
-  const companySet =
-    companyFilter !== null
-      ? applications.filter((app) => app.company === companyFilter)
-      : null;
-
   /**
    * The chip is suppressed for the company the board is already filtered to —
    * "N more at Amazon" while looking at exactly Amazon's set was the bug this
@@ -350,17 +367,47 @@ export function PipelineBoard({
   const showSearch = interactive && applications.length > SEARCH_AFTER;
 
   const columns = boardColumns(STAGES);
-  /** Spine counts read the UNFILTERED rows (with the optimistic overlay), so
-   *  typing a search never reflows the pipeline's stated shape — the spine is
-   *  the account's distribution, the list is the current view. Recomputed per
-   *  render on purpose: one O(n) pass over an already-bounded page. */
-  const spineCounts: Record<StageKey, number> = {
-    applied: 0,
-    interviewing: 0,
-    offered: 0,
-    rejected: 0,
-  };
-  for (const app of applications) spineCounts[stageOf(shownStatus(app))] += 1;
+  /**
+   * The spine states the ACCOUNT's distribution — never the current view's,
+   * and never this page's.
+   *
+   * Not the view's: the counts ignore the search and the company filter, so
+   * typing never reflows the pipeline's stated shape. The spine is the shape,
+   * the list is what you are looking at.
+   *
+   * Not the page's: counting the loaded rows was wrong by construction. Past
+   * `BOARD_PAGE_SIZE` an account's columns would sum to the page, not the
+   * account, and contradict the subtitle's own total the way the scope note
+   * exists to prevent. `stageTotals` is the database's `GROUP BY status`, so
+   * when the caller has it, it wins — and it stays right whatever the list
+   * shows, including once several applications at one employer share a card.
+   * A caller cannot supply `total` without it (see `BoardScope`).
+   *
+   * Optimistic moves still land immediately: a pending drop is a ±1 delta on
+   * top of whichever base is in use, and settles when `router.refresh()`
+   * brings the server's own count back.
+   *
+   * The GROUP HEADINGS below are deliberately NOT treated this way — they
+   * label the rows actually listed, where "applied — 250" over 200 loaded
+   * rows would be its own lie. Spine = the account; headings and `scopeNote`
+   * = this page.
+   */
+  const spineCounts: Record<StageKey, number> = stageTotals
+    ? { ...stageTotals }
+    : { applied: 0, interviewing: 0, offered: 0, rejected: 0 };
+  if (stageTotals) {
+    for (const app of applications) {
+      const pending = pendingMoves[app.id];
+      if (pending === undefined) continue;
+      spineCounts[stageOf(app.status)] -= 1;
+      spineCounts[stageOf(pending)] += 1;
+    }
+  } else {
+    for (const app of applications) spineCounts[stageOf(shownStatus(app))] += 1;
+  }
+  /** "all" must equal the columns it sits above, so it is summed from the same
+   *  source rather than read off `applications.length`. */
+  const spineTotal = columns.reduce((n, column) => n + spineCounts[column.key], 0);
   const spineMax = Math.max(1, ...columns.map((c) => spineCounts[c.key]));
 
   /** Groups actually rendered in the list: the selected stage (even empty, so
@@ -515,7 +562,7 @@ export function PipelineBoard({
       <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5 lg:hidden">
         <button
           type="button"
-          aria-label={`all stages — ${applications.length}`}
+          aria-label={`all stages — ${spineTotal}`}
           aria-pressed={stageFilter === "all"}
           onClick={() => setStageFilter("all")}
           className={cn(
@@ -526,7 +573,7 @@ export function PipelineBoard({
           )}
         >
           all
-          <span className="tabular font-mono text-[11px]">{applications.length}</span>
+          <span className="tabular font-mono text-[11px]">{spineTotal}</span>
         </button>
         {columns.map((column) => stageButton(column, "chip"))}
       </div>
@@ -543,7 +590,7 @@ export function PipelineBoard({
           <p className="label-caps px-2.5 pb-1">stages</p>
           <button
             type="button"
-            aria-label={`all stages — ${applications.length}`}
+            aria-label={`all stages — ${spineTotal}`}
             aria-pressed={stageFilter === "all"}
             onClick={() => setStageFilter("all")}
             className={cn(
@@ -563,7 +610,7 @@ export function PipelineBoard({
                 all
               </span>
               <span className="tabular ml-auto font-mono text-[11px] text-strong">
-                {applications.length}
+                {spineTotal}
               </span>
             </span>
           </button>
@@ -572,12 +619,10 @@ export function PipelineBoard({
         </aside>
 
         <div className={cn("flex min-w-0 flex-1 flex-col gap-3", locked && "lg:min-h-0")}>
-          {/* --- The employer's set, named --------------------------------- */}
-          {companyFilter !== null && companySet !== null ? (
+          {/* --- The filter state, stated once ------------------------------ */}
+          {companyFilter !== null ? (
             <CompanyBand
               company={companyFilter}
-              apps={companySet}
-              statusOf={shownStatus}
               partial={truncated}
               onClear={() => setCompanyFilter(null)}
             />

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -62,6 +62,7 @@ export function PipelinePulse({
   applications,
   total,
   needsReview,
+  layout = "strip",
 }: {
   /** The board's loaded rows — the same page `PipelineBoard` renders. */
   applications: Application[];
@@ -69,6 +70,11 @@ export function PipelinePulse({
   total: number;
   /** Verdicts held under the gate for the user (0 when the queue is clear). */
   needsReview: number;
+  /** `strip` — the standalone horizontal band (the /demo twin). `rail` — the
+   *  same four cells stacked for the board's spine, framed by the spine
+   *  itself rather than their own border. Content and testids are identical
+   *  in both, so the derived signals have one implementation to audit. */
+  layout?: "strip" | "rail";
 }) {
   const today = useLocalToday();
   /** True when the single board page holds every row the account has. */
@@ -101,14 +107,28 @@ export function PipelinePulse({
 
   const scopeNote = complete ? null : `newest ${applications.length} of ${total}`;
 
+  const rail = layout === "rail";
+  /** Per-cell frame: the strip draws its own borders; the rail cells stack
+   *  with hairline separators and lean on the spine's framing. */
+  const cell = {
+    momentum: rail ? "py-3 first:pt-0" : "border-b border-line-soft p-4 sm:border-r lg:border-b-0",
+    ageing: rail ? "border-t border-line-soft py-3" : "border-b border-line-soft p-4 lg:border-b-0 lg:border-r",
+    deadlines: rail ? "border-t border-line-soft py-3" : "border-b border-line-soft p-4 sm:border-b-0 sm:border-r",
+    classifier: rail ? "border-t border-line-soft py-3 last:pb-0" : "p-4",
+  };
+
   return (
     <section
       aria-label="Pipeline pulse"
       data-testid="pipeline-pulse"
-      className="grid overflow-hidden rounded-xl border border-line-soft bg-surface sm:grid-cols-2 lg:grid-cols-4"
+      className={
+        rail
+          ? "flex flex-col"
+          : "grid overflow-hidden rounded-xl border border-line-soft bg-surface sm:grid-cols-2 lg:grid-cols-4"
+      }
     >
       {/* --- momentum -------------------------------------------------------- */}
-      <div className="border-b border-line-soft p-4 sm:border-r lg:border-b-0">
+      <div className={cell.momentum}>
         <h2 className="label-caps">momentum · filed per wk</h2>
         <div
           role="img"
@@ -141,7 +161,7 @@ export function PipelinePulse({
       </div>
 
       {/* --- ageing ---------------------------------------------------------- */}
-      <div className="border-b border-line-soft p-4 lg:border-b-0 lg:border-r">
+      <div className={cell.ageing}>
         <h2 className="label-caps">open · age since filed</h2>
         {openTotal === 0 ? (
           <p className="mt-3 text-xs text-dim">no open applications</p>
@@ -185,7 +205,7 @@ export function PipelinePulse({
       </div>
 
       {/* --- deadlines ------------------------------------------------------- */}
-      <div className="border-b border-line-soft p-4 sm:border-b-0 sm:border-r">
+      <div className={cell.deadlines}>
         <h2 className="label-caps">deadlines · time left</h2>
         {due.total === 0 ? (
           <>
@@ -256,7 +276,7 @@ export function PipelinePulse({
       </div>
 
       {/* --- classifier ------------------------------------------------------ */}
-      <div className="p-4">
+      <div className={cell.classifier}>
         <h2 className="label-caps">classifier</h2>
         <div
           role="img"

--- a/apps/web/components/dashboard/RowActionsMenu.tsx
+++ b/apps/web/components/dashboard/RowActionsMenu.tsx
@@ -160,8 +160,14 @@ export function RowActionsMenu({
         className={
           // `pointer-coarse:opacity-100`: hover-revealed is no affordance at
           // all on touch, so a coarse pointer always sees the trigger.
+          // `group-hover/row` matches the worklist row's group name — the old
+          // `/card` name outlived the card→row rename, so a mouse hovering a
+          // row never saw the trigger at all (focus and coarse pointers did).
+          // `grid h-6 w-6`: the same fixed 24px box as the cluster's other
+          // controls — an inline button + baseline slop measured 25px, and
+          // that stray pixel was the difference between row heights.
           triggerClassName ??
-          "rounded p-0.5 text-dim opacity-0 transition-opacity hover:text-strong focus-visible:opacity-100 disabled:opacity-30 group-hover/card:opacity-100 aria-expanded:opacity-100 pointer-coarse:opacity-100"
+          "grid h-6 w-6 place-items-center rounded text-dim opacity-0 transition-opacity hover:text-strong focus-visible:opacity-100 disabled:opacity-30 group-hover/row:opacity-100 aria-expanded:opacity-100 pointer-coarse:opacity-100"
         }
       >
         {triggerContent ?? <MoreHorizontal className="h-4 w-4" aria-hidden />}

--- a/apps/web/components/dashboard/SyncBar.tsx
+++ b/apps/web/components/dashboard/SyncBar.tsx
@@ -441,7 +441,11 @@ export function SyncBar({
                     simulated account · nothing is read
                   </span>
                 ) : (
-                  <LastSynced at={gmail?.lastSyncAt ?? null} className="font-mono text-[11px] text-dim" />
+                  // A sentence, so the product voice — the machine-readable
+                  // instant already rides in the <time> element's dateTime and
+                  // title. Mono here was the "last synced …" defect the
+                  // type-system note in globals.css names.
+                  <LastSynced at={gmail?.lastSyncAt ?? null} className="text-xs text-dim" />
                 )
               ) : null}
               <button

--- a/apps/web/components/dashboard/SyncBar.tsx
+++ b/apps/web/components/dashboard/SyncBar.tsx
@@ -427,17 +427,22 @@ export function SyncBar({
     // `data-sync-surface` scopes assertions (e.g. "no percentage anywhere in
     // the sync UI") to this surface without leaning on copy or classes.
     <div className="space-y-2" data-sync-surface="">
+      {/* Below `sm` the action cluster takes its own full-width line under the
+          title, anchored LEFT — flex-wrap + justify-end orphaned "File an
+          application" on its own right-aligned line with a dead gap beside it.
+          The recency sentence drops to a quiet line of its own down there
+          (`order-last`), so the controls read as one bar. */}
       <header className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-strong">Pipeline</h1>
           <p className="tabular mt-1 text-[13px] text-muted">{subtitle}</p>
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
           {connected ? (
             <>
               {showRecency ? (
                 simulated ? (
-                  <span className="text-xs text-dim">
+                  <span className="order-last w-full text-xs text-dim sm:order-none sm:w-auto">
                     simulated account · nothing is read
                   </span>
                 ) : (
@@ -445,7 +450,10 @@ export function SyncBar({
                   // instant already rides in the <time> element's dateTime and
                   // title. Mono here was the "last synced …" defect the
                   // type-system note in globals.css names.
-                  <LastSynced at={gmail?.lastSyncAt ?? null} className="text-xs text-dim" />
+                  <LastSynced
+                    at={gmail?.lastSyncAt ?? null}
+                    className="order-last w-full text-xs text-dim sm:order-none sm:w-auto"
+                  />
                 )
               ) : null}
               <button

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -11,7 +11,11 @@ import { isApplicationStatus } from "@/lib/dashboard/status";
 import { summarize, type Application } from "@/lib/dashboard/summary";
 import type { BoardTransport, SyncTransport } from "@/lib/dashboard/transport";
 import { useLocalToday } from "@/lib/dashboard/useLocalToday";
-import { demoApplicationsAsApi, demoUnsyncedAsApi } from "@/lib/demo/asApplications";
+import {
+  demoApplicationsAsApi,
+  demoEarlySearchAsApi,
+  demoUnsyncedAsApi,
+} from "@/lib/demo/asApplications";
 import { demoDetailBody } from "@/lib/demo/demoDetail";
 import { datedById, redate } from "@/lib/demo/redate";
 
@@ -78,13 +82,19 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Which fixture projection the twin renders — see `asApplications.ts`. */
+export type DemoPipeline = "seed" | "early";
+
 /** The whole fixture store, dated against one day — board and pool alike. */
-function buildStore(today: string): DemoBoard {
-  return { apps: demoApplicationsAsApi(today), pool: demoUnsyncedAsApi(today), touched: [] };
+function buildStore(today: string, pipeline: DemoPipeline): DemoBoard {
+  return {
+    apps: pipeline === "early" ? demoEarlySearchAsApi(today) : demoApplicationsAsApi(today),
+    pool: demoUnsyncedAsApi(today),
+    touched: [],
+  };
 }
 
-
-export function DemoDashboard() {
+export function DemoDashboard({ pipeline = "seed" }: { pipeline?: DemoPipeline }) {
   // The day this demo is rendered against. UTC on the server and through
   // hydration, the visitor's own day once mounted — the same read the board,
   // the cards and the pulse strip make for themselves (`useLocalToday`).
@@ -96,7 +106,7 @@ export function DemoDashboard() {
   // module load is what keeps a long-lived server's HTML and the browser's
   // hydration agreeing on what "16 days ago" means.
   const [datedFor, setDatedFor] = useState(todayISO);
-  const [snapshot, setSnapshot] = useState<DemoBoard>(() => buildStore(datedFor));
+  const [snapshot, setSnapshot] = useState<DemoBoard>(() => buildStore(datedFor, pipeline));
   /** The pristine fixtures, kept for `restore` — the rows this board began
    *  with, before any drag, dismissal or rebuild touched them. */
   const original = useRef<Application[]>([...snapshot.apps, ...snapshot.pool]);
@@ -134,7 +144,7 @@ export function DemoDashboard() {
   useEffect(() => {
     if (datedFor === today) return;
     const id = window.setTimeout(() => {
-      const pristine = buildStore(today);
+      const pristine = buildStore(today, pipeline);
       const dated = datedById([...pristine.apps, ...pristine.pool]);
       const s = store.current;
       original.current = [...pristine.apps, ...pristine.pool];
@@ -142,7 +152,7 @@ export function DemoDashboard() {
       commit({ ...s, apps: redate(s.apps, dated), pool: redate(s.pool, dated) });
     }, 0);
     return () => window.clearTimeout(id);
-  }, [today, datedFor, commit]);
+  }, [today, datedFor, pipeline, commit]);
 
   const boardTransport = useMemo<BoardTransport>(
     () => ({

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -323,7 +323,9 @@ export function DemoDashboard({ pipeline = "seed" }: { pipeline?: DemoPipeline }
   }`;
 
   return (
-    <section className="space-y-6">
+    // A flex column (not `space-y`) so the pulse strip can reorder below the
+    // board at phone width without a second instance — see its wrapper.
+    <section className="flex flex-col gap-6">
       <SyncBar subtitle={subtitle} gmail={DEMO_GMAIL} transport={syncTransport}>
         <AddApplicationForm mode="demo" />
       </SyncBar>
@@ -345,8 +347,18 @@ export function DemoDashboard({ pipeline = "seed" }: { pipeline?: DemoPipeline }
           deep-links to /dashboard#needs-classification — an auth-gated route
           that would dead-end an anonymous visitor. The fixture queue
           (DEMO_REVIEW_QUEUE) does hold one sub-gate message; the DecisionTrace
-          lower down this page is where it is shown and explained. */}
-      <PipelinePulse applications={snapshot.apps} total={snapshot.apps.length} needsReview={0} />
+          lower down this page is where it is shown and explained.
+
+          `max-sm:order-last`: at phone width the four cells stack into a
+          full-width column that pushed the first application row ~1500px down
+          the page, so the strip yields the top to the worklist — the same
+          answer the signed-in dashboard already gives below `lg`. One
+          instance, reordered visually; it holds no interactive content here
+          (needsReview is 0 by construction), so visual order and tab order
+          cannot disagree. */}
+      <div className="max-sm:order-last">
+        <PipelinePulse applications={snapshot.apps} total={snapshot.apps.length} needsReview={0} />
+      </div>
       <PipelineBoard applications={snapshot.apps} transport={boardTransport} />
     </section>
   );

--- a/apps/web/components/demo/SampleInbox.tsx
+++ b/apps/web/components/demo/SampleInbox.tsx
@@ -195,7 +195,7 @@ function InboxRow({
         onClick={onToggle}
         aria-expanded={open}
         data-testid="sample-row"
-        className="trace-row flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left hover:bg-surface-2"
+        className="trace-row focus-inset flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left hover:bg-surface-2"
       >
         <div className="min-w-0 basis-full sm:basis-0 sm:flex-1">
           <p className="truncate text-sm font-medium text-strong">{email.subject}</p>

--- a/apps/web/components/gmail/InboxWorkbench.tsx
+++ b/apps/web/components/gmail/InboxWorkbench.tsx
@@ -645,7 +645,7 @@ export function InboxWorkbench({ email }: { email?: string | null }) {
             type="button"
             onClick={() => void fileThese()}
             disabled={filing.phase === "filing"}
-            className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-strong px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules disabled:cursor-not-allowed disabled:opacity-40"
+            className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-strong px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90 focus-accent disabled:cursor-not-allowed disabled:opacity-40"
           >
             {filing.phase === "filing" ? (
               <>

--- a/apps/web/components/landing/InboxScene.tsx
+++ b/apps/web/components/landing/InboxScene.tsx
@@ -64,7 +64,7 @@ export function RawInbox() {
                 key={row.subject}
                 tabIndex={0}
                 aria-label={`${row.subject} — hover to classify`}
-                className="group relative flex cursor-default items-center gap-3 px-4 py-3 outline-none transition-colors hover:bg-surface-2 focus-visible:bg-surface-2"
+                className="focus-inset group relative flex cursor-default items-center gap-3 px-4 py-3 transition-colors hover:bg-surface-2 focus-visible:bg-surface-2"
               >
                 <span className="relative h-3 w-3 shrink-0" aria-hidden>
                   <span className="absolute inset-0 rounded-[3px] border border-line-strong transition-opacity duration-300 group-hover:opacity-0 group-focus-visible:opacity-0" />

--- a/apps/web/components/mail/FiledMailList.tsx
+++ b/apps/web/components/mail/FiledMailList.tsx
@@ -1,0 +1,269 @@
+import { ExternalLink, Search } from "lucide-react";
+import Link from "next/link";
+
+import { ReclassifyControl } from "@/components/mail/ReclassifyControl";
+import { GateMeter } from "@/components/viz/GateMeter";
+import { shortDate } from "@/lib/dashboard/dates";
+import { CATEGORY_META, CATEGORY_ORDER } from "@/lib/gmail/types";
+import {
+  filedMailHref,
+  filedPageCount,
+  type FiledMailPage,
+} from "@/lib/mail/filed";
+import { cn } from "@/lib/utils";
+
+/**
+ * The filed-mail ledger — every message Applied has stored, whatever the
+ * verdict, wherever it went. Server-rendered from `GET /applications/mail`
+ * and driven entirely by the URL (category chips are links, search is a GET
+ * form, the pager is links), so a filter state is shareable and the back
+ * button works; the only client islands are the per-row corrections.
+ *
+ * This is the surface the review queue could never be: the queue filters to
+ * `needs_review AND unlinked AND unreviewed`, so a verdict left it forever the
+ * moment it was touched — the product could display a wrong verdict it would
+ * never let you fix (messages 58/59 in production are exactly that state).
+ * Here every row carries `ReclassifyControl`, and the backend accepts a
+ * correction for any owned message, so a verdict stays correctable for as
+ * long as it exists.
+ */
+
+const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+function CategoryChips({
+  page,
+  activeCategory,
+  q,
+}: {
+  page: FiledMailPage;
+  activeCategory: string | null;
+  q: string | null;
+}) {
+  // Canonical order first, then anything the backend adds later — a category
+  // this file doesn't know is still shown, never silently dropped.
+  const known = CATEGORY_ORDER.filter((c) => (page.categoryCounts[c] ?? 0) > 0);
+  const extra = Object.keys(page.categoryCounts)
+    .filter((c) => !(CATEGORY_ORDER as readonly string[]).includes(c) && page.categoryCounts[c] > 0)
+    .sort();
+  const all = Object.values(page.categoryCounts).reduce((sum, n) => sum + n, 0);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Link
+        href={filedMailHref({ q })}
+        aria-current={activeCategory === null ? "true" : undefined}
+        className={cn(
+          "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+          activeCategory === null
+            ? "border-line-strong text-strong"
+            : "border-line-soft text-dim hover:text-muted",
+        )}
+      >
+        all {all}
+      </Link>
+      {[...known, ...extra].map((c) => {
+        const meta = CATEGORY_META[c] ?? { label: c.replaceAll("_", " "), dot: "bg-dim" };
+        const active = activeCategory === c;
+        return (
+          <Link
+            key={c}
+            href={active ? filedMailHref({ q }) : filedMailHref({ category: c, q })}
+            aria-current={active ? "true" : undefined}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+              active
+                ? "border-line-strong text-strong"
+                : "border-line-soft text-muted hover:text-strong",
+            )}
+          >
+            <span className={`h-1.5 w-1.5 rounded-full ${meta.dot}`} aria-hidden />
+            {meta.label} {page.categoryCounts[c]}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+export function FiledMailList({
+  page,
+  activeCategory,
+  q,
+}: {
+  page: FiledMailPage;
+  activeCategory: string | null;
+  q: string | null;
+}) {
+  const pages = filedPageCount(page.total, page.pageSize);
+
+  return (
+    <div className="space-y-4">
+      {/* --- Filters: category chips + search ------------------------------ */}
+      <div className="space-y-3 rounded-xl border border-line-soft bg-surface p-4">
+        <CategoryChips page={page} activeCategory={activeCategory} q={q} />
+        <form method="get" action="/inbox" className="flex flex-wrap items-center gap-3 border-t border-line-soft pt-3">
+          {activeCategory ? <input type="hidden" name="category" value={activeCategory} /> : null}
+          <div className="relative min-w-0 flex-1 basis-48">
+            <Search
+              className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-dim"
+              aria-hidden
+            />
+            <input
+              type="search"
+              name="q"
+              defaultValue={q ?? ""}
+              placeholder="search subject, sender, company…"
+              aria-label="Search stored mail"
+              className="w-full rounded-lg border border-line bg-surface-2 py-1.5 pl-8 pr-3 text-sm text-strong outline-none placeholder:text-dim focus:border-line-strong"
+            />
+          </div>
+          <button
+            type="submit"
+            className="rounded-lg border border-line px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-line-strong hover:text-strong"
+          >
+            search
+          </button>
+          {q ? (
+            <Link
+              href={filedMailHref({ category: activeCategory })}
+              className="text-xs text-dim underline-offset-2 hover:text-strong hover:underline"
+            >
+              clear
+            </Link>
+          ) : null}
+        </form>
+      </div>
+
+      {/* --- The messages --------------------------------------------------- */}
+      {page.messages.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-line-soft bg-surface p-8 text-center">
+          <p className="text-sm text-muted">
+            {q || activeCategory
+              ? "Nothing stored matches this view."
+              : "Nothing stored yet — mail lands here as Applied reads your inbox."}
+          </p>
+          <p className="mt-2 text-xs text-dim">
+            {q || activeCategory ? (
+              <Link href="/inbox" className="underline-offset-2 hover:text-strong hover:underline">
+                clear the filters →
+              </Link>
+            ) : (
+              <>
+                sync from the dashboard, or{" "}
+                <Link
+                  href="/inbox?view=scan"
+                  className="underline-offset-2 hover:text-strong hover:underline"
+                >
+                  run a live scan →
+                </Link>
+              </>
+            )}
+          </p>
+        </div>
+      ) : (
+        <ul className="rounded-xl border border-line-soft bg-surface px-3">
+          {page.messages.map((m) => {
+            const meta = m.category
+              ? (CATEGORY_META[m.category] ?? { label: m.category.replaceAll("_", " "), dot: "bg-dim" })
+              : { label: "unclassified", dot: "bg-dim" };
+            const sender = m.sender_name || m.sender_email || "unknown sender";
+            const subject = m.subject || "(no subject)";
+            return (
+              <li
+                key={m.message_id}
+                className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b border-line-soft px-1 py-3 last:border-b-0"
+              >
+                <div className="min-w-0 basis-full sm:basis-0 sm:flex-1">
+                  <p className="truncate text-sm font-medium text-strong">{subject}</p>
+                  <p className="truncate text-xs text-dim">
+                    {sender}
+                    {m.company ? <span className="text-muted"> · {m.company}</span> : null}
+                  </p>
+                  {m.snippet ? (
+                    <p className="mt-0.5 line-clamp-1 text-[11px] leading-snug text-dim">{m.snippet}</p>
+                  ) : null}
+                </div>
+                <span className="inline-flex w-24 items-center gap-1.5 text-xs text-muted">
+                  <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${meta.dot}`} aria-hidden />
+                  <span className="truncate">{meta.label}</span>
+                </span>
+                {typeof m.confidence === "number" ? (
+                  <>
+                    <GateMeter confidence={m.confidence} className="hidden sm:inline-block" />
+                    <span
+                      className="tabular w-10 text-right font-mono text-[11px]"
+                      style={{
+                        color: m.category === "needs_review" ? "var(--amber)" : "var(--green)",
+                      }}
+                    >
+                      {pct(m.confidence)}
+                    </span>
+                  </>
+                ) : null}
+                <span className="tabular hidden w-12 shrink-0 text-right font-mono text-[10px] text-dim md:inline">
+                  {m.received_at ? shortDate(m.received_at) : ""}
+                </span>
+                {m.gmail_link ? (
+                  <a
+                    href={m.gmail_link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`Open “${subject}” in Gmail`}
+                    title="open in gmail"
+                    className="grid h-6 w-6 shrink-0 place-items-center rounded text-dim transition-colors hover:bg-surface-2 hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                  </a>
+                ) : null}
+                {/* The row's standing facts: whose verdict it is, and whether it
+                    built a board row. Quiet — they qualify, they don't shout. */}
+                <span className="flex basis-full flex-wrap items-center gap-x-3 gap-y-1">
+                  {m.user_corrected ? (
+                    <span className="text-[11px] text-dim">corrected by you</span>
+                  ) : null}
+                  {m.application_id !== null ? (
+                    <span className="text-[11px] text-dim">on your board</span>
+                  ) : null}
+                  <ReclassifyControl
+                    messageId={m.message_id}
+                    subject={subject}
+                    company={m.company}
+                  />
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* --- Pager ----------------------------------------------------------- */}
+      {pages > 1 ? (
+        <nav aria-label="Mail pages" className="flex items-center justify-between">
+          {page.page > 1 ? (
+            <Link
+              href={filedMailHref({ category: activeCategory, q, page: page.page - 1 })}
+              className="text-xs text-muted underline-offset-2 hover:text-strong hover:underline"
+            >
+              ← newer
+            </Link>
+          ) : (
+            <span aria-hidden />
+          )}
+          <span className="tabular font-mono text-[11px] text-dim">
+            page {page.page} of {pages}
+          </span>
+          {page.page < pages ? (
+            <Link
+              href={filedMailHref({ category: activeCategory, q, page: page.page + 1 })}
+              className="text-xs text-muted underline-offset-2 hover:text-strong hover:underline"
+            >
+              older →
+            </Link>
+          ) : (
+            <span aria-hidden />
+          )}
+        </nav>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/mail/ReclassifyControl.tsx
+++ b/apps/web/components/mail/ReclassifyControl.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import {
+  CLASSIFY_FAILED,
+  canNameCompany,
+  classifyRequestBody,
+  employerPromptFor,
+  readClassifyOutcome,
+  rowStaysInQueue,
+} from "@/lib/dashboard/review";
+
+/**
+ * The correction affordance the filed-mail view exists for: every stored
+ * verdict — including one already reviewed or already linked to a row, which
+ * the needs-review queue can never show again — gets a way to be corrected.
+ *
+ * Same wire contract as the review queue, read through the same
+ * `readClassifyOutcome`: a 2xx does NOT mean a row was filed. When the backend
+ * cannot name the employer it answers `needs_employer: true` and files
+ * nothing, so this control keeps the panel open, says what is missing, and
+ * asks for the company instead of pretending the click worked.
+ *
+ * The category list starts at a placeholder on purpose — the control must not
+ * answer for the user (a preselected value is how absent-minded clicks become
+ * training examples). Choices mirror the review queue's: classifier categories
+ * the classify endpoint accepts, with "other" meaning "not job related".
+ */
+const CATEGORY_CHOICES: { value: string; label: string }[] = [
+  { value: "applied", label: "applied" },
+  { value: "interview", label: "interviewing" },
+  { value: "assessment", label: "assessment" },
+  { value: "offer", label: "offer" },
+  { value: "rejection", label: "rejection" },
+  { value: "other", label: "not job related" },
+];
+
+const PLACEHOLDER = "";
+
+export function ReclassifyControl({
+  messageId,
+  subject,
+  company,
+}: {
+  messageId: string;
+  /** For the control's accessible name — three bare "reclassify" buttons in a
+   *  list are indistinguishable to a screen reader. */
+  subject: string;
+  /** The row's resolved employer token, if any — prefills the employer ask. */
+  company: string | null;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState(PLACEHOLDER);
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  /** Set when the backend filed nothing because it couldn't name the employer. */
+  const [employerPrompt, setEmployerPrompt] = useState<string | null>(null);
+  const [namedCompany, setNamedCompany] = useState(company ?? "");
+
+  async function apply() {
+    setBusy(true);
+    setError(null);
+    const named = namedCompany.trim();
+    try {
+      const res = await fetch(
+        `/api/applications/review/${encodeURIComponent(messageId)}/classify`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // Only send the company once the backend has asked for it — sending
+          // it up front would override an employer the mail itself names.
+          body: JSON.stringify(classifyRequestBody(category, employerPrompt ? named : null)),
+        },
+      );
+      const outcome = readClassifyOutcome(res.ok, await res.json().catch(() => ({})));
+      if (rowStaysInQueue(outcome)) {
+        if (outcome.kind === "needs-employer") {
+          setEmployerPrompt(employerPromptFor(employerPrompt ? named : ""));
+        } else {
+          setError(outcome.detail);
+        }
+        setBusy(false);
+        return;
+      }
+      // The correction stuck. Refresh re-renders the server list (and the
+      // rail's counts) with the new verdict; the local "corrected" note covers
+      // the gap so the click is never silent.
+      setDone(true);
+      setBusy(false);
+      router.refresh();
+    } catch {
+      setError(CLASSIFY_FAILED);
+      setBusy(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <p role="status" className="text-xs text-live">
+        corrected — your call is the verdict now
+      </p>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`Reclassify “${subject}”`}
+        className="rounded border border-line px-2 py-1 text-xs font-medium text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+      >
+        reclassify
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-wrap items-center gap-2">
+      <label className="sr-only" htmlFor={`reclass-${messageId}`}>
+        New category for “{subject}”
+      </label>
+      <select
+        id={`reclass-${messageId}`}
+        value={category}
+        disabled={busy}
+        onChange={(e) => setCategory(e.target.value)}
+        className="rounded border border-line-soft bg-surface px-1.5 py-1 text-xs text-muted outline-none transition-colors hover:border-line focus:border-line-strong disabled:opacity-50"
+      >
+        <option value={PLACEHOLDER} disabled>
+          choose a category…
+        </option>
+        {CATEGORY_CHOICES.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={() => void apply()}
+        disabled={busy || category === PLACEHOLDER || (employerPrompt !== null && !canNameCompany(namedCompany))}
+        className="inline-flex items-center gap-1 rounded border border-line px-2 py-1 text-xs font-medium text-foreground transition-colors hover:border-line-strong hover:text-strong disabled:opacity-50"
+      >
+        {busy ? <Loader2 className="h-3 w-3 animate-spin motion-reduce:animate-none" aria-hidden /> : null}
+        apply
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(false);
+          setError(null);
+          setEmployerPrompt(null);
+        }}
+        disabled={busy}
+        className="text-xs text-dim underline-offset-2 hover:text-strong hover:underline disabled:opacity-50"
+      >
+        cancel
+      </button>
+
+      {employerPrompt ? (
+        <div className="flex basis-full flex-wrap items-center gap-2 rounded border border-review/40 bg-surface px-2.5 py-2">
+          <p role="status" className="basis-full text-xs leading-relaxed text-review">
+            {employerPrompt}
+          </p>
+          <label className="sr-only" htmlFor={`reclass-company-${messageId}`}>
+            Company this email is from
+          </label>
+          <input
+            id={`reclass-company-${messageId}`}
+            value={namedCompany}
+            disabled={busy}
+            onChange={(e) => setNamedCompany(e.target.value)}
+            placeholder="company name"
+            autoComplete="organization"
+            spellCheck={false}
+            className="min-w-0 flex-1 rounded border border-line-soft bg-surface-2 px-1.5 py-1 text-xs text-strong outline-none transition-colors placeholder:text-dim hover:border-line focus:border-line-strong disabled:opacity-50"
+          />
+        </div>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="basis-full text-xs text-reject-ink">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/settings/AccountSection.tsx
+++ b/apps/web/components/settings/AccountSection.tsx
@@ -7,7 +7,7 @@ import { LogOut } from "lucide-react";
 import { SettingsSection } from "./SettingsSection";
 import { Dialog } from "@/components/ui/Dialog";
 import { dangerBtnClass, inputClass, secondaryBtnClass } from "@/components/ui/formStyles";
-import { createClient } from "@/lib/supabase/client";
+import { settingsTransport, type SettingsMode } from "@/lib/settings/transport";
 
 const CONFIRM_WORD = "DELETE";
 
@@ -16,19 +16,30 @@ const CONFIRM_WORD = "DELETE";
  * DELETE to arm, then calls the server route that removes the account. If the
  * deployment hasn't enabled deletion (no service-role key), the route says so
  * honestly rather than silently doing nothing — the button is never a no-op.
+ * On the `/demo/settings` twin the same gate runs end to end; the transport's
+ * answer is the one honest difference ("simulated account — nothing exists to
+ * delete").
  */
-export function AccountSection({ email }: { email: string }) {
+export function AccountSection({ email, mode = "live" }: { email: string; mode?: SettingsMode }) {
   const router = useRouter();
   const [signingOut, setSigningOut] = useState(false);
+  const [signOutNote, setSignOutNote] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const [confirm, setConfirm] = useState("");
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const transport = settingsTransport(mode);
 
   async function signOut() {
     setSigningOut(true);
-    const supabase = createClient();
-    await supabase.auth.signOut();
+    await transport.signOut();
+    if (transport.mode === "demo") {
+      // No session exists here to end — the twin says so instead of bouncing
+      // an anonymous visitor to the login wall.
+      setSignOutNote("Simulated account — there is no session to sign out of.");
+      setSigningOut(false);
+      return;
+    }
     router.refresh();
     router.replace("/login");
   }
@@ -36,29 +47,23 @@ export function AccountSection({ email }: { email: string }) {
   async function deleteAccount() {
     setDeleting(true);
     setError(null);
-    try {
-      const res = await fetch("/api/account/delete", { method: "POST" });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
-        setError(
-          typeof body.detail === "string"
-            ? body.detail
-            : "Account deletion isn’t available on this deployment yet.",
-        );
-        setDeleting(false);
-        return;
-      }
-      const supabase = createClient();
-      await supabase.auth.signOut();
-      router.replace("/");
-    } catch {
-      setError("Couldn’t reach the server. Try again shortly.");
+    const result = await transport.deleteAccount();
+    if (!result.ok) {
+      setError(result.detail ?? "Account deletion isn’t available on this deployment yet.");
       setDeleting(false);
+      return;
     }
+    await transport.signOut();
+    router.replace("/");
   }
 
   return (
-    <SettingsSection title="Account" description="Sign out, or remove your account entirely." tone="danger">
+    <SettingsSection
+      id="account"
+      title="Account"
+      description="Sign out, or remove your account entirely."
+      tone="danger"
+    >
       <div className="flex flex-wrap items-center gap-3">
         <button type="button" onClick={signOut} disabled={signingOut} className={secondaryBtnClass}>
           <LogOut className="h-4 w-4" aria-hidden="true" />
@@ -68,6 +73,12 @@ export function AccountSection({ email }: { email: string }) {
           Delete account
         </button>
       </div>
+
+      {signOutNote ? (
+        <p role="status" className="mt-3 text-xs text-dim">
+          {signOutNote}
+        </p>
+      ) : null}
 
       <p className="mt-3 text-[12px] leading-relaxed text-dim">
         Deleting removes your applications and revokes any connected Gmail. This can’t be undone.

--- a/apps/web/components/settings/AppearanceSection.tsx
+++ b/apps/web/components/settings/AppearanceSection.tsx
@@ -4,6 +4,7 @@ import { useSyncExternalStore } from "react";
 import { Moon, Sun } from "lucide-react";
 
 import { SettingsSection } from "./SettingsSection";
+import type { SettingsMode } from "@/lib/settings/transport";
 import { THEME_CHANGE_EVENT, applyTheme, readAppliedTheme, type Theme } from "@/lib/theme";
 
 const OPTIONS: { value: Theme; label: string; icon: typeof Moon }[] = [
@@ -26,8 +27,14 @@ function subscribe(onChange: () => void) {
  * the dark default, then the client syncs to the saved choice); selecting an
  * option flips `data-theme` on <html> and persists it, re-theming the whole app
  * with no reload and no flash on the next visit.
+ *
+ * `mode="demo"` changes nothing about the mechanism — the switch writes and
+ * persists the real theme there too — but the demo family pins its own dark
+ * ground (see app/demo/page.tsx), so the change is invisible ON that page. The
+ * control says so rather than looking broken: a switch you flip and nothing
+ * moves reads as a bug, whatever it did underneath.
  */
-export function AppearanceSection() {
+export function AppearanceSection({ mode = "live" }: { mode?: SettingsMode }) {
   const theme = useSyncExternalStore(subscribe, readAppliedTheme, () => "dark" as Theme);
 
   return (
@@ -57,7 +64,11 @@ export function AppearanceSection() {
           );
         })}
       </div>
-      <p className="mt-3 text-[12px] leading-relaxed text-dim">Saved on this device. Dark is the default.</p>
+      <p className="mt-3 text-[12px] leading-relaxed text-dim">
+        {mode === "demo"
+          ? "Saved on this device, and applied the moment you pick it — but the demo is shown in the product's dark theme throughout, so this page will not change colour. Sign in to see it applied."
+          : "Saved on this device. Dark is the default."}
+      </p>
     </SettingsSection>
   );
 }

--- a/apps/web/components/settings/AppearanceSection.tsx
+++ b/apps/web/components/settings/AppearanceSection.tsx
@@ -31,7 +31,7 @@ export function AppearanceSection() {
   const theme = useSyncExternalStore(subscribe, readAppliedTheme, () => "dark" as Theme);
 
   return (
-    <SettingsSection title="Appearance" description="Choose how Applied looks on this device.">
+    <SettingsSection id="appearance" title="Appearance" description="Choose how Applied looks on this device.">
       <div
         role="radiogroup"
         aria-label="Theme"

--- a/apps/web/components/settings/ClassificationSection.tsx
+++ b/apps/web/components/settings/ClassificationSection.tsx
@@ -6,7 +6,7 @@ import { SaveStatus, SettingsSection } from "./SettingsSection";
 import { primaryBtnClass } from "@/components/ui/formStyles";
 import { GATE_MAX, GATE_MIN } from "@/lib/dashboard/model";
 import { DEMO_REVIEW_QUEUE } from "@/lib/demo/demoData";
-import { createClient } from "@/lib/supabase/client";
+import { settingsTransport, type SettingsMode } from "@/lib/settings/transport";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -29,9 +29,16 @@ const CATEGORIES = [
  * persists to the user's metadata. The caption is explicit that the hosted
  * classifier still files at the shipped 0.85 gate today.
  */
-export function ClassificationSection({ initialGate }: { initialGate: number }) {
+export function ClassificationSection({
+  initialGate,
+  mode = "live",
+}: {
+  initialGate: number;
+  mode?: SettingsMode;
+}) {
   const [gate, setGate] = useState(initialGate);
   const [state, setState] = useState<SaveState>("idle");
+  const transport = settingsTransport(mode);
 
   const held = useMemo(
     () => DEMO_REVIEW_QUEUE.filter((v) => v.confidence < gate).length,
@@ -40,13 +47,13 @@ export function ClassificationSection({ initialGate }: { initialGate: number }) 
 
   async function save() {
     setState("saving");
-    const supabase = createClient();
-    const { error } = await supabase.auth.updateUser({ data: { gate_threshold: gate } });
-    setState(error ? "error" : "saved");
+    const { ok } = await transport.saveMetadata({ gate_threshold: gate });
+    setState(ok ? "saved" : "error");
   }
 
   return (
     <SettingsSection
+      id="classification"
       title="Classification"
       description="How Applied decides what to auto-file versus hold for you."
     >
@@ -106,8 +113,8 @@ export function ClassificationSection({ initialGate }: { initialGate: number }) 
         </div>
 
         <p className="text-[12px] leading-relaxed text-dim">
-          Your gate is stored on your account. The hosted classifier files at the shipped{" "}
-          <span className="font-mono text-muted">0.85</span> gate today and honors your value as
+          Stored on your account. The hosted classifier files at the shipped{" "}
+          <span className="font-mono text-muted">0.85</span> gate today; your value applies as
           per-user tuning rolls out.
         </p>
       </div>

--- a/apps/web/components/settings/DataSection.tsx
+++ b/apps/web/components/settings/DataSection.tsx
@@ -7,45 +7,45 @@ import { Download, Upload } from "lucide-react";
 import { SettingsSection } from "./SettingsSection";
 import { secondaryBtnClass } from "@/components/ui/formStyles";
 import { localTodayISO } from "@/lib/dashboard/age";
+import { settingsTransport, type SettingsMode } from "@/lib/settings/transport";
 
 type ExportState = "idle" | "working" | "error";
 
 /**
  * Data: export everything Applied holds for you, and the on-device mail
- * import path. Export pulls your rows from the server-side proxy (which carries
- * your JWT) and downloads them as JSON entirely in the browser — no third party,
- * nothing emailed.
+ * import path. Export pulls your rows through the settings transport (live:
+ * the server-side proxy, which carries your JWT) and downloads them as JSON
+ * entirely in the browser — no third party, nothing emailed.
  */
-export function DataSection() {
+export function DataSection({ mode = "live" }: { mode?: SettingsMode }) {
   const [state, setState] = useState<ExportState>("idle");
+  const transport = settingsTransport(mode);
 
   async function exportData() {
     setState("working");
-    try {
-      const res = await fetch("/api/applications", { headers: { Accept: "application/json" } });
-      if (!res.ok) throw new Error(`export failed (${res.status})`);
-      const data = await res.json();
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      // The user's own day, not UTC. `toISOString()` here put tomorrow's date
-      // on the file for anyone west of Greenwich after their evening cutoff —
-      // a New York export at 9pm was stamped with the next day. Same defect as
-      // the deadline bucketing, in a filename rather than a card.
-      a.download = `applied-applications-${localTodayISO()}.json`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-      setState("idle");
-    } catch {
+    const result = await transport.exportApplications();
+    if (!result.ok) {
       setState("error");
+      return;
     }
+    const blob = new Blob([JSON.stringify(result.data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    // The user's own day, not UTC. `toISOString()` here put tomorrow's date
+    // on the file for anyone west of Greenwich after their evening cutoff —
+    // a New York export at 9pm was stamped with the next day. Same defect as
+    // the deadline bucketing, in a filename rather than a card.
+    a.download = `applied-applications-${localTodayISO()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    setState("idle");
   }
 
   return (
-    <SettingsSection title="Your data" description="Take it with you, or bring more in.">
+    <SettingsSection id="data" title="Your data" description="Take it with you, or bring more in.">
       <div className="flex flex-wrap items-center gap-3">
         <button type="button" onClick={exportData} disabled={state === "working"} className={secondaryBtnClass}>
           <Download className="h-4 w-4" aria-hidden="true" />
@@ -62,8 +62,8 @@ export function DataSection() {
         </p>
       ) : (
         <p className="mt-3 text-[12px] leading-relaxed text-dim">
-          Export downloads your application rows as JSON, in your browser. Import classifies your own
-          mail on-device — nothing is uploaded.
+          Export downloads your rows as JSON, in your browser. Import classifies your own mail
+          on-device — nothing is uploaded.
         </p>
       )}
     </SettingsSection>

--- a/apps/web/components/settings/GmailConnectionCard.tsx
+++ b/apps/web/components/settings/GmailConnectionCard.tsx
@@ -78,8 +78,11 @@ export function GmailConnectionCard({
   const email = status?.email ?? null;
   const needsSignin = !demo && (result.kind === "unauthenticated" || result.kind === "auth");
 
+  // The one settings anchor that is not a <SettingsSection> (it is two cards
+  // under one id), so it carries that component's scroll-mt itself:
+  // `scroll-mt-16` below `lg` clears the chip strip SettingsNav pins there.
   return (
-    <div id="gmail" className="scroll-mt-4 space-y-6">
+    <div id="gmail" className="scroll-mt-16 space-y-6 lg:scroll-mt-4">
       {/* ---- Gmail connection card ------------------------------------- */}
       <div className="rounded-xl border border-line-soft bg-surface p-5">
         <div className="flex flex-wrap items-start justify-between gap-4">

--- a/apps/web/components/settings/GmailConnectionCard.tsx
+++ b/apps/web/components/settings/GmailConnectionCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ChevronDown } from "lucide-react";
 
 import { BetaCard } from "@/components/beta/BetaCard";
 import { ConnectGmailButton } from "@/components/gmail/ConnectGmailButton";
@@ -13,24 +14,76 @@ import type { GmailStatusResult } from "@/lib/gmail/server";
  * enabled vs. transient backend error), and every state routes forward (the
  * import fallback, the sample inbox) so the card is never a dead end.
  *
+ * The card leads with the STATE and the one control; the safeguards brief and
+ * the restricted-scope scale story still live here — they are the product's
+ * honesty and they stay — but behind disclosures, because they are reference
+ * material, not something to re-read on every visit. That cut is most of what
+ * "too much text for the user to read" was reacting to on this page.
+ *
  * A connected account also gets its sync state: when the board was last built,
  * whether the last attempt failed, and — only when a cursor actually exists —
  * that the next sync resumes from it. With `has_cursor` false the next sync is
  * a full scan, so nothing is claimed about it beyond the time.
+ *
+ * `demo` renders the same card on `/demo/settings` over a fixture status: the
+ * disconnect POST would 401 without a session, so the control is disabled and
+ * says why — a dead button with a reason beats a live one that lies.
  */
-export function GmailConnectionCard({ result }: { result: GmailStatusResult }) {
+
+/** One safeguard, one line — the details element carries the paragraph. */
+const SAFEGUARDS: [string, string][] = [
+  [
+    "Read-only",
+    "Applied requests only the gmail.readonly scope. It can read messages to classify them — it cannot send, delete, or modify anything.",
+  ],
+  [
+    "Standard OAuth",
+    "Sign-in happens on Google's own consent screen. Applied never sees your Google password.",
+  ],
+  [
+    "Encrypted at rest",
+    "The refresh token is stored Fernet-encrypted, scoped to your account. It is never shown in the browser, never logged, and never placed in a URL.",
+  ],
+  [
+    "Revocable anytime",
+    "Disconnect here to revoke access at Google and delete the stored token. You can also remove it at myaccount.google.com/permissions.",
+  ],
+];
+
+function Disclosure({ summary, children }: { summary: string; children: React.ReactNode }) {
+  return (
+    <details className="group border-t border-line-soft pt-3">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-sm font-medium text-muted transition-colors hover:text-strong [&::-webkit-details-marker]:hidden">
+        <ChevronDown
+          className="h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180 motion-reduce:transition-none"
+          aria-hidden
+        />
+        {summary}
+      </summary>
+      <div className="mt-3 space-y-3 pl-5">{children}</div>
+    </details>
+  );
+}
+
+export function GmailConnectionCard({
+  result,
+  demo = false,
+}: {
+  result: GmailStatusResult;
+  demo?: boolean;
+}) {
   const status = result.kind === "ok" ? result.status : null;
   const connected = status?.connected === true;
   const configured = status?.configured === true;
   const email = status?.email ?? null;
-  const needsSignin = result.kind === "unauthenticated" || result.kind === "auth";
+  const needsSignin = !demo && (result.kind === "unauthenticated" || result.kind === "auth");
 
   return (
-    <div className="space-y-8">
+    <div id="gmail" className="scroll-mt-4 space-y-6">
       {/* ---- Gmail connection card ------------------------------------- */}
       <div className="rounded-xl border border-line-soft bg-surface p-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
+          <div className="min-w-0">
             <h2 className="text-lg font-medium text-strong">Gmail</h2>
             <p className="mt-1 text-sm text-muted">
               Read-only access so the classifier can read your job-search mail at the source.
@@ -63,7 +116,10 @@ export function GmailConnectionCard({ result }: { result: GmailStatusResult }) {
             {connected ? (
               <div className="mt-2 space-y-1 text-xs text-dim">
                 <p>
-                  <LastSynced at={status?.last_sync_at ?? null} className="font-mono text-[11px]" />
+                  {/* A sentence, so the product voice — the machine-readable
+                      instant rides in the <time> element's dateTime/title.
+                      This was one of the two "last synced …" mono defects. */}
+                  <LastSynced at={status?.last_sync_at ?? null} className="text-xs" />
                   {status?.has_cursor ? (
                     <span> · next sync resumes from where that one stopped</span>
                   ) : null}
@@ -81,14 +137,25 @@ export function GmailConnectionCard({ result }: { result: GmailStatusResult }) {
 
           <div className="flex shrink-0 items-center gap-2">
             {connected ? (
-              <form action="/api/gmail/disconnect" method="post">
+              demo ? (
                 <button
-                  type="submit"
-                  className="rounded-lg border border-line px-4 py-2 text-sm text-foreground transition-colors hover:border-reject/60 hover:text-strong"
+                  type="button"
+                  disabled
+                  title="Simulated account — there is no real connection to revoke."
+                  className="cursor-not-allowed rounded-lg border border-line px-4 py-2 text-sm text-dim opacity-60"
                 >
                   Disconnect
                 </button>
-              </form>
+              ) : (
+                <form action="/api/gmail/disconnect" method="post">
+                  <button
+                    type="submit"
+                    className="rounded-lg border border-line px-4 py-2 text-sm text-foreground transition-colors hover:border-reject/60 hover:text-strong"
+                  >
+                    Disconnect
+                  </button>
+                </form>
+              )
             ) : needsSignin ? (
               <Link
                 href="/login?redirect=/settings"
@@ -102,92 +169,93 @@ export function GmailConnectionCard({ result }: { result: GmailStatusResult }) {
           </div>
         </div>
 
-        {connected ? (
-          <p className="mt-4 border-t border-line-soft pt-4 text-sm text-muted">
-            View the classified result in your{" "}
-            <Link href="/inbox" className="text-strong underline-offset-4 hover:underline">
-              classified inbox →
-            </Link>
-          </p>
-        ) : (
-          <p className="mt-4 border-t border-line-soft pt-4 text-sm text-muted">
-            Not ready to connect? See exactly what the classifier does on a{" "}
-            <Link href="/demo/inbox" className="text-strong underline-offset-4 hover:underline">
-              sample inbox →
-            </Link>
-          </p>
-        )}
+        <p className="mt-4 border-t border-line-soft pt-4 text-sm text-muted">
+          {connected ? (
+            <>
+              Review what it has read in your{" "}
+              <Link href="/inbox" className="text-strong underline-offset-4 hover:underline">
+                filed mail →
+              </Link>
+            </>
+          ) : (
+            <>
+              Not ready to connect? See exactly what the classifier does on a{" "}
+              <Link href="/demo/inbox" className="text-strong underline-offset-4 hover:underline">
+                sample inbox →
+              </Link>
+            </>
+          )}
+        </p>
+
+        {/* ---- Reference material, foldered ------------------------------ */}
+        <div className="mt-4 space-y-3">
+          <Disclosure summary="How the connection works — and why it's safe">
+            <ul className="grid gap-2 text-sm text-muted">
+              {SAFEGUARDS.map(([k, v]) => (
+                <li key={k} className="flex gap-2">
+                  <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-live" aria-hidden />
+                  <span>
+                    <span className="text-strong">{k}.</span> {v}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Disclosure>
+
+          <Disclosure summary="A note on scale — the honest version">
+            <p className="text-sm text-muted">
+              <code className="text-strong">gmail.readonly</code> is a Google{" "}
+              {/* The space is an explicit expression because a literal one does not survive the
+                  build. Production rendered "restrictedscope"; building this file's own committed
+                  source with our toolchain compiles the children to `restricted"}),"scope. Until`,
+                  so the bundler drops the leading whitespace of this text node. The sibling
+                  paragraph below keeps its space, and the difference is the entity: a JSX text node
+                  containing &apos; loses its leading space, one without keeps it. This was the only
+                  such node in the app — see the landing page, where `</span> int8-ONNX` and
+                  `</span> to classify` both survive. Do not "simplify" this back to a plain space. */}
+              <span className="text-strong">restricted</span>{" "}
+              scope. Until this app completes Google&apos;s
+              OAuth verification and an independent CASA security assessment, it can authorize at most{" "}
+              <span className="text-strong">100 test users</span> added on the OAuth consent screen. So
+              direct Gmail linking works, but is intentionally gated to invited testers.
+            </p>
+            <p className="text-sm text-muted">
+              The path that scales to the public <span className="text-strong">without</span>{" "}
+              restricted-scope verification is <span className="text-strong">forwarding ingestion</span>:
+              you set a Gmail filter that auto-forwards job-related mail to a per-user Applied address,
+              and the same classifier labels what arrives — no account access required. That is the
+              recommended route for broad, public use; the direct OAuth connection above is the right
+              fit for a small, invited group and for the desktop app.
+            </p>
+          </Disclosure>
+        </div>
       </div>
 
       {/* ---- No-connection path: import your own mail ----------------- */}
       {!connected ? (
         <div className="rounded-xl border border-line-soft bg-surface p-5">
-          <h2 className="text-lg font-medium text-strong">Import your mail — no connection needed</h2>
-          <p className="mt-1 text-sm text-muted">
-            Don&apos;t want to connect an account (or waiting on a beta seat)? Export your mail from
-            Google Takeout and classify it <span className="text-strong">on-device</span> — parsed and
-            scored entirely in your browser, never uploaded.
-          </p>
-          <Link
-            href="/import"
-            className="mt-3 inline-flex items-center gap-2 rounded-lg border border-line px-4 py-2 text-sm text-foreground transition-colors hover:border-line-strong hover:text-strong"
-          >
-            Open mail import <span aria-hidden>→</span>
-          </Link>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="min-w-0">
+              <h3 className="text-base font-medium text-strong">
+                Import your mail — no connection needed
+              </h3>
+              <p className="mt-1 text-sm text-muted">
+                Drop a Google Takeout export and classify it{" "}
+                <span className="text-strong">on-device</span> — never uploaded.
+              </p>
+            </div>
+            <Link
+              href="/import"
+              className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-line px-4 py-2 text-sm text-foreground transition-colors hover:border-line-strong hover:text-strong"
+            >
+              Open mail import <span aria-hidden>→</span>
+            </Link>
+          </div>
         </div>
       ) : null}
 
       {/* ---- Beta access — invite-only direct Gmail connection -------- */}
       {!connected ? <BetaCard /> : null}
-
-      {/* ---- How it works / why it's safe ----------------------------- */}
-      <div className="space-y-3">
-        <h3 className="label-caps">how the connection works — and why it&apos;s safe</h3>
-        <ul className="grid gap-2 text-sm text-muted">
-          {[
-            ["Read-only", "Applied requests only the gmail.readonly scope. It can read messages to classify them — it cannot send, delete, or modify anything."],
-            ["Standard OAuth", "Sign-in happens on Google's own consent screen. Applied never sees your Google password."],
-            ["Encrypted at rest", "The refresh token is stored Fernet-encrypted, scoped to your account. It is never shown in the browser, never logged, and never placed in a URL."],
-            ["Revocable anytime", "Disconnect here to revoke access at Google and delete the stored token. You can also remove it at myaccount.google.com/permissions."],
-          ].map(([k, v]) => (
-            <li key={k} className="flex gap-2">
-              <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-live" aria-hidden />
-              <span>
-                <span className="text-strong">{k}.</span> {v}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      {/* ---- Honest scale story --------------------------------------- */}
-      <div className="rounded-xl border border-line-soft bg-surface p-5">
-        <h3 className="label-caps mb-3">a note on scale — the honest version</h3>
-        <p className="text-sm text-muted">
-          <code className="text-strong">gmail.readonly</code> is a Google{" "}
-          {/* The space is an explicit expression because a literal one does not survive the
-              build. Production rendered "restrictedscope"; building this file's own committed
-              source with our toolchain compiles the children to `restricted"}),"scope. Until`,
-              so the bundler drops the leading whitespace of this text node. The sibling
-              paragraph below keeps its space, and the difference is the entity: a JSX text node
-              containing &apos; loses its leading space, one without keeps it. This was the only
-              such node in the app — see the landing page, where `</span> int8-ONNX` and
-              `</span> to classify` both survive. Do not "simplify" this back to a plain space. */}
-          <span className="text-strong">restricted</span>{" "}
-          scope. Until this app completes Google&apos;s
-          OAuth verification and an independent CASA security assessment, it can authorize at most{" "}
-          <span className="text-strong">100 test users</span> added on the OAuth consent screen. So
-          direct Gmail linking works, but is intentionally gated to invited testers.
-        </p>
-        <p className="mt-3 text-sm text-muted">
-          The path that scales to the public <span className="text-strong">without</span> restricted-scope
-          verification is <span className="text-strong">forwarding ingestion</span>: you set a Gmail
-          filter that auto-forwards job-related mail to a per-user Applied address, and the same
-          classifier labels what arrives — no account access required. That is the recommended route
-          for broad, public use; the direct OAuth connection above is the right fit for a small,
-          invited group and for the desktop app.
-        </p>
-      </div>
     </div>
   );
 }

--- a/apps/web/components/settings/NotificationsSection.tsx
+++ b/apps/web/components/settings/NotificationsSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 import { SaveStatus, SettingsSection } from "./SettingsSection";
-import { createClient } from "@/lib/supabase/client";
+import { settingsTransport, type SettingsMode } from "@/lib/settings/transport";
 
 export interface NotificationPrefs {
   weekly: boolean;
@@ -59,20 +59,27 @@ function Toggle({
  * wired on this deployment yet — the caption says so plainly rather than
  * implying a toggle sends mail it can't.
  */
-export function NotificationsSection({ initial }: { initial: NotificationPrefs }) {
+export function NotificationsSection({
+  initial,
+  mode = "live",
+}: {
+  initial: NotificationPrefs;
+  mode?: SettingsMode;
+}) {
   const [prefs, setPrefs] = useState<NotificationPrefs>(initial);
   const [state, setState] = useState<SaveState>("idle");
+  const transport = settingsTransport(mode);
 
   async function persist(next: NotificationPrefs) {
     setPrefs(next);
     setState("saving");
-    const supabase = createClient();
-    const { error } = await supabase.auth.updateUser({ data: { notifications: next } });
-    setState(error ? "error" : "saved");
+    const { ok } = await transport.saveMetadata({ notifications: next });
+    setState(ok ? "saved" : "error");
   }
 
   return (
     <SettingsSection
+      id="notifications"
       title="Notifications"
       description="What Applied should keep you posted about."
     >
@@ -81,20 +88,19 @@ export function NotificationsSection({ initial }: { initial: NotificationPrefs }
           checked={prefs.weekly}
           onChange={(v) => persist({ ...prefs, weekly: v })}
           label="Weekly pipeline summary"
-          description="Show a this-week digest on your dashboard — new applications, what’s in motion, offers."
+          description="A one-line this-week digest at the top of your dashboard."
         />
         <Toggle
           checked={prefs.reviewAlerts}
           onChange={(v) => persist({ ...prefs, reviewAlerts: v })}
           label="Needs-review alerts"
-          description="Held mail interrupts your board — the Needs review queue sits above it. Off, it waits quietly below."
+          description="On, held mail interrupts the board above your rows. Off, it waits below them."
         />
       </div>
       <div className="mt-4 flex items-center justify-between gap-3 border-t border-line-soft pt-4">
         <p className="text-[12px] leading-relaxed text-dim">
-          Saved to your account and applied to your dashboard cues right away. Email delivery isn’t
-          live on this deployment yet — these switches drive the in-app cues only, and will drive
-          email too once it ships.
+          Takes effect on your dashboard right away. Email delivery isn&apos;t live yet — these
+          drive the in-app cues only.
         </p>
         <SaveStatus state={state} />
       </div>

--- a/apps/web/components/settings/ProfileSection.tsx
+++ b/apps/web/components/settings/ProfileSection.tsx
@@ -4,40 +4,43 @@ import { useState } from "react";
 
 import { ReadonlyField, SaveStatus, SettingsSection } from "./SettingsSection";
 import { inputClass, primaryBtnClass, fieldLabelClass } from "@/components/ui/formStyles";
-import { createClient } from "@/lib/supabase/client";
+import { settingsTransport, type SettingsMode } from "@/lib/settings/transport";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
 /**
  * Profile: an editable, persisted display name plus honest read-only account
- * facts. The name is written to the Supabase user's `user_metadata` via
- * `auth.updateUser`, so it survives reloads and is available anywhere the
- * session is read. Email, sign-in method, and member-since are real values
- * passed from the server — never editable stand-ins.
+ * facts. The name is written through the settings transport (live: the
+ * Supabase user's `user_metadata`, so it survives reloads and is available
+ * anywhere the session is read; demo: simulated). Email, sign-in method, and
+ * member-since are real values passed from the server — never editable
+ * stand-ins.
  */
 export function ProfileSection({
   initialName,
   email,
   memberSince,
+  mode = "live",
 }: {
   initialName: string;
   email: string;
   memberSince: string | null;
+  mode?: SettingsMode;
 }) {
   const [name, setName] = useState(initialName);
   const [state, setState] = useState<SaveState>("idle");
   const dirty = name.trim() !== initialName.trim();
+  const transport = settingsTransport(mode);
 
   async function save(e: React.FormEvent) {
     e.preventDefault();
     setState("saving");
-    const supabase = createClient();
-    const { error } = await supabase.auth.updateUser({ data: { display_name: name.trim() } });
-    setState(error ? "error" : "saved");
+    const { ok } = await transport.saveMetadata({ display_name: name.trim() });
+    setState(ok ? "saved" : "error");
   }
 
   return (
-    <SettingsSection title="Profile" description="How you show up in Applied.">
+    <SettingsSection id="profile" title="Profile" description="How you show up in Applied.">
       <form onSubmit={save} className="space-y-4">
         <label className="grid gap-1">
           <span className={fieldLabelClass}>display name</span>

--- a/apps/web/components/settings/SettingsNav.tsx
+++ b/apps/web/components/settings/SettingsNav.tsx
@@ -1,9 +1,20 @@
 /**
  * The Settings page's table of contents — plain anchors into the section ids,
- * sticky beside the cards at desktop, absent below `lg` (five cards on a
- * phone don't need a map). Server-rendered: no scroll-spy, no state — the
- * shell's scroll pane honours the fragment jumps, and each section's
- * `scroll-mt` keeps its heading clear of the pane's edge.
+ * in the form each viewport can carry. Server-rendered in both: no scroll-spy,
+ * no state — the shell's scroll pane honours the fragment jumps, and each
+ * section's `scroll-mt` keeps its heading clear of whatever is pinned above it.
+ *
+ *  - `lg` and up: a sticky rail beside the cards.
+ *  - below `lg`: a chip strip pinned to the top of the scroll pane. The rail
+ *    used to be `hidden lg:block` and nothing replaced it, which left a phone
+ *    with 2819px of settings and no way to move through it. Horizontal scroll
+ *    rather than a wrap so the strip stays one row tall whatever the labels
+ *    measure, and `SettingsSection`'s `scroll-mt` clears its height so a jump
+ *    never lands a heading underneath it.
+ *
+ * The strip's accessible name is deliberately not the rail's: two navigations
+ * answering to "Settings sections" is a worse a11y tree to move through, and an
+ * ambiguous selector for anything driving the page.
  */
 const ITEMS: { id: string; label: string }[] = [
   { id: "profile", label: "Profile" },
@@ -17,22 +28,45 @@ const ITEMS: { id: string; label: string }[] = [
 
 export function SettingsNav() {
   return (
-    <nav
-      aria-label="Settings sections"
-      className="hidden lg:block lg:self-start lg:sticky lg:top-1"
-    >
-      <ul className="space-y-0.5 border-l border-line-soft">
-        {ITEMS.map((item) => (
-          <li key={item.id}>
-            <a
-              href={`#${item.id}`}
-              className="-ml-px block border-l border-transparent py-1 pl-3 text-[13px] text-muted transition-colors hover:border-line-strong hover:text-strong"
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
+    <>
+      {/* `-mx-6` bleeds the strip to the scroll pane's edges — both pages that
+          render this pad by 6 — so the pinned background covers the full width
+          of what passes under it and the chips scroll edge to edge. */}
+      <nav
+        aria-label="Jump to section"
+        className="sticky top-0 z-20 -mx-6 mb-4 border-b border-line-soft bg-background lg:hidden"
+      >
+        <ul className="flex gap-2 overflow-x-auto px-6 py-2">
+          {ITEMS.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className="inline-flex min-h-9 items-center whitespace-nowrap rounded-full border border-line px-3 text-[13px] text-muted transition-colors hover:border-line-strong hover:text-strong"
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <nav
+        aria-label="Settings sections"
+        className="hidden lg:block lg:self-start lg:sticky lg:top-1"
+      >
+        <ul className="space-y-0.5 border-l border-line-soft">
+          {ITEMS.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className="-ml-px block border-l border-transparent py-1 pl-3 text-[13px] text-muted transition-colors hover:border-line-strong hover:text-strong"
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
   );
 }

--- a/apps/web/components/settings/SettingsNav.tsx
+++ b/apps/web/components/settings/SettingsNav.tsx
@@ -1,0 +1,38 @@
+/**
+ * The Settings page's table of contents — plain anchors into the section ids,
+ * sticky beside the cards at desktop, absent below `lg` (five cards on a
+ * phone don't need a map). Server-rendered: no scroll-spy, no state — the
+ * shell's scroll pane honours the fragment jumps, and each section's
+ * `scroll-mt` keeps its heading clear of the pane's edge.
+ */
+const ITEMS: { id: string; label: string }[] = [
+  { id: "profile", label: "Profile" },
+  { id: "appearance", label: "Appearance" },
+  { id: "gmail", label: "Gmail" },
+  { id: "notifications", label: "Notifications" },
+  { id: "classification", label: "Classification" },
+  { id: "data", label: "Your data" },
+  { id: "account", label: "Account" },
+];
+
+export function SettingsNav() {
+  return (
+    <nav
+      aria-label="Settings sections"
+      className="hidden lg:block lg:self-start lg:sticky lg:top-1"
+    >
+      <ul className="space-y-0.5 border-l border-line-soft">
+        {ITEMS.map((item) => (
+          <li key={item.id}>
+            <a
+              href={`#${item.id}`}
+              className="-ml-px block border-l border-transparent py-1 pl-3 text-[13px] text-muted transition-colors hover:border-line-strong hover:text-strong"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/components/settings/SettingsSection.tsx
+++ b/apps/web/components/settings/SettingsSection.tsx
@@ -21,7 +21,7 @@ export function SettingsSection({
     <section
       id={id}
       aria-label={title}
-      className={`rounded-xl border bg-surface p-5 ${
+      className={`scroll-mt-4 rounded-xl border bg-surface p-5 ${
         tone === "danger" ? "border-reject/30" : "border-line-soft"
       }`}
     >

--- a/apps/web/components/settings/SettingsSection.tsx
+++ b/apps/web/components/settings/SettingsSection.tsx
@@ -18,10 +18,14 @@ export function SettingsSection({
   tone?: "default" | "danger";
 }) {
   return (
+    // `scroll-mt-16` below `lg` clears the chip strip SettingsNav pins to the
+    // top of the scroll pane (53px tall) — without it an anchor jump lands the
+    // heading underneath it. At `lg` the rail sits beside the cards with
+    // nothing above them, so the jump only needs room to breathe.
     <section
       id={id}
       aria-label={title}
-      className={`scroll-mt-4 rounded-xl border bg-surface p-5 ${
+      className={`scroll-mt-16 rounded-xl border bg-surface p-5 lg:scroll-mt-4 ${
         tone === "danger" ? "border-reject/30" : "border-line-soft"
       }`}
     >

--- a/apps/web/components/shell/AppShell.tsx
+++ b/apps/web/components/shell/AppShell.tsx
@@ -14,6 +14,19 @@ type AppShellProps = {
  * of `/import`). Renders the persistent sidebar rail and a top bar (mobile
  * nav + sign-out) around the page content.
  *
+ * The frame is viewport-locked: exactly one screen tall (`h-dvh`), chrome
+ * (rail + top bar) that never moves, and <main> as the one scroll pane. The
+ * document itself never scrolls — the app reads as an instrument, not a page.
+ * Two geometries live inside that pane:
+ *
+ *   - a FLOW page (settings, inbox, import) renders normal top-to-bottom
+ *     content; the wrapper grows with it and the pane scrolls.
+ *   - a LOCKED page (the dashboard) declares `lg:min-h-0 lg:flex-1` on its
+ *     root and scrolls a region of its own, so the page always fits the
+ *     screen and only the worklist moves. The wrapper is a flex column with
+ *     `flex-1` (no `min-h-0`), which is what makes both work: it fills the
+ *     pane for the locked page and still grows for the flow pages.
+ *
  * This is an async Server Component: it assembles the rail's snapshot data
  * (pipeline summary + Gmail connection) via `loadRailData()` — two parallel,
  * never-throwing backend reads that degrade to honest fallbacks — and hands
@@ -26,19 +39,17 @@ export async function AppShell({ children, userEmail }: AppShellProps) {
   const rail = await loadRailData();
 
   return (
-    <div className="flex min-h-screen w-full">
+    <div className="flex h-dvh w-full overflow-hidden">
       <Sidebar rail={rail} userEmail={userEmail} />
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar userEmail={userEmail} />
         {/* ONE page geometry for every authed surface: a shared centred column
             with a common left edge. The dashboard fills it; narrower pages
             (settings, inbox) cap their own measure inside it but start at the
-            same x — previously /dashboard was full-bleed while /inbox and
-            /settings centred a 730px column behind a ~280px dead gutter.
-            (`overflow-y-auto` is gone: it was inert — the column has no height
-            bound, so the page body is, and should be, the scroll context.) */}
-        <main className="flex-1 px-6 py-6">
-          <div className="mx-auto w-full max-w-6xl">{children}</div>
+            same x. `overflow-y-auto` here is NOT inert anymore: the shell is
+            h-dvh, so this pane is the scroll context the whole app shares. */}
+        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5">
+          <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col">{children}</div>
         </main>
       </div>
     </div>

--- a/apps/web/components/shell/RailFooter.tsx
+++ b/apps/web/components/shell/RailFooter.tsx
@@ -78,7 +78,7 @@ function distinctMailbox(gmailEmail: string | null, userEmail: string | null): s
 
 /** Shared with the identity row so the two rows behave as one control strip. */
 const ROW =
-  "group flex rounded-md px-2 py-1.5 transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules";
+  "group flex rounded-md px-2 py-1.5 transition-colors hover:bg-surface-2 focus-accent";
 
 function ConnectionLine({ gmail, userEmail }: { gmail: RailGmailData; userEmail: string | null }) {
   if (!gmail.connected) {

--- a/apps/web/components/shell/RailPipeline.tsx
+++ b/apps/web/components/shell/RailPipeline.tsx
@@ -30,7 +30,7 @@ function ReviewNudge({ count }: { count: number }) {
   return (
     <Link
       href="/dashboard#needs-classification"
-      className="group mt-3 flex items-center gap-1.5 rounded-lg border border-review/40 px-2.5 py-1.5 text-xs font-medium text-review transition-colors hover:border-review focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+      className="group mt-3 flex items-center gap-1.5 rounded-lg border border-review/40 px-2.5 py-1.5 text-xs font-medium text-review transition-colors hover:border-review focus-accent"
     >
       <span className="tabular">{count}</span>
       <span>need{count === 1 ? "s" : ""} review</span>

--- a/apps/web/components/shell/Sidebar.tsx
+++ b/apps/web/components/shell/Sidebar.tsx
@@ -47,7 +47,7 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
         <Link
           href="/dashboard"
           aria-label="Applied — go to dashboard"
-          className="brand-logo-link rounded-md text-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules"
+          className="brand-logo-link rounded-md text-strong focus-accent"
         >
           <Logo className="h-7 w-auto" />
         </Link>
@@ -65,7 +65,7 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
                     href={item.href}
                     aria-current={active ? "page" : undefined}
                     className={cn(
-                      "group relative flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-viz-rules",
+                      "group relative flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-accent",
                       active
                         ? "bg-surface-2 text-strong"
                         : "text-muted hover:bg-surface-2 hover:text-strong",

--- a/apps/web/components/viz/DecisionTrace.tsx
+++ b/apps/web/components/viz/DecisionTrace.tsx
@@ -84,7 +84,7 @@ export function DecisionTrace() {
               <button
                 type="button"
                 onClick={() => setOpen(isOpen ? null : item.subject)}
-                className="group trace-row flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left hover:bg-surface-2"
+                className="group trace-row focus-inset flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left hover:bg-surface-2"
               >
                 {/* basis-full on mobile gives the subject its own line so the
                     layer track / verdict / % wrap below instead of squeezing it

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -248,6 +248,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/applications/mail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Mail Listing Cloud
+         * @description Every message this user has stored, whatever the classifier decided.
+         *
+         *     Declared ABOVE ``GET /{application_id}`` deliberately: FastAPI matches in
+         *     declaration order and would otherwise try ``"mail"`` as an int path param
+         *     and answer 422. Same pattern as ``/summary``, ``/review`` and ``/statuses``.
+         *
+         *     WHY THIS EXISTS
+         *     ---------------
+         *     ``/review`` is the only other listing of classified mail, and it filters to
+         *     ``needs_review AND unlinked AND not-yet-reviewed``. That is the right set
+         *     for a work queue and the wrong set for a correction surface, because those
+         *     three predicates make a verdict unreachable the moment it is touched:
+         *
+         *     * a message already reviewed once drops out for good — emails 58 and 59 of
+         *       the owner's account sit at ``needs_review`` with ``is_reviewed = true``
+         *       and no endpoint in the product could name them, so no screen could
+         *       change them;
+         *     * a message linked to an application drops out too, so a ``rejection``
+         *       filed as ``applied`` is a wrong stored verdict a user can see on the
+         *       board and never correct at its source;
+         *     * and for an account whose mail all classified confidently, ``/review``
+         *       returns zero rows and the review UI never renders at all.
+         *
+         *     The write path never had that restriction — :func:`classify_review_item`
+         *     selects on ``(user_id, message_id)`` alone — so correcting any of these
+         *     already worked. What was missing was a way to *find* them. This is that
+         *     read, and nothing more: no new write, no body, no state change.
+         *
+         *     SHAPE
+         *     -----
+         *     Newest first with an ``id`` tiebreak, for the same reason the applications
+         *     listing has one: a sync writes a batch of rows carrying identical
+         *     ``received_at`` values, tied rows are free to come back in a different
+         *     order per request on Postgres, and paging a partial order drops some rows
+         *     and repeats others.
+         *
+         *     One entry per MESSAGE — unlike ``/review``, which collapses a thread to its
+         *     newest message because being asked the same question twice is duplicated
+         *     work. Here the user is auditing what is stored, and every stored row is
+         *     correctable individually, so hiding siblings would hide exactly the rows
+         *     this endpoint exists to reach.
+         */
+        get: operations["mail_listing_cloud_applications_mail_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/applications/{application_id}": {
         parameters: {
             query?: never;
@@ -966,6 +1026,88 @@ export interface components {
             company: string;
         };
         /**
+         * MailListResponse
+         * @description A page of the user's stored mail, plus the counts the chips need.
+         *
+         *     ``total`` is the size of the CURRENT query — it respects both ``category``
+         *     and ``q``, because it is the number ``page``/``page_size`` walk.
+         *
+         *     ``category_counts`` is deliberately different: it respects ``q`` but NOT
+         *     ``category``, so each filter chip can show its own total while one of them
+         *     is active. Counting only the filtered set would make every chip but the
+         *     selected one read zero.
+         */
+        MailListResponse: {
+            /** Messages */
+            messages: components["schemas"]["MailMessageResponse"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Category Counts */
+            category_counts: {
+                [key: string]: number;
+            };
+        };
+        /**
+         * MailMessageResponse
+         * @description One stored message in the full mail listing.
+         *
+         *     Deliberately METADATA ONLY. ``snippet`` is the persisted ``body_snippet``
+         *     and there is no field for ``body_text`` or ``body_html``: the cloud sync
+         *     never fetches a body and this listing is not the place to start.
+         *
+         *     ``category``/``confidence``/``method`` are the stored verdict verbatim —
+         *     ``classified_as``, ``classification_confidence``, ``classification_method``
+         *     — so a reader can see WHAT was decided and HOW, which is the difference
+         *     between "the machine says applied" and "a rule matched at 0.71".
+         *
+         *     ``category`` carries the enum's own value (``"applied"``, ``"needs_review"``
+         *     …), the same lowercase vocabulary ``?category=`` accepts and
+         *     ``POST /review/{message_id}/classify`` takes back. One vocabulary end to
+         *     end, so a value read here can be sent straight back as a correction.
+         */
+        MailMessageResponse: {
+            /** Message Id */
+            message_id: string;
+            /** Thread Id */
+            thread_id?: string | null;
+            /** Subject */
+            subject?: string | null;
+            /** Sender Name */
+            sender_name?: string | null;
+            /** Sender Email */
+            sender_email?: string | null;
+            /** Received At */
+            received_at?: string | null;
+            /** Snippet */
+            snippet?: string | null;
+            /** Category */
+            category?: string | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Method */
+            method?: string | null;
+            /**
+             * User Corrected
+             * @default false
+             */
+            user_corrected: boolean;
+            /**
+             * Is Reviewed
+             * @default false
+             */
+            is_reviewed: boolean;
+            /** Application Id */
+            application_id?: number | null;
+            /** Company */
+            company?: string | null;
+            /** Gmail Link */
+            gmail_link?: string | null;
+        };
+        /**
          * MessageRefResponse
          * @description One underlying email surfaced in the click-through detail view.
          */
@@ -1535,6 +1677,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StatusVocabularyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    mail_listing_cloud_applications_mail_get: {
+        parameters: {
+            query?: {
+                /** @description 1-based page number. */
+                page?: number;
+                /** @description Rows per page (capped so a single response stays bounded). */
+                page_size?: number;
+                /** @description Filter to one stored verdict. Does not affect `category_counts`. */
+                category?: components["schemas"]["EmailCategory"] | null;
+                /** @description Case-insensitive substring match on subject/sender. */
+                q?: string | null;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MailListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/apps/web/lib/applications/server.ts
+++ b/apps/web/lib/applications/server.ts
@@ -138,6 +138,35 @@ export function getReviewQueue(): Promise<ApiCallResult> {
   return call(`/applications/review`, { method: "GET" });
 }
 
+/** The query parameters `/applications/mail` accepts. Nothing else is forwarded. */
+const MAIL_QUERY_PARAMS = ["page", "page_size", "category", "q"] as const;
+
+/**
+ * GET /applications/mail — every stored message, whatever the verdict.
+ *
+ * The counterpart to `getReviewQueue`, and the reason it exists: the review
+ * queue filters to `needs_review AND unlinked AND not-yet-reviewed`, so a
+ * verdict becomes unreachable the moment it is touched. This lists the user's
+ * mail regardless of review state or linkage, which is what makes a wrong
+ * verdict correctable more than once. Metadata only — bodies never leave the
+ * backend.
+ *
+ * Values are forwarded as strings and validated by FastAPI, which already
+ * answers a precise 422 naming the offending parameter. A second parser here
+ * would be a second thing to drift. The keys ARE allowlisted: only the four
+ * the endpoint declares travel, so this proxy cannot be used to reach
+ * parameters the backend adds later without a deliberate change here.
+ */
+export function getMail(search: URLSearchParams): Promise<ApiCallResult> {
+  const forwarded = new URLSearchParams();
+  for (const key of MAIL_QUERY_PARAMS) {
+    const value = search.get(key)?.trim();
+    if (value) forwarded.set(key, value);
+  }
+  const query = forwarded.toString();
+  return call(`/applications/mail${query ? `?${query}` : ""}`, { method: "GET" });
+}
+
 /**
  * POST /applications/review/{messageId}/classify — classify + persist + train.
  *

--- a/apps/web/lib/dashboard/employerGroups.ts
+++ b/apps/web/lib/dashboard/employerGroups.ts
@@ -1,0 +1,85 @@
+/**
+ * DISPLAY grouping of worklist rows by employer — and only display.
+ *
+ * One employer can hold several applications (four Amazon requisitions in one
+ * evening is the proven case), and rendering each as its own row headed by the
+ * same company name read as duplication — four near-identical lines all saying
+ * "Amazon". So the board folds same-employer rows *within one stage group*
+ * into a single employer card that opens inline.
+ *
+ * What this module must never become: a merge. Collapsing applications into
+ * one *record* per company was a real correctness bug fixed at real cost — a
+ * merged row took the furthest stage any of the employer's mail reached, a
+ * per-requisition rejection froze it terminal, and every later interview and
+ * offer for the other requisitions went invisible. Each application keeps its
+ * own id, its own status, its own mail and its own controls; a group here is
+ * a list of the same rows the flat board would render, in the same order.
+ *
+ * Grouping is scoped to a stage on purpose. An employer whose applications sit
+ * in different stages appears once per stage it occupies — Amazon under
+ * `applied` holding 3 AND under `interviewing` holding 1 — because any
+ * cross-stage summary row would have to pick one stage to live in, which is
+ * exactly the furthest-stage-wins display the merge bug taught us not to
+ * draw. Stage counts stay honest application counts by construction, and no
+ * row's true stage is ever behind an employer summary.
+ *
+ * Import-free so `node --test` loads it under type stripping, like `board.ts`.
+ */
+
+/** The one field grouping reads. Structural, so this stays schema-free. */
+interface CompanyRow {
+  company: string;
+}
+
+/**
+ * One rendered position in a stage group's list: a plain application row, or
+ * an employer set holding every application that employer has in this stage.
+ */
+export type WorklistEntry<T extends CompanyRow> =
+  | { kind: "single"; app: T }
+  | { kind: "set"; company: string; items: T[] };
+
+/**
+ * Fold a stage group's rows into worklist entries. A set forms only when two
+ * or more rows share an employer — the singleton (most rows) renders exactly
+ * as before. A set anchors at its first member's position and keeps its
+ * members in list order, so grouping never reorders what the flat list showed.
+ */
+export function groupByEmployer<T extends CompanyRow>(rows: T[]): WorklistEntry<T>[] {
+  const byCompany = new Map<string, T[]>();
+  for (const row of rows) {
+    const members = byCompany.get(row.company);
+    if (members) members.push(row);
+    else byCompany.set(row.company, [row]);
+  }
+
+  const entries: WorklistEntry<T>[] = [];
+  const emitted = new Set<string>();
+  for (const row of rows) {
+    const members = byCompany.get(row.company)!;
+    if (members.length === 1) {
+      entries.push({ kind: "single", app: row });
+      continue;
+    }
+    if (emitted.has(row.company)) continue;
+    emitted.add(row.company);
+    entries.push({ kind: "set", company: row.company, items: members });
+  }
+  return entries;
+}
+
+/**
+ * The visible text of the cross-stage chip: what an employer holds OUTSIDE the
+ * stage the reader is looking at. `"+1 in interviewing"` when the rest sits in
+ * one stage, `"+3 in other stages"` when it is spread. The old text repeated
+ * the employer's name ("+3 at Amazon") one word away from the row already
+ * saying "Amazon" — the same duplication grouping exists to remove — and was
+ * the widest thing on a phone row. The accessible name is NOT built here: it
+ * stays `Show all applications at {company}`, the contract the specs and
+ * muscle memory hold (see `SameCompanyChip`).
+ */
+export function elsewhereLabel(count: number, stageLabels: readonly string[]): string | null {
+  if (count <= 0 || stageLabels.length === 0) return null;
+  const distinct = [...new Set(stageLabels)];
+  return distinct.length === 1 ? `+${count} in ${distinct[0]}` : `+${count} in other stages`;
+}

--- a/apps/web/lib/dashboard/summary.ts
+++ b/apps/web/lib/dashboard/summary.ts
@@ -141,6 +141,24 @@ export function summarizeCounts(
 }
 
 /**
+ * The summary's per-stage counts as a keyed record — the shape the board's
+ * spine reads. Folded here rather than at the call site so the spine's numbers
+ * and the subtitle's numbers keep coming out of one implementation of stage
+ * semantics; a second `for` loop over `status_counts` somewhere else is how
+ * two surfaces start disagreeing about what "closed" contains.
+ */
+export function stageCountsOf(summary: PipelineSummary): Record<StageKey, number> {
+  const counts: Record<StageKey, number> = {
+    applied: 0,
+    interviewing: 0,
+    offered: 0,
+    rejected: 0,
+  };
+  for (const { stage, count } of summary.stages) counts[stage.key] = count;
+  return counts;
+}
+
+/**
  * Derive every headline number from the application list. `now` is injectable
  * so tests are deterministic; production passes the real clock.
  *

--- a/apps/web/lib/dashboard/transport.ts
+++ b/apps/web/lib/dashboard/transport.ts
@@ -1,7 +1,7 @@
 /**
  * The board's transport seam — how the interactive components reach data.
  *
- * Every mutating surface (`ApplicationCard`, `ApplicationDetail`,
+ * Every mutating surface (`ApplicationRow`, `ApplicationDetail`,
  * `PipelineBoard`'s drag, `SyncBar`) takes one of these interfaces and
  * defaults to the live implementation below, which talks to the same-origin
  * proxy routes exactly as before. The public `/demo` passes an in-memory

--- a/apps/web/lib/demo/asApplications.ts
+++ b/apps/web/lib/demo/asApplications.ts
@@ -48,3 +48,24 @@ export function demoApplicationsAsApi(today: string = todayISO()): Application[]
 export function demoUnsyncedAsApi(today: string = todayISO()): Application[] {
   return demoUnsynced(today).map((app, index) => toApi(app, DEMO_APPLICATION_COUNT + index + 1));
 }
+
+/**
+ * The early-search projection (`/demo?pipeline=early`): the SAME fixtures,
+ * every row resting at `applied` — the measured shape of the one real
+ * production account (29 live rows, 100% in one stage), which is the case the
+ * worklist redesign exists for and the case the healthy seed board can never
+ * show. Roughly the real board's share of rows also lose their role (8 of 29
+ * live rows never had one named), so the fixed role slot renders at its real
+ * density. Deadlines are cleared: a board this young hasn't earned any, and a
+ * leftover assessment date would contradict the all-applied claim.
+ */
+export function demoEarlySearchAsApi(today: string = todayISO()): Application[] {
+  return demoApplicationsAsApi(today).map((app, index) => ({
+    ...app,
+    status: "applied",
+    notes: "Your application was received",
+    due_at: null,
+    due_source: null,
+    position: index % 4 === 2 ? "" : app.position,
+  }));
+}

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -86,19 +86,26 @@ function resolve(seed: DemoSeed, today: string): DemoApplication {
 
 /**
  * Shaped like a REAL early-search board, not a brochure: the applied column is
- * heavy (10 of 17), offered is empty, and one employer holds several
- * applications in different stages — the owner's own board has four Amazon
- * requisitions, so the fixtures must exercise the same truths the live board
- * does: company+role as the card identity, the "N more at …" affordance,
- * cross-column same-company cards, an applied column past the collapse
- * threshold, and an honestly empty column.
+ * heavy (10 of 17), offered is empty, and two employers hold several
+ * applications in different stages — Northstar ×4 and Cedar Labs ×2, so both
+ * ends of the affordance render ("+3 at …" and "+1 at …") and the four-deep
+ * set is reachable. That mirrors the owner's own board, where four employers
+ * hold several requisitions each (Amazon 4, Verkada 4). The fixtures must
+ * exercise the same truths the live board does: company+role as the card
+ * identity, the "+N at …" affordance, cross-column same-company cards, an
+ * applied column past the collapse threshold, and an honestly empty column.
  *
  * Order matters as much as the dates: the applied group renders in this
  * order, and the specs assert specific rows by name against it.
  */
 const APPLICATION_SEEDS: DemoSeed[] = [
-  // Northstar Systems ×3 — one advanced, two still applied. Three cards, three
+  // Northstar Systems ×4 — one advanced, three still applied. Four cards, four
   // distinct roles, two different columns: an application is not a company.
+  // Four is the number on purpose: the owner's own board holds four Amazon
+  // requisitions, so this is the shape the "+3 at …" chip and the set view it
+  // opens have to be reviewable against. The fourth row (`a7`) stays down in
+  // filing order rather than being moved up here — the seed order IS the
+  // applied group's render order, and the specs read specific rows off it.
   { id: "a1", company: "Northstar Systems", position: "ML Engineer", status: "interviewing", filedDaysAgo: 18, lastSignal: "Interview availability — technical round" },
   { id: "a2", company: "Northstar Systems", position: "ML Engineer, Platform", status: "applied", filedDaysAgo: 16, lastSignal: "Your application was received" },
   { id: "a3", company: "Northstar Systems", position: "Research Engineer, Applied ML", status: "applied", filedDaysAgo: 15, lastSignal: "Thanks for applying" },
@@ -107,7 +114,11 @@ const APPLICATION_SEEDS: DemoSeed[] = [
   { id: "a5", company: "Cedar Labs", position: "Site Reliability Engineer", status: "rejected", filedDaysAgo: 34, lastSignal: "Moving forward with other candidates" },
   // Single-application employers — the common case, which stays untaxed.
   { id: "a6", company: "Harbor Analytics", position: "Backend Engineer", status: "applied", filedDaysAgo: 11, lastSignal: "Application under review" },
-  { id: "a7", company: "Summit Platform", position: "Full-Stack Engineer", status: "applied", filedDaysAgo: 9, lastSignal: "Application under review" },
+  // Northstar's fourth, filed a week after the third — the row that makes the
+  // employer's set four cards deep. Retargeted from a single-application
+  // employer rather than added, so the board's totals (17 rows, 10 applied)
+  // and every count the specs assert against them are untouched.
+  { id: "a7", company: "Northstar Systems", position: "Full-Stack Engineer", status: "applied", filedDaysAgo: 9, lastSignal: "Application under review" },
   { id: "a8", company: "Quarry Data", position: "Data Engineer", status: "applied", filedDaysAgo: 8, lastSignal: "Thanks for applying" },
   // The role-not-captured case: 8 of the real board's 29 live rows have no
   // role (an ATS receipt that never named one), so the twin must exercise the

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -93,9 +93,8 @@ function resolve(seed: DemoSeed, today: string): DemoApplication {
  * cross-column same-company cards, an applied column past the collapse
  * threshold, and an honestly empty column.
  *
- * Order matters as much as the dates: the applied column renders in this
- * order, and the collapse expander test depends on Copperline and Waypoint
- * being the two that wait behind "show all 10".
+ * Order matters as much as the dates: the applied group renders in this
+ * order, and the specs assert specific rows by name against it.
  */
 const APPLICATION_SEEDS: DemoSeed[] = [
   // Northstar Systems ×3 — one advanced, two still applied. Three cards, three
@@ -110,7 +109,11 @@ const APPLICATION_SEEDS: DemoSeed[] = [
   { id: "a6", company: "Harbor Analytics", position: "Backend Engineer", status: "applied", filedDaysAgo: 11, lastSignal: "Application under review" },
   { id: "a7", company: "Summit Platform", position: "Full-Stack Engineer", status: "applied", filedDaysAgo: 9, lastSignal: "Application under review" },
   { id: "a8", company: "Quarry Data", position: "Data Engineer", status: "applied", filedDaysAgo: 8, lastSignal: "Thanks for applying" },
-  { id: "a9", company: "Beacon Health", position: "ML Engineer, Risk", status: "applied", filedDaysAgo: 6, lastSignal: "We received your application" },
+  // The role-not-captured case: 8 of the real board's 29 live rows have no
+  // role (an ATS receipt that never named one), so the twin must exercise the
+  // row's fixed role slot — the honest "role not captured" placeholder — or
+  // the raggedness it fixes stays unreviewable.
+  { id: "a9", company: "Beacon Health", position: "", status: "applied", filedDaysAgo: 6, lastSignal: "We received your application" },
   { id: "a10", company: "Fernworks", position: "Systems Engineer", status: "rejected", filedDaysAgo: 45, lastSignal: "Update on your application" },
   { id: "a11", company: "Atlas Freight", position: "Software Engineer II", status: "rejected", filedDaysAgo: 38, lastSignal: "Moving forward with other candidates" },
   { id: "a12", company: "Juniper Cloud", position: "Infrastructure Engineer", status: "applied", filedDaysAgo: 5, lastSignal: "We received your application" },

--- a/apps/web/lib/demo/demoDetail.ts
+++ b/apps/web/lib/demo/demoDetail.ts
@@ -76,7 +76,11 @@ export function demoDetailBody(app: Application): Record<string, unknown> {
     sender_name: `${app.company} Talent`,
     sender_email,
     received_at: filed,
-    snippet: `Thanks for applying to the ${app.position} role.`,
+    // A fixture without a captured role mirrors the real mail that caused it:
+    // the receipt simply doesn't name one.
+    snippet: app.position.trim()
+      ? `Thanks for applying to the ${app.position} role.`
+      : "Thanks for applying.",
     category: "applied",
     confidence: 0.99,
     gmail_link: null,

--- a/apps/web/lib/mail/filed.ts
+++ b/apps/web/lib/mail/filed.ts
@@ -1,0 +1,127 @@
+/**
+ * The filed-mail view's ONE reading of `GET /applications/mail`.
+ *
+ * The page hands the endpoint's body straight to `readFiledMailPage`, so the
+ * defensive parsing — every field optional on the wire, booleans honoured only
+ * when literal — lives here once, next to the URL builder the chips and the
+ * pager share. Deliberately dependency-free (no React, no `@/` alias, no
+ * generated schema) so `tests/unit/` can load it directly under Node's type
+ * stripping — the same rule as `review.ts` and `dates.ts`.
+ */
+
+/** One stored message, as the listing serves it. Metadata only — no bodies. */
+export interface FiledMessage {
+  message_id: string;
+  thread_id: string | null;
+  subject: string | null;
+  sender_name: string | null;
+  sender_email: string | null;
+  received_at: string | null;
+  snippet: string | null;
+  /** Lowercase wire vocabulary (`applied`, `needs_review`, …) — the same form
+   *  the classify endpoint accepts back, so a correction round-trips with no
+   *  case mapping. */
+  category: string | null;
+  confidence: number | null;
+  method: string | null;
+  user_corrected: boolean;
+  is_reviewed: boolean;
+  application_id: number | null;
+  company: string | null;
+  gmail_link: string | null;
+}
+
+export interface FiledMailPage {
+  messages: FiledMessage[];
+  /** Total matching rows under the ACTIVE category + search. */
+  total: number;
+  page: number;
+  pageSize: number;
+  /** Per-category totals under the active search ONLY — the chips keep their
+   *  own counts while one of them is selected. */
+  categoryCounts: Record<string, number>;
+}
+
+/** One server page. 32 stored messages is the real account today; 50 keeps
+ *  the common case a single page without shipping an unbounded list. */
+export const FILED_PAGE_SIZE = 50;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Read the listing body into the page the view renders, or `null` when the
+ *  shape is not the endpoint's — the caller shows the honest failure state
+ *  instead of an empty inbox that reads as "you have no mail". */
+export function readFiledMailPage(body: unknown): FiledMailPage | null {
+  const data = asRecord(body);
+  if (!Array.isArray(data.messages)) return null;
+
+  const counts: Record<string, number> = {};
+  for (const [key, value] of Object.entries(asRecord(data.category_counts))) {
+    const n = num(value);
+    if (n !== null) counts[key] = n;
+  }
+
+  const messages: FiledMessage[] = [];
+  for (const raw of data.messages) {
+    const m = asRecord(raw);
+    const id = str(m.message_id);
+    if (!id) continue; // a message we cannot correct or key is not renderable
+    messages.push({
+      message_id: id,
+      thread_id: str(m.thread_id),
+      subject: str(m.subject),
+      sender_name: str(m.sender_name),
+      sender_email: str(m.sender_email),
+      received_at: str(m.received_at),
+      snippet: str(m.snippet),
+      category: str(m.category),
+      confidence: num(m.confidence),
+      method: str(m.method),
+      user_corrected: m.user_corrected === true,
+      is_reviewed: m.is_reviewed === true,
+      application_id: num(m.application_id),
+      company: str(m.company),
+      gmail_link: str(m.gmail_link),
+    });
+  }
+
+  return {
+    messages,
+    total: num(data.total) ?? messages.length,
+    page: num(data.page) ?? 1,
+    pageSize: num(data.page_size) ?? FILED_PAGE_SIZE,
+    categoryCounts: counts,
+  };
+}
+
+/** How many pages the pager offers — never less than one. */
+export function filedPageCount(total: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+/** The filed view's canonical URL for a filter state. Defaults are omitted so
+ *  `/inbox` stays the clean address of the resting view. */
+export function filedMailHref(params: {
+  category?: string | null;
+  q?: string | null;
+  page?: number;
+}): string {
+  const search = new URLSearchParams();
+  if (params.category) search.set("category", params.category);
+  const q = params.q?.trim();
+  if (q) search.set("q", q);
+  if (params.page !== undefined && params.page > 1) search.set("page", String(params.page));
+  const qs = search.toString();
+  return qs ? `/inbox?${qs}` : "/inbox";
+}

--- a/apps/web/lib/settings/transport.ts
+++ b/apps/web/lib/settings/transport.ts
@@ -1,0 +1,99 @@
+/**
+ * The Settings sections' transport seam — how a preference write, the data
+ * export, and the account actions reach the world.
+ *
+ * Same pattern as `lib/dashboard/transport.ts`, and for the same reason: the
+ * signed-in Settings page is auth-gated, CI has no Supabase session, and every
+ * settings e2e was skipping. The sections take a `mode` string (serializable,
+ * so a Server Component can choose it) and resolve their transport here:
+ * `live` talks to Supabase and the proxy exactly as before; `demo` — the
+ * public `/demo/settings` twin — runs the identical component state machines
+ * over simulated outcomes, which is what makes the real controls reviewable
+ * and testable without a session. Nothing in the demo transport touches the
+ * network, and its one refusal (account deletion) says plainly that it is a
+ * refusal.
+ */
+import { createClient } from "@/lib/supabase/client";
+import { demoApplicationsAsApi } from "@/lib/demo/asApplications";
+
+export type SettingsMode = "live" | "demo";
+
+export interface SettingsTransport {
+  mode: SettingsMode;
+  /** Persist a patch of the user's metadata (display name, prefs, gate). */
+  saveMetadata(data: Record<string, unknown>): Promise<{ ok: boolean }>;
+  /** Fetch everything the export downloads. The section owns the blob/anchor
+   *  dance — that part is the browser's either way. */
+  exportApplications(): Promise<{ ok: boolean; data?: unknown }>;
+  /** End the session. The section owns the navigation that follows. */
+  signOut(): Promise<void>;
+  deleteAccount(): Promise<{ ok: boolean; detail?: string }>;
+}
+
+const live: SettingsTransport = {
+  mode: "live",
+  async saveMetadata(data) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({ data });
+    return { ok: !error };
+  },
+  async exportApplications() {
+    try {
+      const res = await fetch("/api/applications", { headers: { Accept: "application/json" } });
+      if (!res.ok) return { ok: false };
+      return { ok: true, data: await res.json() };
+    } catch {
+      return { ok: false };
+    }
+  },
+  async signOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+  },
+  async deleteAccount() {
+    try {
+      const res = await fetch("/api/account/delete", { method: "POST" });
+      if (res.ok) return { ok: true };
+      const body = (await res.json().catch(() => ({}))) as { detail?: unknown };
+      return {
+        ok: false,
+        detail:
+          typeof body.detail === "string"
+            ? body.detail
+            : "Account deletion isn’t available on this deployment yet.",
+      };
+    } catch {
+      return { ok: false, detail: "Couldn’t reach the server. Try again shortly." };
+    }
+  },
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const demo: SettingsTransport = {
+  mode: "demo",
+  async saveMetadata() {
+    // Long enough that "Saving…" renders and can be asserted; nothing persists.
+    await delay(300);
+    return { ok: true };
+  },
+  async exportApplications() {
+    await delay(300);
+    // The twin's export is a real download of the fixture board — the control
+    // genuinely works, on data that is genuinely synthetic.
+    return { ok: true, data: { applications: demoApplicationsAsApi() } };
+  },
+  async signOut() {
+    await delay(150);
+  },
+  async deleteAccount() {
+    await delay(300);
+    return { ok: false, detail: "Simulated account — nothing exists to delete on the demo." };
+  },
+};
+
+export function settingsTransport(mode: SettingsMode): SettingsTransport {
+  return mode === "demo" ? demo : live;
+}

--- a/apps/web/tests/e2e/dashboard.spec.ts
+++ b/apps/web/tests/e2e/dashboard.spec.ts
@@ -91,9 +91,10 @@ test.describe("dashboard content (via the public /demo twin)", () => {
   test("a row is an application: role is the discriminator, company repeats", async ({ page }) => {
     await page.goto("/demo");
 
-    // Northstar Systems holds three applications in two different stages.
-    // (`exact` so the "2 more at Northstar Systems" chips don't also match.)
-    await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(3);
+    // Northstar Systems holds four applications in two different stages — the
+    // shape of the owner's own board, where one employer holds four requisitions.
+    // (`exact` so the "+3 at Northstar Systems" chips don't also match.)
+    await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(4);
     await expect(page.getByText("ML Engineer", { exact: true })).toBeVisible();
     await expect(page.getByText("ML Engineer, Platform", { exact: true })).toBeVisible();
     await expect(page.getByText("Research Engineer, Applied ML", { exact: true })).toBeVisible();
@@ -103,7 +104,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
       .getByRole("button", { name: /show all applications at Northstar Systems/i })
       .first()
       .click();
-    await expect(page.getByText("3 of 17 shown")).toBeVisible();
+    await expect(page.getByText("4 of 17 shown")).toBeVisible();
     await expect(page.getByText("Harbor Analytics")).toHaveCount(0);
     // …and the filter chip clears it.
     await page.getByRole("button", { name: /stop filtering by Northstar Systems/i }).click();

--- a/apps/web/tests/e2e/dashboard.spec.ts
+++ b/apps/web/tests/e2e/dashboard.spec.ts
@@ -8,10 +8,17 @@ import { expectNoHorizontalOverflow, MOBILE_375, startConsoleWatch } from "./hel
  * The signed-in `/dashboard` is auth-gated and unreachable without a Supabase
  * session (see navigation.spec / shell.spec). But it renders from the SAME
  * `PipelineBoard` component as the public `/demo` twin — the header hierarchy,
- * the board with search/company-filter/expanders — fed by fixture rows adapted
- * to the exact API shape. So we drive that content on `/demo` here, and add a
- * skip-guarded pass that becomes real coverage of `/dashboard` itself the
- * moment the suite runs against a session.
+ * the stage spine, the grouped worklist with search/company-filter — fed by
+ * fixture rows adapted to the exact API shape. So we drive that content on
+ * `/demo` here, and add a skip-guarded pass that becomes real coverage of
+ * `/dashboard` itself the moment the suite runs against a session.
+ *
+ * The board is a worklist now, not a kanban: stage groups render as regions
+ * ONLY while they hold rows; an empty stage is a line in the spine (a button
+ * named `${stage} — ${count}`), never a full-width box of nothing. The
+ * `?pipeline=early` variant renders the measured production distribution —
+ * every row in one stage — which is the case the worklist exists for and the
+ * healthy seed spread cannot show.
  *
  * What is deliberately ABSENT is asserted too: the stat-tile row, the
  * classifier-context strip (auto-file gate / macro-F1 / CI floor), the
@@ -28,7 +35,7 @@ async function reachDashboardOrSkip(page: Page): Promise<void> {
 }
 
 test.describe("dashboard content (via the public /demo twin)", () => {
-  test("the header is one honest line of state, and the board leads", async ({ page }) => {
+  test("the header is one honest line of state, and the worklist leads", async ({ page }) => {
     const watch = startConsoleWatch(page);
     await page.goto("/demo");
 
@@ -37,15 +44,31 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     // interviewing), 0 offers. The page's only rendering of the totals.
     await expect(page.getByText("17 filed · 14 in motion · 0 offers")).toBeVisible();
 
-    // Board columns carry the per-stage counts (the fixtures are shaped like a
-    // real early search: applied-heavy, offered honestly empty).
+    // Populated stages render as list groups, carrying their counts…
     await expect(page.getByRole("region", { name: /applied — 10/i })).toBeVisible();
     await expect(page.getByRole("region", { name: /interviewing — 4/i })).toBeVisible();
-    await expect(page.getByRole("region", { name: /offered — 0/i })).toBeVisible();
     await expect(page.getByRole("region", { name: /closed — 3/i })).toBeVisible();
-    await expect(page.getByText("none yet")).toBeVisible();
+    // …while the EMPTY stage renders no group at all: its emptiness is the
+    // spine's one line, not a quarter of the screen.
+    await expect(page.getByRole("region", { name: /offered/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "offered — 0" })).toBeVisible();
 
     expect(watch.errors, watch.errors.join("\n")).toEqual([]);
+  });
+
+  test("the spine is the stage lens: filtering to an empty stage says so", async ({ page }) => {
+    await page.goto("/demo");
+
+    await page.getByRole("button", { name: "offered — 0" }).click();
+    // The selected stage renders its (empty) group with the honest copy…
+    await expect(page.getByRole("region", { name: /offered — 0/i })).toBeVisible();
+    await expect(page.getByText("none yet")).toBeVisible();
+    // …and other groups leave the list while the lens is narrowed.
+    await expect(page.getByRole("region", { name: /applied — 10/i })).toHaveCount(0);
+
+    // Pressing the active stage again returns to the whole pipeline.
+    await page.getByRole("button", { name: "offered — 0" }).click();
+    await expect(page.getByRole("region", { name: /applied — 10/i })).toBeVisible();
   });
 
   test("the metrics-poster surfaces stay dead: no tiles, no strip, no funnel, no feed", async ({
@@ -65,10 +88,10 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await expect(page.getByText("this week", { exact: true })).toHaveCount(0);
   });
 
-  test("a card is an application: role is the discriminator, company repeats", async ({ page }) => {
+  test("a row is an application: role is the discriminator, company repeats", async ({ page }) => {
     await page.goto("/demo");
 
-    // Northstar Systems holds three applications in two different columns.
+    // Northstar Systems holds three applications in two different stages.
     // (`exact` so the "2 more at Northstar Systems" chips don't also match.)
     await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(3);
     await expect(page.getByText("ML Engineer", { exact: true })).toBeVisible();
@@ -84,7 +107,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await expect(page.getByText("Harbor Analytics")).toHaveCount(0);
     // …and the filter chip clears it.
     await page.getByRole("button", { name: /stop filtering by Northstar Systems/i }).click();
-    // (`exact` on every visible-company assertion: the interactive cards'
+    // (`exact` on every visible-company assertion: the interactive rows'
     // sr-only "Change stage for {company}" labels otherwise trip strict mode.)
     await expect(page.getByText("Harbor Analytics", { exact: true })).toBeVisible();
   });
@@ -102,16 +125,44 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await expect(page.getByText("Quarry Data", { exact: true })).toBeVisible();
   });
 
-  test("a tall column expands on the page instead of scrolling inside it", async ({ page }) => {
+  test("the whole worklist is present — no expander, no nested scroll on the flow twin", async ({
+    page,
+  }) => {
     await page.goto("/demo");
 
-    // 10 applied fixtures, 8 shown collapsed: the newest rows wait behind the
-    // expander rather than behind a nested scrollbar.
-    await expect(page.getByText("Waypoint Robotics")).toHaveCount(0);
-    await page.getByRole("button", { name: "show all 10" }).click();
+    // Every applied row renders immediately (the old board held the newest two
+    // behind a "show all 10" expander); the page is the one scroll context on
+    // the flow twin, so nothing waits behind a control or an inner scrollbar.
     await expect(page.getByText("Waypoint Robotics", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "show fewer" }).click();
-    await expect(page.getByText("Waypoint Robotics")).toHaveCount(0);
+    await expect(page.getByText("Copperline", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: /show all \d+/ })).toHaveCount(0);
+  });
+
+  test("the early-search distribution renders deliberately, not as three empty boxes", async ({
+    page,
+  }) => {
+    const watch = startConsoleWatch(page);
+    // `?pipeline=early` is the measured production shape: every live row in
+    // one stage (the real account is 29-0-0-0). This is the distribution the
+    // worklist redesign exists for.
+    await page.goto("/demo?pipeline=early");
+
+    await expect(page.getByText("17 filed · 17 in motion · 0 offers")).toBeVisible();
+    // One populated group…
+    await expect(page.getByRole("region", { name: /applied — 17/i })).toBeVisible();
+    // …and the three empty stages are spine lines, not rendered groups.
+    for (const name of ["interviewing — 0", "offered — 0", "closed — 0"]) {
+      await expect(page.getByRole("button", { name })).toBeVisible();
+    }
+    await expect(page.getByRole("region", { name: /interviewing/i })).toHaveCount(0);
+    await expect(page.getByRole("region", { name: /closed/i })).toHaveCount(0);
+
+    // The role slot holds its shape at the real board's density: this variant
+    // blanks roughly the production share of roles (8 of 29 live rows), and
+    // each prints the honest placeholder instead of shortening its row.
+    expect(await page.getByText("role not captured", { exact: true }).count()).toBeGreaterThan(2);
+
+    expect(watch.errors, watch.errors.join("\n")).toEqual([]);
   });
 
   test("no console errors and no horizontal overflow at 375px", async ({ page }) => {
@@ -127,10 +178,25 @@ test.describe("dashboard content (via the public /demo twin)", () => {
 test.describe("dashboard (signed in — needs a session)", () => {
   test("shows the pipeline header and a way to file an application", async ({ page }) => {
     await reachDashboardOrSkip(page);
-    // Either populated (the board) or empty (the empty-state hero) — both must
-    // offer the file-application entry point and never be a blank page.
+    // Either populated (the worklist) or empty (the empty-state hero) — both
+    // must offer the file-application entry point and never be a blank page.
     await expect(page.getByRole("button", { name: /file an application/i }).first()).toBeVisible();
     await expect(page.getByRole("heading", { name: /pipeline/i })).toBeVisible();
+  });
+
+  test("the dashboard is viewport-locked at desktop: the page itself does not scroll", async ({
+    page,
+  }) => {
+    await reachDashboardOrSkip(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    // The shell is h-dvh with the worklist as the one scroll region — the
+    // document never grows past the viewport (complaint: "the dashboard means
+    // it's the screen size and doesn't scroll").
+    const heights = await page.evaluate(() => ({
+      scroll: document.documentElement.scrollHeight,
+      client: document.documentElement.clientHeight,
+    }));
+    expect(heights.scroll).toBeLessThanOrEqual(heights.client + 1);
   });
 
   // The "Re-sync is retired" vocabulary guard lives in demo.spec.ts, where it

--- a/apps/web/tests/e2e/dashboard.spec.ts
+++ b/apps/web/tests/e2e/dashboard.spec.ts
@@ -88,18 +88,28 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await expect(page.getByText("this week", { exact: true })).toHaveCount(0);
   });
 
-  test("a row is an application: role is the discriminator, company repeats", async ({ page }) => {
+  test("a row is an application: grouped by employer in the view, never in the data", async ({
+    page,
+  }) => {
     await page.goto("/demo");
 
     // Northstar Systems holds four applications in two different stages — the
-    // shape of the owner's own board, where one employer holds four requisitions.
-    // (`exact` so the "+3 at Northstar Systems" chips don't also match.)
-    await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(4);
+    // shape of the owner's own board, where one employer holds four
+    // requisitions. The three applied ones share ONE employer card; the
+    // interviewing one keeps its own row — so the name renders twice, not
+    // four times, and no application's stage hides behind a summary.
+    await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(2);
     await expect(page.getByText("ML Engineer", { exact: true })).toBeVisible();
+
+    // Opening the set reveals every member led by its role — the discriminator
+    // (four requisitions must read as four different lines). The employer's
+    // name still renders exactly twice: members don't repeat the header.
+    await page.getByRole("button", { name: "Northstar Systems — 3 applications" }).click();
     await expect(page.getByText("ML Engineer, Platform", { exact: true })).toBeVisible();
     await expect(page.getByText("Research Engineer, Applied ML", { exact: true })).toBeVisible();
+    await expect(page.getByText("Northstar Systems", { exact: true })).toHaveCount(2);
 
-    // The light same-company affordance filters the board to that employer.
+    // The cross-stage chip filters the board to the employer's whole set.
     await page
       .getByRole("button", { name: /show all applications at Northstar Systems/i })
       .first()
@@ -149,8 +159,13 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     await page.goto("/demo?pipeline=early");
 
     await expect(page.getByText("17 filed · 17 in motion · 0 offers")).toBeVisible();
-    // One populated group…
+    // One populated group — 17 APPLICATIONS, however few cards the employer
+    // grouping draws (Northstar's four and Cedar's two fold into one card
+    // each; the count must reflect the applications, not the cards)…
     await expect(page.getByRole("region", { name: /applied — 17/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Northstar Systems — 4 applications" }),
+    ).toBeVisible();
     // …and the three empty stages are spine lines, not rendered groups.
     for (const name of ["interviewing — 0", "offered — 0", "closed — 0"]) {
       await expect(page.getByRole("button", { name })).toBeVisible();

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -227,8 +227,9 @@ test.describe("live demo (/demo)", () => {
 
     // And the full role is always reachable on the row itself: it may wrap
     // rather than ellipsize its discriminating tail, with the complete text
-    // in `title` as the floor.
-    await expect(page.getByTitle("ML Engineer, Platform")).toBeVisible();
+    // in `title` as the floor. (A singleton's role — Northstar's rows sit
+    // inside a collapsed employer set on this view.)
+    await expect(page.getByTitle("Software Engineer, Platform")).toBeVisible();
   });
 
   test("a card moves between stages by drag, and by its select", async ({ page }) => {
@@ -473,8 +474,10 @@ test.describe("live demo (/demo)", () => {
     await expect(pulse.getByText("17 of 17 auto-filed from mail")).toBeVisible();
     await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
 
-    // The card-level ageing tag agrees with the strip's threshold.
-    await expect(page.getByText(/quiet \d+d/).first()).toBeVisible();
+    // The card-level ageing tag agrees with the strip's threshold. `.last()`,
+    // not `.first()`: the filed stamp renders a phone-width twin earlier in
+    // the row's DOM that is display:none at this viewport.
+    await expect(page.getByText(/quiet \d+d/).last()).toBeVisible();
   });
 
   test("the pulse strip moves when Sync files fresh mail", async ({ page }) => {
@@ -818,15 +821,45 @@ test.describe("live demo (/demo)", () => {
     await expect(pulse.getByText(/1 overdue · 1 due ≤2d · 1 later/)).toBeVisible();
   });
 
-  test("a company opens as a set: band on, chips suppressed, clear restores", async ({ page }) => {
+  test("one employer, one card: the set opens inline and hides no application's stage", async ({
+    page,
+  }) => {
     await page.goto("/demo");
-    // Four Northstar cards each carry the "+3 at" chip while unfiltered.
+
+    // Northstar's three APPLIED applications fold into one employer card;
+    // the interviewing one keeps its own row under its own stage heading —
+    // grouping is per stage, so a row's true stage is never behind a summary.
+    const header = page.getByRole("button", { name: "Northstar Systems — 3 applications" });
+    await expect(header).toBeVisible();
+    await expect(header).toHaveAttribute("aria-expanded", "false");
+    // Collapsed, only the interviewing row's Open control is on the board…
+    await expect(page.getByRole("button", { name: /^Open Northstar Systems — / })).toHaveCount(1);
+    // …but the stage heading still counts APPLICATIONS, not cards.
+    await expect(page.getByRole("region", { name: /applied — 10/i })).toBeVisible();
+
+    // Opening the set reveals every member as a full row: its own Open
+    // control, its own stage select — one select per application, no merge.
+    await header.click();
+    await expect(header).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByRole("button", { name: /^Open Northstar Systems — / })).toHaveCount(4);
+    await expect(page.getByLabel("Change stage for Northstar Systems")).toHaveCount(4);
+    await header.click();
+    await expect(page.getByRole("button", { name: /^Open Northstar Systems — / })).toHaveCount(1);
+  });
+
+  test("a company opens as a set view: band on, chips suppressed, clear restores", async ({
+    page,
+  }) => {
+    await page.goto("/demo");
+    // The cross-stage chip renders twice while unfiltered: on the applied
+    // set's header ("+1 in interviewing") and on the interviewing singleton
+    // ("+3 in applied"). Its accessible name is the stable contract.
     const chips = page.getByRole("button", { name: "Show all applications at Northstar Systems" });
-    await expect(chips).toHaveCount(4);
+    await expect(chips).toHaveCount(2);
 
     await chips.first().click();
-    // The chip's "+3" counts the OTHERS, so the set it opens is all four —
-    // the row you clicked plus the three the chip was offering.
+    // The set view disperses the employer card: all four applications render
+    // flat, one row each, under their own stage headings.
     await expect(page.getByRole("button", { name: /^Open Northstar Systems — / })).toHaveCount(4);
 
     // The band states the filter and stops there. It used to add "3
@@ -840,14 +873,42 @@ test.describe("live demo (/demo)", () => {
     await expect(band.getByText("Northstar Systems")).toBeVisible();
     await expect(band.getByText(/\d+\s+applications?/)).toHaveCount(0);
     // …and the chip must NOT render while the active filter already is this
-    // company ("+3 at Northstar" inside Northstar's own set was the bug).
+    // company (a "+N" chip inside Northstar's own set view was the bug).
     await expect(chips).toHaveCount(0);
-    await expect(page.getByText(/at Northstar Systems/)).toHaveCount(0);
 
-    // Clear via the band restores the board and the chips.
+    // Clear via the band restores the grouped board and the chips.
     await page.getByRole("button", { name: "Stop filtering by Northstar Systems" }).click();
     await expect(page.getByText("Harbor Analytics", { exact: true })).toBeVisible();
-    await expect(chips).toHaveCount(4);
+    await expect(chips).toHaveCount(2);
+    await expect(
+      page.getByRole("button", { name: "Northstar Systems — 3 applications" }),
+    ).toBeVisible();
+  });
+
+  test("a four-deep employer on the early board opens four applications from one card", async ({
+    page,
+  }) => {
+    // `?pipeline=early` holds every row at applied, so Northstar's four
+    // applications share ONE stage — the owner's own shape (four Amazon
+    // requisitions, all applied), and the case the grouping exists for.
+    await page.goto("/demo?pipeline=early");
+
+    const header = page.getByRole("button", { name: "Northstar Systems — 4 applications" });
+    await expect(header).toBeVisible();
+    // Nothing of Northstar's lives outside this stage → no cross-stage chip.
+    await expect(
+      page.getByRole("button", { name: "Show all applications at Northstar Systems" }),
+    ).toHaveCount(0);
+    // The stage heading and the spine keep the real number — 17 applications,
+    // however few cards the grouped list draws.
+    await expect(page.getByRole("region", { name: /applied — 17/i })).toBeVisible();
+
+    await header.click();
+    await expect(page.getByRole("button", { name: /^Open Northstar Systems/ })).toHaveCount(4);
+    // Cedar Labs' pair folds the same way.
+    await expect(
+      page.getByRole("button", { name: "Cedar Labs — 2 applications" }),
+    ).toBeVisible();
   });
 
   test("with reduced motion, every surface is fully present — nothing gated", async ({ page }) => {

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -115,21 +115,35 @@ test.describe("live demo (/demo)", () => {
     );
   });
 
-  test("the populated column claims the space empty ones don't use", async ({ page }) => {
-    // A real search is one heavy column and three near-empty ones. An even
-    // split starved the only column with cards until four real Amazon roles
-    // ellipsized into identical text; now space follows content at desktop.
+  test("rows are even: a missing role never changes a row's height", async ({ page }) => {
+    // Half of the raggedness complaint, measured: 8 of the real board's 29
+    // live rows have no role, and the old cards rendered them visibly shorter.
+    // The worklist row keeps a fixed skeleton — company and the role slot
+    // share one line, and an absent role prints the honest placeholder — so a
+    // role-less row (Beacon Health, the fixture for this case) must measure
+    // exactly as tall as a role-carrying one.
     await page.setViewportSize({ width: 1600, height: 1000 });
     await page.goto("/demo");
-    const applied = await page.getByRole("region", { name: /applied — 10/i }).boundingBox();
-    const offered = await page.getByRole("region", { name: /offered — 0/i }).boundingBox();
-    expect(applied, "applied column renders").not.toBeNull();
-    expect(offered, "offered column renders").not.toBeNull();
-    expect(applied!.width).toBeGreaterThan(offered!.width * 1.5);
 
-    // And the full role is always reachable on the card itself: it wraps to
-    // two lines rather than ellipsizing its discriminating tail, with the
-    // complete text in `title` as the floor.
+    const beacon = page
+      .locator("li")
+      .filter({ has: page.getByText("Beacon Health", { exact: true }) })
+      .first();
+    await expect(beacon.getByText("role not captured")).toBeVisible();
+    const quarry = page
+      .locator("li")
+      .filter({ has: page.getByText("Quarry Data", { exact: true }) })
+      .first();
+
+    const beaconBox = await beacon.boundingBox();
+    const quarryBox = await quarry.boundingBox();
+    expect(beaconBox, "role-less row renders").not.toBeNull();
+    expect(quarryBox, "role-carrying row renders").not.toBeNull();
+    expect(Math.abs(beaconBox!.height - quarryBox!.height)).toBeLessThanOrEqual(2);
+
+    // And the full role is always reachable on the row itself: it may wrap
+    // rather than ellipsize its discriminating tail, with the complete text
+    // in `title` as the floor.
     await expect(page.getByTitle("ML Engineer, Platform")).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -168,7 +168,7 @@ test.describe("live demo (/demo)", () => {
     // Drop near the TOP of the column, not its centre. Hovering the centre of a
     // 2249px-tall board scrolls the page ~147px between mouse-down and the first
     // move, so the HTML5 `dragstart` fires on whichever card has slid under the
-    // cursor — Summit Platform moved while Harbor stayed put, and the count
+    // cursor — the neighbouring card moved while Harbor stayed put, and the count
     // assertion above was satisfied by the wrong card. A real drag has no
     // programmatic scroll between press and move; this is the harness, not the
     // product. The assertion below must keep naming Harbor: asserting whichever
@@ -545,25 +545,34 @@ test.describe("live demo (/demo)", () => {
 
   test("a company opens as a set: band on, chips suppressed, clear restores", async ({ page }) => {
     await page.goto("/demo");
-    // Three Northstar cards each carry the "+2 at" chip while unfiltered.
+    // Four Northstar cards each carry the "+3 at" chip while unfiltered.
     const chips = page.getByRole("button", { name: "Show all applications at Northstar Systems" });
-    await expect(chips).toHaveCount(3);
+    await expect(chips).toHaveCount(4);
 
     await chips.first().click();
-    // The band names the set…
+    // The chip's "+3" counts the OTHERS, so the set it opens is all four —
+    // the row you clicked plus the three the chip was offering.
+    await expect(page.getByRole("button", { name: /^Open Northstar Systems — / })).toHaveCount(4);
+
+    // The band states the filter and stops there. It used to add "3
+    // applications", a per-stage dot list and the filing span — all three of
+    // which the four cards on screen already say, each carrying its own stage
+    // and its own date. A count here is the metrics-poster defect coming back
+    // through a side door.
     const band = page.getByTestId("company-band");
     await expect(band).toBeVisible();
+    await expect(band.getByText("filtered to")).toBeVisible();
     await expect(band.getByText("Northstar Systems")).toBeVisible();
-    await expect(band.getByText(/3 applications/)).toBeVisible();
+    await expect(band.getByText(/\d+\s+applications?/)).toHaveCount(0);
     // …and the chip must NOT render while the active filter already is this
-    // company ("2 more at Northstar" inside Northstar's own set was the bug).
+    // company ("+3 at Northstar" inside Northstar's own set was the bug).
     await expect(chips).toHaveCount(0);
     await expect(page.getByText(/at Northstar Systems/)).toHaveCount(0);
 
     // Clear via the band restores the board and the chips.
     await page.getByRole("button", { name: "Stop filtering by Northstar Systems" }).click();
     await expect(page.getByText("Harbor Analytics", { exact: true })).toBeVisible();
-    await expect(chips).toHaveCount(3);
+    await expect(chips).toHaveCount(4);
   });
 
   test("with reduced motion, every surface is fully present — nothing gated", async ({ page }) => {
@@ -615,7 +624,13 @@ test.describe("live demo (/demo)", () => {
       .click();
     const band = page.getByTestId("company-band");
     await expect(band.getByText("Northstar Systems")).toBeVisible();
-    await expect(band.getByText(/3 applications/)).toBeVisible();
+    // The band's whole content, statically: the state it names and the control
+    // that undoes it. `toBeVisible()` on the bordered bar alone would pass on
+    // an empty one.
+    await expect(band.getByText("filtered to")).toBeVisible();
+    await expect(
+      band.getByRole("button", { name: "Stop filtering by Northstar Systems" }),
+    ).toBeVisible();
     // The set view keeps only Northstar cards, so open one of those.
     await page
       .getByRole("button", { name: "Open Northstar Systems — ML Engineer, Platform" })

--- a/apps/web/tests/e2e/production.spec.ts
+++ b/apps/web/tests/e2e/production.spec.ts
@@ -104,6 +104,10 @@ function watch(page: Page): PageFault[] {
 const ROUTES: { path: string; label: string; expect: RegExp }[] = [
   { path: "/", label: "landing", expect: /Applied/i },
   { path: "/demo", label: "demo dashboard", expect: /decision trace/i },
+  // The measured production distribution (every row one stage) — the case the
+  // worklist redesign exists for, kept hydration-clean like the seed twin.
+  { path: "/demo?pipeline=early", label: "demo dashboard (early search)", expect: /decision trace/i },
+  { path: "/demo/settings", label: "settings twin", expect: /nothing is saved/i },
   { path: "/demo/inbox", label: "sample inbox", expect: /inbox/i },
   { path: "/import", label: "import", expect: /import/i },
   { path: "/login", label: "login", expect: /sign in|log in|email/i },

--- a/apps/web/tests/e2e/settings.spec.ts
+++ b/apps/web/tests/e2e/settings.spec.ts
@@ -43,6 +43,93 @@ test.describe("appearance theme (public mechanism)", () => {
   });
 });
 
+test.describe("settings (via the public /demo/settings twin)", () => {
+  // The REAL settings sections over the simulated settings transport — the
+  // only executing coverage these components have: `/settings` needs a
+  // Supabase session that neither CI nor a local checkout can mint, so the
+  // signed-in describe below skips everywhere it matters.
+
+  test("renders every wired section, with the section rail", async ({ page }) => {
+    const watch = startConsoleWatch(page);
+    await page.goto("/demo/settings");
+
+    await expect(page.getByRole("heading", { name: /^settings$/i })).toBeVisible();
+    for (const name of [
+      /^profile$/i,
+      /^appearance$/i,
+      /^gmail$/i,
+      /^notifications$/i,
+      /^classification$/i,
+      /your data/i,
+      /^account$/i,
+    ]) {
+      await expect(page.getByRole("heading", { name })).toBeVisible();
+    }
+    await expect(page.getByRole("navigation", { name: /settings sections/i })).toBeVisible();
+    // The provenance badge — this page must never read as a real account.
+    await expect(page.getByText("demo · fixture account · nothing is saved")).toBeVisible();
+    expect(watch.errors, watch.errors.join("\n")).toEqual([]);
+  });
+
+  test("the appearance switch is a working radiogroup — the real theme mechanism", async ({
+    page,
+  }) => {
+    await page.goto("/demo/settings");
+    const group = page.getByRole("radiogroup", { name: /theme/i });
+    await expect(group).toBeVisible();
+    await group.getByRole("radio", { name: /light/i }).click();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe("light");
+    // Reset so the run doesn't leave the app themed light.
+    await group.getByRole("radio", { name: /dark/i }).click();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe("dark");
+  });
+
+  test("the classification gate shows a live consequence as it moves", async ({ page }) => {
+    await page.goto("/demo/settings");
+    await expect(page.getByText(/would wait for your review/i)).toBeVisible();
+    await expect(page.getByRole("slider", { name: /gate/i })).toBeVisible();
+  });
+
+  test("a profile save runs the whole machine and reports Saved", async ({ page }) => {
+    await page.goto("/demo/settings");
+    const name = page.getByPlaceholder("e.g. Ayush Yadav");
+    await name.fill("Sam Fixture II");
+    await page.getByRole("button", { name: "Save profile" }).click();
+    await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+  });
+
+  test("account deletion is gated behind a typed confirmation — and the demo refuses honestly", async ({
+    page,
+  }) => {
+    await page.goto("/demo/settings");
+    await page.getByRole("button", { name: /delete account/i }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    const confirmButton = dialog.getByRole("button", { name: /permanently delete/i });
+    await expect(confirmButton).toBeDisabled();
+    await dialog.getByRole("textbox").fill("DELETE");
+    await expect(confirmButton).toBeEnabled();
+    // On the twin the transport answers with the one honest difference —
+    // nothing exists to delete — through the same error surface the live
+    // route uses for a deployment without deletion enabled.
+    await confirmButton.click();
+    await expect(dialog.getByRole("alert")).toContainText(/simulated account/i);
+  });
+
+  test("the disconnect control is disabled with a reason, never a dead button that lies", async ({
+    page,
+  }) => {
+    await page.goto("/demo/settings");
+    const disconnect = page.getByRole("button", { name: /^disconnect$/i });
+    await expect(disconnect).toBeDisabled();
+    await expect(disconnect).toHaveAttribute("title", /simulated account/i);
+  });
+});
+
 test.describe("settings sections (signed in — needs a session)", () => {
   test("renders every wired section", async ({ page }) => {
     await reachSettingsOrSkip(page);

--- a/apps/web/tests/unit/employer-groups.test.mjs
+++ b/apps/web/tests/unit/employer-groups.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the employer DISPLAY grouping (`lib/dashboard/employerGroups.ts`).
+ *
+ * What these pin down:
+ *
+ *  1. Grouping is a fold over the same rows the flat list would render — no
+ *     row is dropped, invented or reordered. This is the boundary that keeps
+ *     it a view and never a merge (the merge was a real correctness bug:
+ *     furthest-stage-wins plus a terminal override made one rejection swallow
+ *     an employer's other live applications).
+ *  2. The singleton — most rows — passes through untouched, so the common
+ *     case cannot be made worse by the grouped one.
+ *  3. A set anchors at its first member's position and keeps member order.
+ *  4. The cross-stage chip text names ONE other stage when there is one, and
+ *     says "other stages" when there are several — and renders nothing for a
+ *     count of zero, because "+0 elsewhere" is noise.
+ *
+ * Run:  npm run test:unit
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { elsewhereLabel, groupByEmployer } from "../../lib/dashboard/employerGroups.ts";
+
+const row = (id, company) => ({ id, company });
+
+test("singletons pass through as singles, in order", () => {
+  const rows = [row(1, "Harbor"), row(2, "Quarry"), row(3, "Beacon")];
+  assert.deepEqual(groupByEmployer(rows), [
+    { kind: "single", app: rows[0] },
+    { kind: "single", app: rows[1] },
+    { kind: "single", app: rows[2] },
+  ]);
+});
+
+test("two or more rows at one employer fold into one set holding every row", () => {
+  const rows = [row(1, "Northstar"), row(2, "Northstar"), row(3, "Northstar"), row(4, "Northstar")];
+  const entries = groupByEmployer(rows);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, "set");
+  assert.equal(entries[0].company, "Northstar");
+  // Every application is present — a set is a view, never a merge.
+  assert.deepEqual(
+    entries[0].items.map((r) => r.id),
+    [1, 2, 3, 4],
+  );
+});
+
+test("a set anchors at its first member's position; interleaved rows keep their own", () => {
+  const rows = [row(1, "Northstar"), row(2, "Cedar"), row(3, "Northstar"), row(4, "Quarry")];
+  const entries = groupByEmployer(rows);
+  assert.deepEqual(
+    entries.map((e) => (e.kind === "set" ? `set:${e.company}` : `single:${e.app.company}`)),
+    ["set:Northstar", "single:Cedar", "single:Quarry"],
+  );
+  assert.deepEqual(
+    entries[0].items.map((r) => r.id),
+    [1, 3],
+  );
+});
+
+test("no row is lost or duplicated across any mix of sets and singles", () => {
+  const rows = [
+    row(1, "A"),
+    row(2, "B"),
+    row(3, "A"),
+    row(4, "C"),
+    row(5, "B"),
+    row(6, "A"),
+  ];
+  const entries = groupByEmployer(rows);
+  const ids = entries.flatMap((e) => (e.kind === "set" ? e.items.map((r) => r.id) : [e.app.id]));
+  assert.deepEqual([...ids].sort((a, b) => a - b), [1, 2, 3, 4, 5, 6]);
+});
+
+test("elsewhereLabel names the one other stage, or 'other stages' for a spread", () => {
+  assert.equal(elsewhereLabel(1, ["interviewing"]), "+1 in interviewing");
+  assert.equal(elsewhereLabel(3, ["applied"]), "+3 in applied");
+  // Duplicate labels are still ONE stage.
+  assert.equal(elsewhereLabel(2, ["closed", "closed"]), "+2 in closed");
+  assert.equal(elsewhereLabel(3, ["interviewing", "closed"]), "+3 in other stages");
+});
+
+test("elsewhereLabel renders nothing when there is nothing elsewhere", () => {
+  assert.equal(elsewhereLabel(0, []), null);
+  assert.equal(elsewhereLabel(0, ["applied"]), null);
+  assert.equal(elsewhereLabel(2, []), null);
+});

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -251,6 +251,11 @@ router = APIRouter(
 DEFAULT_PAGE_SIZE = 100
 MAX_PAGE_SIZE = 500
 
+# The mail listing pages smaller than the board does: a message row carries a
+# subject and a snippet, so 50 of them is already a heavier response than 100
+# applications. Same MAX_PAGE_SIZE ceiling.
+DEFAULT_MAIL_PAGE_SIZE = 50
+
 # How recent an application counts as "this week" for the summary tile. Kept
 # in one place so the backend aggregate and the frontend's array-based
 # `summarize()` fold agree on the window (7 days).
@@ -407,6 +412,63 @@ class ReviewQueueResponse(BaseModel):
 
     items: list[ReviewItemResponse]
     total: int
+
+
+class MailMessageResponse(BaseModel):
+    """One stored message in the full mail listing.
+
+    Deliberately METADATA ONLY. ``snippet`` is the persisted ``body_snippet``
+    and there is no field for ``body_text`` or ``body_html``: the cloud sync
+    never fetches a body and this listing is not the place to start.
+
+    ``category``/``confidence``/``method`` are the stored verdict verbatim —
+    ``classified_as``, ``classification_confidence``, ``classification_method``
+    — so a reader can see WHAT was decided and HOW, which is the difference
+    between "the machine says applied" and "a rule matched at 0.71".
+
+    ``category`` carries the enum's own value (``"applied"``, ``"needs_review"``
+    …), the same lowercase vocabulary ``?category=`` accepts and
+    ``POST /review/{message_id}/classify`` takes back. One vocabulary end to
+    end, so a value read here can be sent straight back as a correction.
+    """
+
+    message_id: str
+    thread_id: str | None = None
+    subject: str | None = None
+    sender_name: str | None = None
+    sender_email: str | None = None
+    received_at: str | None = None
+    snippet: str | None = None
+    category: str | None = None
+    confidence: float | None = None
+    method: str | None = None
+    user_corrected: bool = False
+    is_reviewed: bool = False
+    application_id: int | None = None
+    # The linked application's employer, resolved in ONE query for the whole
+    # page (never per row). ``None`` when the message is not filed against an
+    # application — which most needs-review mail is not.
+    company: str | None = None
+    gmail_link: str | None = None
+
+
+class MailListResponse(BaseModel):
+    """A page of the user's stored mail, plus the counts the chips need.
+
+    ``total`` is the size of the CURRENT query — it respects both ``category``
+    and ``q``, because it is the number ``page``/``page_size`` walk.
+
+    ``category_counts`` is deliberately different: it respects ``q`` but NOT
+    ``category``, so each filter chip can show its own total while one of them
+    is active. Counting only the filtered set would make every chip but the
+    selected one read zero.
+    """
+
+    messages: list[MailMessageResponse]
+    total: int
+    page: int
+    page_size: int
+    category_counts: dict[str, int]
 
 
 class ReviewClassifyRequest(BaseModel):
@@ -2580,6 +2642,188 @@ async def application_statuses_cloud() -> StatusVocabularyResponse:
             for category, status in CATEGORY_TO_STATUS.items()
         },
         classifier_categories=list(pipeline.CANONICAL_CATEGORIES),
+    )
+
+
+@router.get("/mail", response_model=MailListResponse)
+async def mail_listing_cloud(
+    user_id: uuid.UUID = Depends(current_user),
+    page: int = Query(1, ge=1, description="1-based page number."),
+    page_size: int = Query(
+        DEFAULT_MAIL_PAGE_SIZE,
+        ge=1,
+        le=MAX_PAGE_SIZE,
+        description="Rows per page (capped so a single response stays bounded).",
+    ),
+    category: EmailCategory | None = Query(
+        None,
+        description=(
+            "Filter to one stored verdict. Does not affect `category_counts`."
+        ),
+    ),
+    q: str | None = Query(
+        None, description="Case-insensitive substring match on subject/sender."
+    ),
+) -> MailListResponse:
+    """Every message this user has stored, whatever the classifier decided.
+
+    Declared ABOVE ``GET /{application_id}`` deliberately: FastAPI matches in
+    declaration order and would otherwise try ``"mail"`` as an int path param
+    and answer 422. Same pattern as ``/summary``, ``/review`` and ``/statuses``.
+
+    WHY THIS EXISTS
+    ---------------
+    ``/review`` is the only other listing of classified mail, and it filters to
+    ``needs_review AND unlinked AND not-yet-reviewed``. That is the right set
+    for a work queue and the wrong set for a correction surface, because those
+    three predicates make a verdict unreachable the moment it is touched:
+
+    * a message already reviewed once drops out for good — emails 58 and 59 of
+      the owner's account sit at ``needs_review`` with ``is_reviewed = true``
+      and no endpoint in the product could name them, so no screen could
+      change them;
+    * a message linked to an application drops out too, so a ``rejection``
+      filed as ``applied`` is a wrong stored verdict a user can see on the
+      board and never correct at its source;
+    * and for an account whose mail all classified confidently, ``/review``
+      returns zero rows and the review UI never renders at all.
+
+    The write path never had that restriction — :func:`classify_review_item`
+    selects on ``(user_id, message_id)`` alone — so correcting any of these
+    already worked. What was missing was a way to *find* them. This is that
+    read, and nothing more: no new write, no body, no state change.
+
+    SHAPE
+    -----
+    Newest first with an ``id`` tiebreak, for the same reason the applications
+    listing has one: a sync writes a batch of rows carrying identical
+    ``received_at`` values, tied rows are free to come back in a different
+    order per request on Postgres, and paging a partial order drops some rows
+    and repeats others.
+
+    One entry per MESSAGE — unlike ``/review``, which collapses a thread to its
+    newest message because being asked the same question twice is duplicated
+    work. Here the user is auditing what is stored, and every stored row is
+    correctable individually, so hiding siblings would hide exactly the rows
+    this endpoint exists to reach.
+    """
+
+    # Two filter sets, and the difference is the contract: `total` counts the
+    # query being paged (category + q), while the chips' counts must ignore
+    # `category` or every chip but the active one reads zero.
+    base_filters = [Email.user_id == user_id]
+    needle = (q or "").strip()
+    if needle:
+        like = f"%{needle}%"
+        base_filters.append(
+            or_(
+                Email.subject.ilike(like),
+                Email.sender_name.ilike(like),
+                Email.sender_email.ilike(like),
+            )
+        )
+
+    page_filters = list(base_filters)
+    if category is not None:
+        page_filters.append(Email.classified_as == category)
+
+    offset = (page - 1) * page_size
+
+    async with get_session() as session:
+        total = (
+            await session.exec(
+                select(func.count()).select_from(Email).where(*page_filters)
+            )
+        ).one()
+
+        grouped = (
+            await session.exec(
+                select(Email.classified_as, func.count())
+                .where(*base_filters)
+                .group_by(Email.classified_as)
+            )
+        ).all()
+
+        stmt = (
+            select(Email)
+            .where(*page_filters)
+            # The tiebreak, and it has to be here. A sync writes a batch of
+            # rows inside the same second, so `received_at` alone leaves them
+            # tied and Postgres may return them in a different order per
+            # request — which drops and repeats rows across pages.
+            .order_by(Email.received_at.desc(), Email.id.desc())
+            .offset(offset)
+            .limit(page_size)
+        )
+        rows = (await session.exec(stmt)).all()
+
+        # ONE query for the whole page's employers, not one per row. Scoped to
+        # the owner as well as the id set: a linked id is only ever this user's,
+        # and re-asserting it here means a stale link cannot read across users.
+        linked_ids = {e.application_id for e in rows if e.application_id is not None}
+        company_by_application: dict[int, str] = {}
+        if linked_ids:
+            pairs = (
+                await session.exec(
+                    select(Application.id, Application.company).where(
+                        Application.id.in_(linked_ids),
+                        Application.user_id == user_id,
+                    )
+                )
+            ).all()
+            company_by_application = dict(pairs)
+
+    category_counts: dict[str, int] = {}
+    for stored_category, count in grouped:
+        if stored_category is None:
+            # An unclassified row is real, but it has no chip to land on and
+            # `dict[str, int]` has no key for it. Counted nowhere rather than
+            # under a made-up name; `total` still includes it.
+            continue
+        key = (
+            stored_category.value
+            if hasattr(stored_category, "value")
+            else str(stored_category)
+        )
+        category_counts[key] = count
+
+    account_email = await _connected_account_email(user_id)
+    messages = [
+        MailMessageResponse(
+            message_id=e.message_id,
+            thread_id=e.thread_id,
+            subject=e.subject,
+            sender_name=e.sender_name,
+            sender_email=e.sender_email,
+            received_at=e.received_at.isoformat() if e.received_at else None,
+            # `body_snippet` — the stored preview. Never `body_text`/`body_html`.
+            snippet=e.body_snippet,
+            category=e.classified_as.value if e.classified_as else None,
+            confidence=e.classification_confidence,
+            method=e.classification_method,
+            user_corrected=e.user_corrected,
+            is_reviewed=e.is_reviewed,
+            application_id=e.application_id,
+            company=(
+                company_by_application.get(e.application_id)
+                if e.application_id is not None
+                else None
+            ),
+            gmail_link=pipeline.gmail_deeplink(
+                thread_id=e.thread_id,
+                message_id=e.message_id,
+                account_email=account_email,
+            ),
+        )
+        for e in rows
+    ]
+
+    return MailListResponse(
+        messages=messages,
+        total=total,
+        page=page,
+        page_size=page_size,
+        category_counts=category_counts,
     )
 
 

--- a/backend/tests/test_mail_listing.py
+++ b/backend/tests/test_mail_listing.py
@@ -1,0 +1,740 @@
+"""``GET /applications/mail`` — every stored verdict must be reachable.
+
+Why this file exists
+--------------------
+
+``/applications/review`` was the product's only listing of classified mail, and
+it filters to ``needs_review AND application_id IS NULL AND is_reviewed = false``.
+Those three predicates make a verdict unreachable the moment it is touched. In
+the owner's production database:
+
+* emails 58 and 59 sit at ``needs_review`` with ``is_reviewed = true`` (58 is
+  linked to application 67). No endpoint could name them, so no screen could
+  show them and no screen could change them — permanently stuck at a verdict
+  the user disagreed with;
+* the same query returns **0 rows** for that account overall, so the review UI
+  never rendered at all;
+* meanwhile the write path, :func:`classify_review_item`, selects on
+  ``(user_id, message_id)`` with no such constraint — correcting any of these
+  already worked. Only the *read* was missing.
+
+So the case that matters most here is the boring-looking one: a reviewed email
+appears. That single assertion is the whole point of the endpoint, and it is
+the one a re-added ``is_reviewed == False`` filter would break.
+
+Proven to fail
+--------------
+
+Every assertion below was checked by breaking the thing it covers and watching
+it go red (see the report accompanying the change). The mutations and their
+results are recorded next to each test.
+
+The fixtures are guarded: :func:`test_the_fixture_set_is_what_the_tests_assume`
+runs first and pins the seeded corpus against the literals the other tests use,
+because a test that seeds nothing and asserts over nothing is green.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import time
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
+
+JWT_SECRET = "mail-listing-test-jwt-secret-at-least-32-bytes-long-hs256"
+OWNER = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+STRANGER = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+
+# Nearly every row carries the SAME timestamp on purpose: that is the state a
+# sync leaves behind, and the only state in which the `id` tiebreak matters.
+TIED_AT = datetime(2026, 8, 11, 9, 30, 0)
+# One row is genuinely newer, so "newest first" is falsifiable rather than
+# vacuously true over a set of ties.
+NEWEST_AT = TIED_AT + timedelta(days=1)
+
+# Seeded into `body_text`/`body_html` on every row. Bodies are never fetched by
+# the cloud sync and must never leave the backend; asserting on this string
+# rather than on the absence of a field name is what makes the check able to
+# fail (a response model with no `body_text` field cannot ever contain the
+# literal "body_text", so that assertion would pass no matter what).
+BODY_SENTINEL = "SENTINEL-BODY-MUST-NOT-LEAVE-THE-BACKEND"
+
+CRUSOE = "Crusoe Energy"
+NORTHWIND = "Northwind Systems"
+
+
+# (message_id, subject, sender_name, sender_email, category, is_reviewed, link)
+# `link` is a company name to file the message under, or None for unlinked.
+OWNER_MAIL: tuple[tuple[str, str, str, str, str, bool, str | None], ...] = (
+    # The two rows this endpoint exists for. Both already reviewed once, so
+    # `/review` can never list them again; one is linked to an application
+    # (email 58's shape), one is not (email 59's).
+    (
+        "m-58",
+        "Crusoe | Application Received",
+        "Crusoe Recruiting",
+        "recruiting@crusoe.ai",
+        "needs_review",
+        True,
+        CRUSOE,
+    ),
+    (
+        "m-59",
+        "Crusoe | Application Received",
+        "Crusoe Recruiting",
+        "recruiting@crusoe.ai",
+        "needs_review",
+        True,
+        None,
+    ),
+    # Matches q="crusoe" on the SENDER only — its subject says nothing.
+    (
+        "m-sender",
+        "Thanks for your interest",
+        "Talent Team",
+        "jobs@crusoe.ai",
+        "applied",
+        False,
+        None,
+    ),
+    # Matches q="crusoe" on the SUBJECT only — its sender is a job board.
+    (
+        "m-subject",
+        "Your Crusoe application",
+        "Greenhouse",
+        "noreply@greenhouse.io",
+        "applied",
+        False,
+        None,
+    ),
+    ("n-1", "Thanks for applying", "Northwind", "careers@northwind.test", "applied", False, NORTHWIND),
+    ("n-2", "Application received", "Northwind", "careers@northwind.test", "applied", False, NORTHWIND),
+    ("n-3", "We got your application", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-4", "Application submitted", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-5", "Received: Backend Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-6", "Received: Data Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    ("n-7", "Received: Platform Engineer", "Northwind", "careers@northwind.test", "applied", False, None),
+    # The newest row, and not an application at all.
+    ("m-other", "Your weekly newsletter", "Substack", "no-reply@substack.test", "other", False, None),
+)
+
+# A second account whose mail must never appear in the first one's listing —
+# including a row that would match every filter the tests apply.
+STRANGER_MAIL: tuple[tuple[str, str, str, str, str, bool, str | None], ...] = (
+    ("s-1", "Crusoe | Application Received", "Crusoe Recruiting", "recruiting@crusoe.ai", "needs_review", True, None),
+    ("s-2", "Thanks for applying", "Someone Else", "careers@elsewhere.test", "applied", False, None),
+    ("s-3", "Your weekly newsletter", "Substack", "no-reply@substack.test", "other", False, None),
+)
+
+# Hardcoded so a mistake in the table above cannot quietly redefine what the
+# tests prove; `test_the_fixture_set_is_what_the_tests_assume` reconciles the
+# two. (Derived-only expectations agree with any corpus, including an empty one.)
+EXPECTED_TOTAL = 12
+EXPECTED_COUNTS = {"applied": 9, "needs_review": 2, "other": 1}
+Q_NEEDLE = "crusoe"
+EXPECTED_Q_MATCHES = {"m-58", "m-59", "m-sender", "m-subject"}
+EXPECTED_Q_COUNTS = {"applied": 2, "needs_review": 2}
+LINKED_MESSAGES = {"m-58": CRUSOE, "n-1": NORTHWIND, "n-2": NORTHWIND}
+
+
+def _token_for(user_id: str) -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {"sub": user_id, "aud": "authenticated", "iat": now, "exp": now + 300},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+async def cloud_app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Any]:
+    """The cloud app over the in-memory SQLite test DB (see test_user_id_scoping)."""
+
+    monkeypatch.setenv("JOBTRACKER_DEPLOYMENT", "cloud")
+    monkeypatch.setenv("JOBTRACKER_ENVIRONMENT", "test")
+    monkeypatch.setenv("JOBTRACKER_SUPABASE_JWT_SECRET", JWT_SECRET)
+
+    import jobtracker.config as config_module
+    import jobtracker.database.connection as connection_module
+
+    importlib.reload(config_module)
+    connection_module._engine = None
+
+    import jobtracker.auth.supabase_jwt as auth_module
+
+    importlib.reload(auth_module)
+
+    import jobtracker.cloud.applications as cloud_apps_module
+
+    importlib.reload(cloud_apps_module)
+
+    import jobtracker.main_cloud as main_cloud_module
+
+    importlib.reload(main_cloud_module)
+
+    from jobtracker.database import init_db
+
+    await init_db()
+
+    yield main_cloud_module.app
+
+    if connection_module._engine is not None:
+        await connection_module._engine.dispose()
+    connection_module._engine = None
+    monkeypatch.undo()
+    importlib.reload(config_module)
+
+
+async def _seed() -> dict[str, int]:
+    """Write both accounts' applications and mail. Returns app ids by company."""
+
+    from jobtracker.database.connection import get_session
+    from jobtracker.database.models import (
+        Application,
+        ApplicationStatus,
+        Email,
+        EmailCategory,
+        EmailSource,
+    )
+
+    app_ids: dict[str, int] = {}
+    async with get_session() as session:
+        for company in (CRUSOE, NORTHWIND):
+            row = Application(
+                user_id=uuid.UUID(OWNER),
+                company=company,
+                position="Software Engineer",
+                status=ApplicationStatus.APPLIED,
+            )
+            session.add(row)
+            await session.flush()
+            app_ids[company] = row.id
+
+        # The stranger holds an application at the same employer, so a
+        # cross-user company lookup would resolve to something plausible
+        # rather than to nothing.
+        stranger_app = Application(
+            user_id=uuid.UUID(STRANGER),
+            company=CRUSOE,
+            position="Software Engineer",
+            status=ApplicationStatus.APPLIED,
+        )
+        session.add(stranger_app)
+        await session.flush()
+
+        for owner, table in ((OWNER, OWNER_MAIL), (STRANGER, STRANGER_MAIL)):
+            for (
+                message_id,
+                subject,
+                sender_name,
+                sender_email,
+                category,
+                is_reviewed,
+                link,
+            ) in table:
+                session.add(
+                    Email(
+                        user_id=uuid.UUID(owner),
+                        source_account=EmailSource.GMAIL,
+                        message_id=message_id,
+                        thread_id=f"thread-{message_id}",
+                        subject=subject,
+                        sender_name=sender_name,
+                        sender_email=sender_email,
+                        received_at=NEWEST_AT if message_id == "m-other" else TIED_AT,
+                        body_text=f"{BODY_SENTINEL} plain",
+                        body_html=f"<p>{BODY_SENTINEL} html</p>",
+                        body_snippet=f"snippet for {message_id}",
+                        classified_as=EmailCategory(category),
+                        classification_confidence=0.71,
+                        classification_method="rules",
+                        user_corrected=is_reviewed,
+                        is_reviewed=is_reviewed,
+                        application_id=app_ids[link] if link and owner == OWNER else None,
+                    )
+                )
+        await session.commit()
+
+    return app_ids
+
+
+async def _get(cloud_app, user: str = OWNER, **params: Any) -> Any:
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        return await client.get(
+            "/applications/mail",
+            params=params,
+            headers={"Authorization": f"Bearer {_token_for(user)}"},
+        )
+
+
+# =============================================================================
+# The premise guard — run this before believing anything below it
+# =============================================================================
+
+
+async def test_the_fixture_set_is_what_the_tests_assume(cloud_app):
+    """Reconcile the seeded corpus with the literals the other tests use.
+
+    A previous test in this repo reported "3 passed, 4 skipped" because its
+    table names were wrong and every case skipped itself into green. Assertions
+    over an empty or mis-shaped fixture set are worth nothing, so this pins the
+    fixture set itself before anything asserts over it.
+    """
+
+    app_ids = await _seed()
+    assert set(app_ids) == {CRUSOE, NORTHWIND}
+
+    assert len(OWNER_MAIL) == EXPECTED_TOTAL, "the owner's corpus changed size"
+    assert len({row[0] for row in OWNER_MAIL}) == EXPECTED_TOTAL, "duplicate message ids"
+
+    derived: dict[str, int] = {}
+    for row in OWNER_MAIL:
+        derived[row[4]] = derived.get(row[4], 0) + 1
+    assert derived == EXPECTED_COUNTS
+
+    derived_q = {row[0] for row in OWNER_MAIL if Q_NEEDLE in (row[1] + row[3]).lower()}
+    assert derived_q == EXPECTED_Q_MATCHES
+
+    derived_links = {row[0]: row[6] for row in OWNER_MAIL if row[6] is not None}
+    assert derived_links == LINKED_MESSAGES
+    assert len(LINKED_MESSAGES) >= 2, (
+        "the N+1 check needs at least two linked rows on one page, otherwise "
+        "'one query' and 'one query per row' are the same number"
+    )
+
+    # And the rows really landed in the database.
+    from sqlmodel import select
+
+    from jobtracker.database.connection import get_session
+    from jobtracker.database.models import Email
+
+    async with get_session() as session:
+        stored = (await session.exec(select(Email))).all()
+    assert len(stored) == len(OWNER_MAIL) + len(STRANGER_MAIL)
+
+
+# =============================================================================
+# The gap this endpoint closes
+# =============================================================================
+
+
+async def test_a_reviewed_email_is_listed(cloud_app):
+    """Emails 58 and 59: reviewed, and therefore invisible to ``/review``.
+
+    THE POINT OF THE ENDPOINT. A verdict the user already touched once stays
+    correctable, instead of being frozen wherever the classifier left it.
+
+    Mutation: re-adding ``Email.is_reviewed == False`` to the page filters →
+    this test fails (both ids missing).
+    """
+
+    await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["messages"], "the listing returned nothing to assert over"
+    by_id = {m["message_id"]: m for m in body["messages"]}
+
+    for message_id in ("m-58", "m-59"):
+        assert message_id in by_id, (
+            f"{message_id} is reviewed needs-review mail and is unreachable "
+            "again — this is the exact state emails 58/59 are stuck in"
+        )
+        assert by_id[message_id]["is_reviewed"] is True
+        assert by_id[message_id]["category"] == "needs_review"
+
+    # 59 is unlinked; the review queue would additionally have dropped 58 for
+    # being filed against an application.
+    assert by_id["m-59"]["application_id"] is None
+    assert by_id["m-58"]["application_id"] is not None
+
+
+async def test_a_linked_email_carries_its_company(cloud_app):
+    """A filed message names its employer, and an unfiled one names nothing.
+
+    Mutation: adding ``Email.application_id.is_(None)`` to the page filters →
+    fails (m-58 missing). Returning ``company=None`` unconditionally → fails.
+    """
+
+    app_ids = await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    by_id = {m["message_id"]: m for m in res.json()["messages"]}
+    assert by_id, "the listing returned nothing to assert over"
+
+    for message_id, company in LINKED_MESSAGES.items():
+        assert by_id[message_id]["application_id"] == app_ids[company]
+        assert by_id[message_id]["company"] == company
+
+    assert by_id["m-59"]["company"] is None
+    assert by_id["m-other"]["company"] is None
+
+
+async def test_company_resolution_is_one_query_not_one_per_row(cloud_app):
+    """Three linked rows on the page must cost ONE applications SELECT.
+
+    Reads the statements handed to the driver, so it measures the query the
+    database actually receives rather than the shape of the Python.
+
+    Mutation: resolving the company inside the per-row loop → 3 statements,
+    this fails.
+    """
+
+    await _seed()
+
+    import jobtracker.database.connection as connection_module
+
+    engine = connection_module._engine
+    assert engine is not None, "the fixture should have built an engine"
+
+    statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        statements.append(statement)
+
+    try:
+        res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+        assert res.status_code == 200, res.text
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    linked = [m for m in res.json()["messages"] if m["application_id"] is not None]
+    assert len(linked) == len(LINKED_MESSAGES), "the page did not contain the linked rows"
+
+    against_applications = [s for s in statements if "FROM applications" in s]
+    assert len(against_applications) <= 1, (
+        "the company lookup is running per row: "
+        f"{len(against_applications)} SELECTs against applications for "
+        f"{len(linked)} linked messages"
+    )
+
+
+async def test_another_users_mail_is_never_listed(cloud_app):
+    """Owner-scoped rows, owner-scoped counts.
+
+    Mutation: dropping ``Email.user_id == user_id`` from the page filters →
+    fails (the stranger's ids appear and the totals inflate).
+    """
+
+    await _seed()
+
+    mine = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert mine.status_code == 200, mine.text
+    mine_body = mine.json()
+    mine_ids = {m["message_id"] for m in mine_body["messages"]}
+    assert mine_ids == {row[0] for row in OWNER_MAIL}
+    assert mine_body["total"] == EXPECTED_TOTAL
+    assert mine_body["category_counts"] == EXPECTED_COUNTS
+
+    theirs = await _get(cloud_app, user=STRANGER, page_size=EXPECTED_TOTAL)
+    assert theirs.status_code == 200, theirs.text
+    theirs_body = theirs.json()
+    theirs_ids = {m["message_id"] for m in theirs_body["messages"]}
+    assert theirs_ids == {row[0] for row in STRANGER_MAIL}
+    assert theirs_ids, "the stranger's own listing came back empty"
+    assert not (theirs_ids & mine_ids)
+    assert theirs_body["total"] == len(STRANGER_MAIL)
+
+    # And the stranger's Crusoe application must not surface on their mail
+    # either — s-1 is unlinked, so it names no employer.
+    assert all(m["company"] is None for m in theirs_body["messages"])
+
+
+async def test_bodies_never_leave_the_backend(cloud_app):
+    """The stored body is on disk; it is not in the response.
+
+    Asserts on a SENTINEL seeded into ``body_text``/``body_html``, not on the
+    absence of a field name — the response model has no body field, so
+    ``"body_text" not in response`` is a check that cannot fail.
+
+    Mutation: ``snippet=e.body_text`` → fails.
+    """
+
+    await _seed()
+    res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["messages"], "the listing returned nothing to assert over"
+    assert BODY_SENTINEL not in res.text, "a stored email body reached the client"
+    # The snippet is still there — this is not passing because the payload is
+    # empty of content.
+    assert all(m["snippet"] for m in body["messages"])
+    assert body["messages"][0]["snippet"].startswith("snippet for ")
+
+
+# =============================================================================
+# Filtering
+# =============================================================================
+
+
+async def test_category_filters_the_page(cloud_app):
+    """``?category=`` narrows the listing and ``total`` follows it.
+
+    Mutation: dropping the ``category`` filter from the page filters → fails
+    (12 rows come back for a filter that should return 2).
+    """
+
+    await _seed()
+
+    res = await _get(cloud_app, category="needs_review", page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert {m["message_id"] for m in body["messages"]} == {"m-58", "m-59"}
+    assert body["total"] == EXPECTED_COUNTS["needs_review"]
+
+    applied = await _get(cloud_app, category="applied", page_size=EXPECTED_TOTAL)
+    assert applied.status_code == 200, applied.text
+    assert applied.json()["total"] == EXPECTED_COUNTS["applied"]
+    assert all(m["category"] == "applied" for m in applied.json()["messages"])
+
+    # The wire vocabulary is the enum's VALUES, lowercase — the same words
+    # `POST /review/{message_id}/classify` accepts, so a category read here can
+    # be sent straight back as a correction. An unknown one is a visible 422,
+    # not a silently empty page.
+    assert (await _get(cloud_app, category="NEEDS_REVIEW")).status_code == 422
+    assert (await _get(cloud_app, category="banana")).status_code == 422
+
+
+async def test_q_matches_subject_and_sender(cloud_app):
+    """``?q=`` is a case-insensitive substring over subject AND sender.
+
+    The corpus contains a row that matches on the sender only and a row that
+    matches on the subject only, so dropping either half of the OR fails.
+
+    Mutation: dropping the ``q`` filter → fails (12 rows for a 4-row query).
+    """
+
+    await _seed()
+
+    res = await _get(cloud_app, q=Q_NEEDLE, page_size=EXPECTED_TOTAL)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert {m["message_id"] for m in body["messages"]} == EXPECTED_Q_MATCHES
+    assert body["total"] == len(EXPECTED_Q_MATCHES)
+
+    # Case-insensitive: the corpus spells it "Crusoe".
+    upper = await _get(cloud_app, q="CRUSOE", page_size=EXPECTED_TOTAL)
+    assert {m["message_id"] for m in upper.json()["messages"]} == EXPECTED_Q_MATCHES
+
+    # A needle that matches nothing returns an honest empty page, not everything.
+    empty = await _get(cloud_app, q="zzz-no-such-mail", page_size=EXPECTED_TOTAL)
+    assert empty.json()["total"] == 0
+    assert empty.json()["messages"] == []
+
+
+async def test_category_counts_ignore_category_but_respect_q(cloud_app):
+    """The chips must show their own totals while one of them is selected.
+
+    This is the asymmetry in the contract: ``total`` is the current query,
+    ``category_counts`` deliberately is not.
+
+    Mutations: counting over the page filters instead of the base filters →
+    fails (the counts collapse to the selected chip); dropping ``q`` from the
+    counts query → fails (the counts stay at the unfiltered totals).
+    """
+
+    await _seed()
+
+    unfiltered = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    assert unfiltered.json()["category_counts"] == EXPECTED_COUNTS
+
+    # Selecting a chip must NOT change what the other chips say.
+    filtered = await _get(cloud_app, category="needs_review", page_size=EXPECTED_TOTAL)
+    assert filtered.json()["category_counts"] == EXPECTED_COUNTS, (
+        "the counts collapsed to the selected category — every other chip "
+        "would read zero the moment one was clicked"
+    )
+    assert filtered.json()["total"] == EXPECTED_COUNTS["needs_review"]
+
+    # A search DOES change them: the chips describe the searched set.
+    searched = await _get(cloud_app, q=Q_NEEDLE, page_size=EXPECTED_TOTAL)
+    assert searched.json()["category_counts"] == EXPECTED_Q_COUNTS
+    assert searched.json()["category_counts"] != EXPECTED_COUNTS
+
+    # Both at once: counts follow `q` only.
+    both = await _get(
+        cloud_app, category="applied", q=Q_NEEDLE, page_size=EXPECTED_TOTAL
+    )
+    assert both.json()["category_counts"] == EXPECTED_Q_COUNTS
+    assert both.json()["total"] == EXPECTED_Q_COUNTS["applied"]
+    assert {m["message_id"] for m in both.json()["messages"]} == {"m-sender", "m-subject"}
+
+
+# =============================================================================
+# Ordering and paging
+# =============================================================================
+
+
+async def test_newest_first(cloud_app):
+    """``m-other`` is a day newer than everything else, so it leads.
+
+    Mutation: ``.asc()`` instead of ``.desc()`` on ``received_at`` → fails.
+    """
+
+    await _seed()
+    res = await _get(cloud_app, page_size=EXPECTED_TOTAL)
+    body = res.json()
+    assert body["messages"], "the listing returned nothing to assert over"
+    assert body["messages"][0]["message_id"] == "m-other"
+
+    stamps = [m["received_at"] for m in body["messages"]]
+    assert stamps == sorted(stamps, reverse=True), "the page is not newest-first"
+
+
+async def test_paging_returns_every_row_exactly_once(cloud_app):
+    """Walk every page over a corpus of tied timestamps and rebuild the set.
+
+    Proves the offset/limit arithmetic and the ``page``/``page_size`` echo.
+    It does NOT prove the ordering: SQLite returns tied rows in rowid order, so
+    it is stable here whether or not the tiebreak exists. That half is
+    :func:`test_the_listing_asks_the_database_for_a_total_order` — see the
+    module docstring of ``test_listing_order_is_deterministic.py`` for why the
+    split is necessary rather than belt-and-braces.
+    """
+
+    await _seed()
+
+    page_size = 5
+    collected: list[str] = []
+    page = 1
+    while True:
+        res = await _get(cloud_app, page=page, page_size=page_size)
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["total"] == EXPECTED_TOTAL
+        assert body["page"] == page
+        assert body["page_size"] == page_size
+        got = [m["message_id"] for m in body["messages"]]
+        if not got:
+            break
+        assert len(got) <= page_size
+        collected.extend(got)
+        if len(collected) >= body["total"]:
+            break
+        page += 1
+
+    assert len(collected) == EXPECTED_TOTAL, "paging dropped or duplicated rows"
+    assert len(set(collected)) == EXPECTED_TOTAL, "a row appeared on two pages"
+    assert set(collected) == {row[0] for row in OWNER_MAIL}
+
+    # Past the end: an empty page, not an error and not a wrapped-around one.
+    over = await _get(cloud_app, page=99, page_size=page_size)
+    assert over.status_code == 200
+    assert over.json()["messages"] == []
+    assert over.json()["total"] == EXPECTED_TOTAL
+
+
+async def test_the_same_page_twice_is_the_same_page(cloud_app):
+    """A second identical read must not reshuffle a page of tied timestamps."""
+
+    await _seed()
+    first = await _get(cloud_app, page=1, page_size=5)
+    second = await _get(cloud_app, page=1, page_size=5)
+    assert first.status_code == second.status_code == 200
+    assert [m["message_id"] for m in first.json()["messages"]] == [
+        m["message_id"] for m in second.json()["messages"]
+    ]
+
+
+async def test_the_listing_asks_the_database_for_a_total_order(cloud_app):
+    """The emitted SQL must order by ``received_at`` AND ``id``.
+
+    The assertion that catches the tiebreak being deleted. SQLite cannot show
+    the bug — it returns tied rows in rowid order — so this reads the statement
+    handed to the driver instead of the row order it happens to produce, which
+    is what Postgres would receive in production.
+
+    Mutation: deleting ``Email.id.desc()`` → fails here, and only here.
+    """
+
+    await _seed()
+
+    import jobtracker.database.connection as connection_module
+
+    engine = connection_module._engine
+    assert engine is not None, "the fixture should have built an engine"
+
+    statements: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _capture(conn, cursor, statement, parameters, context, executemany):  # noqa: ANN001
+        statements.append(statement)
+
+    try:
+        res = await _get(cloud_app, page=1, page_size=5)
+        assert res.status_code == 200, res.text
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    # The count and GROUP BY queries also read `emails` and carry no ORDER BY;
+    # this picks out the one that pages.
+    ordered = [
+        s for s in statements if "FROM emails" in s and "ORDER BY" in s.upper()
+    ]
+    assert ordered, f"no ordered SELECT against emails was issued: {statements}"
+
+    order_clause = re.split(r"ORDER BY", ordered[-1], flags=re.IGNORECASE)[1]
+    lowered = order_clause.lower()
+
+    assert "received_at" in lowered, f"received_at is not in the ORDER BY: {order_clause}"
+    assert re.search(r"\bid\b", lowered), (
+        "the mail listing no longer breaks ties on id — rows sharing a "
+        "received_at are free to reorder per request on Postgres, which drops "
+        f"and repeats them across pages. ORDER BY was: {order_clause}"
+    )
+    assert lowered.index("received_at") < lowered.rindex("id"), (
+        "id must come after received_at, otherwise it is the primary sort and "
+        f"the newest-first contract is broken. ORDER BY was: {order_clause}"
+    )
+
+
+async def test_page_size_is_bounded(cloud_app):
+    """``page_size`` is capped by the router's MAX_PAGE_SIZE, and it is a 422."""
+
+    await _seed()
+    import jobtracker.cloud.applications as cloud_apps_module
+
+    over = await _get(cloud_app, page_size=cloud_apps_module.MAX_PAGE_SIZE + 1)
+    assert over.status_code == 422
+    at_cap = await _get(cloud_app, page_size=cloud_apps_module.MAX_PAGE_SIZE)
+    assert at_cap.status_code == 200
+    assert at_cap.json()["page_size"] == cloud_apps_module.MAX_PAGE_SIZE
+
+
+async def test_the_listing_requires_a_token(cloud_app):
+    """No bearer token, no mail — the router-level dependency covers this route."""
+
+    async with AsyncClient(
+        transport=ASGITransport(app=cloud_app), base_url="http://test"
+    ) as client:
+        res = await client.get("/applications/mail")
+    assert res.status_code == 401
+
+
+async def test_mail_is_not_swallowed_by_the_application_id_route(cloud_app):
+    """``/applications/mail`` must not be parsed as ``/applications/{id}``.
+
+    FastAPI matches in declaration order. Declared below ``/{application_id}``
+    this returns 422 ("mail" is not an int) — the same trap ``/summary``,
+    ``/review`` and ``/statuses`` are each declared above it to avoid.
+    """
+
+    await _seed()
+    res = await _get(cloud_app)
+    assert res.status_code == 200, res.text
+    assert "messages" in res.json(), (
+        "the mail route was shadowed by /applications/{application_id}"
+    )


### PR DESCRIPTION
feat(web): redesign the signed-in surface — worklist dashboard, filed-mail review, settings rebuilt

The board answers the kanban question with a worklist: stage is a lens,
not geometry. A personal search's measured shape is 100% one stage (29
live rows, all applied), which a four-column kanban renders as one
starved strip and three boxes of nothing. The stage spine (filter, drop
target, per-stage meter) states the distribution in four lines; the
grouped rows are even by construction — a missing role prints 'role not
captured' in a fixed slot instead of shortening its card (8 of 29 real
rows have none).

The shell is viewport-locked (h-dvh, main as the one scroll pane); at
desktop the dashboard fits the screen and only the worklist scrolls.
Below lg the lock releases. A one-line notice zone under the SyncBar is
reserved for SinceLastLook (#113).

Filed-mail review lives at /inbox (default view): every stored message,
chips from category_counts, URL-driven search/pager, and a per-row
reclassify control that branches on needs_employer — verdicts stay
correctable after review/linkage, which the queue never allowed. The
live Gmail mine stays as /inbox?view=scan.

Settings: sticky section rail, one working line of copy per control,
Gmail safeguards + scale story folded into disclosures. The sections
run over a transport seam so /demo/settings renders them publicly on a
simulated account — their only executing e2e coverage, since /settings
needs a session CI cannot mint. /demo?pipeline=early renders the real
account's all-one-stage distribution for the same reason. Two 'last
synced' sentences drop font-mono (mono means machine value; the instant
stays in the time element's dateTime/title).

Verified: pnpm lint, typecheck and build green; production build served
and screenshotted at 1440/375 for /demo, /demo?pipeline=early and
/demo/settings. dashboard/demo/settings/production specs updated to the
new anatomy — not run here by design; route the suite to CI.

