### PR TITLE
ci: fix the overlapping pip entries and pin the transformers cap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,11 +32,42 @@ updates:
   # those — but a major bump can still pull a heavier transitive tree, so these
   # PRs want a human eye rather than an automerge.
   #
+  # `exclude-paths` is what keeps this entry pointed at the root manifest and
+  # nothing else. Without it, it also updated backend/: pip's file fetcher scans
+  # the configured `directory` for requirements files and then descends one
+  # level into every immediate subdirectory, so `directory: "/"` was reaching
+  # backend/requirements*.txt and duplicating the /backend entry below. It
+  # surfaced as two pull requests carrying byte-identical diffs for a single
+  # pin — #58 and #60 both raising transformers in backend/requirements.txt,
+  # #56 and #62 both raising setfit — while the file this entry exists to guard
+  # got no PRs at all and sat on a stale email-validator>=2.0.0 floor that #63
+  # was raising over in backend/. GitHub's own reference states the rule this
+  # broke: with more than one block per ecosystem and branch, "you must ensure
+  # that all values are unique and there is no overlap in directories defined."
+  #
+  # `backend/**` excludes the backend directory entry itself from the scan, so
+  # the descent into it never begins. Patterns are globs relative to this
+  # entry's `directory`; `directory` takes no wildcards of its own (only the
+  # plural `directories` does, and that would not have stopped the descent
+  # either — there is no directory-recursion switch to turn off).
+  #
+  # The list is live, not decorative. Because the descent is exactly one level,
+  # a requirements .txt landing directly in any other top-level directory
+  # (api/, scripts/, ...) would start being updated from here and would need
+  # adding above. That one-level limit is also why the ml/** manifests called
+  # out at the top of this file have never needed excluding — they sit three or
+  # more levels down, out of reach. And if duplicate PRs ever reappear, read
+  # the Dependabot run log before editing anything: exclude-paths filtering is
+  # gated server-side, and a key that is accepted but not honoured is silently
+  # a no-op rather than the loud config error an unknown key would be.
+  #
   # Monthly, not weekly: `schedule` governs Dependabot's VERSION updates only.
   # Security updates are a separate mechanism, unaffected by this interval, so
   # vulnerability patches still arrive immediately regardless of the cadence.
   - package-ecosystem: "pip"
     directory: "/"
+    exclude-paths:
+      - "backend/**"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -50,7 +81,16 @@ updates:
   # ---------------------------------------------------------------------------
   # One entry covers requirements.txt, requirements-dev.txt and
   # requirements-migrate.txt: Dependabot picks up every requirements file in the
-  # directory it is pointed at.
+  # directory it is pointed at — and, less obviously, in each of that
+  # directory's immediate subdirectories, which is the reach the root entry
+  # above has to exclude. All three files sit directly in backend/, so none of
+  # them depend on that descent.
+  #
+  # It also covers backend/pyproject.toml, whose [project] dependencies list is
+  # the source of truth for the packaged app. pyproject.toml is only ever read
+  # from an entry's own directory and never from a subdirectory, so this is the
+  # only entry that can see it — which is why the fix above is a narrowing of
+  # the root entry rather than a deletion of this one.
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,35 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+    # transformers is capped at <5 in backend/requirements.txt, and that cap is
+    # a guard on a published number — not an upgrade nobody got round to.
+    # Dependabot filed the bump anyway (#60, >=4.40,<5 to >=5.14.1,<6) and would
+    # refile it every month forever, so the major is ignored here.
+    #
+    # Nothing in the metadata enforces the cap: setfit 1.1.3 declares
+    # transformers>=4.41.0 with no upper bound and sentence-transformers 5.2.2
+    # allows <6.0.0, so a resolver installs 5.x happily. 5.x then breaks setfit:
+    #     ImportError: cannot import name 'default_logdir'
+    #                  from 'transformers.training_args'
+    # tested 2026-08-02. And it breaks it SILENTLY — HybridClassifier catches
+    # that ImportError and degrades to the rules layer, so the API keeps
+    # answering and the benchmark keeps printing 0.9791, the RULES figure, under
+    # the cascade's name. That number is published on the System Card, the
+    # portfolio and a résumé. backend/tests/test_evaluate_classifier_layer_guard.py
+    # records the degradation as observed, not hypothesised. Lifting this needs
+    # a setfit release that supports transformers 5 AND a decision to re-measure
+    # and republish the number — not a green CI run.
+    #
+    # Scoped to the major deliberately: 4.x patch and minor updates must keep
+    # flowing, because the cap holds open PYSEC-2026-2288/2289/2290 and
+    # PYSEC-2025-217, which backend/requirements.txt records as accepted cost
+    # rather than hiding. Note that an ignore condition applies to Dependabot's
+    # security-update PRs as well as its version updates, so a security bump to
+    # 5.x is withheld too — the same trade already written down over there, made
+    # mechanical here so it survives the next monthly run.
+    ignore:
+      - dependency-name: "transformers"
+        update-types: ["version-update:semver-major"]
     groups:
       pip-backend:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,10 +118,13 @@ updates:
     # Scoped to the major deliberately: 4.x patch and minor updates must keep
     # flowing, because the cap holds open PYSEC-2026-2288/2289/2290 and
     # PYSEC-2025-217, which backend/requirements.txt records as accepted cost
-    # rather than hiding. Note that an ignore condition applies to Dependabot's
-    # security-update PRs as well as its version updates, so a security bump to
-    # 5.x is withheld too — the same trade already written down over there, made
-    # mechanical here so it survives the next monthly run.
+    # rather than hiding. What this rule is known to stop is the monthly
+    # VERSION-update PR that #60 was. Whether an ignore written here also
+    # withholds a Dependabot SECURITY update for those advisories is not
+    # something the docs state unambiguously for the dependabot.yml form of
+    # ignore — only for the @dependabot ignore comment command — so it is not
+    # claimed. Those four are accepted cost over there either way, and this
+    # file configures update pull requests, not the alerts themselves.
     ignore:
       - dependency-name: "transformers"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Two changes to `.github/dependabot.yml`, one file, nothing else touched.

---

# 1. The root pip entry was updating `backend/`, not the root manifest

`.github/dependabot.yml` declares two pip entries. The `directory: "/"` one exists to guard the **root `requirements.txt`** — the Vercel cloud-function manifest, hand-tuned against a 50 MB zipped function budget and carrying an explicit DO-NOT-ADD list (torch, sentence-transformers, setfit, transformers, scikit-learn, keyring, aiosqlite, websockets). The `directory: "/backend"` one covers the full local backend.

The `"/"` entry was not guarding the root manifest. It was updating `backend/`, duplicating the `/backend` entry, while the root manifest got no PRs at all.

| dep | from the `"/"` entry | from the `/backend` entry | both edit |
|---|---|---|---|
| transformers | #58 (closed) | #60 | `backend/requirements.txt` — byte-identical diffs |
| setfit | #56 (closed) | #62 | `backend/requirements.txt` (#62 also `backend/pyproject.toml`) |

#57 (ruff), #59 (pytest-asyncio) and #40 (mypy) likewise came from the `"/"` entry yet edit `backend/requirements-dev.txt`.

And the root manifest is not silent because it is current. #63 has since merged, so the asymmetry is now visible in `main` itself: `backend/requirements.txt:14` reads `email-validator>=2.3.0`, `requirements.txt:25` still reads `email-validator>=2.0.0`. Same dependency, same stale floor, a PR filed against one file and not the other.

`git log -p --follow .github/dependabot.yml` shows only two commits (`d2ac5b0`, `c4a3bd4`) and **zero** changes to any `directory:` value, and both PR batches postdate the config — so this is live behaviour, not a stale path.

## Cause

pip's file fetcher scans the configured `directory` for `*.txt`/`*.in` requirements files **and then descends one level into every immediate subdirectory**. In `dependabot-core`, `python/lib/dependabot/python/shared_file_fetcher.rb`:

```ruby
repo_contents
  .select { |f| f.type == "dir" }
  .each { |f| files.concat(req_files_for_dir(f)) }
```

With `backend/` one level below the repo root, the `"/"` entry is a strict superset of the `/backend` entry for requirements files. GitHub's options reference names the rule this breaks: if you use more than one block for a single ecosystem and target branch, *"you must ensure that all values are unique and there is no overlap in directories defined."*

## Fix

`exclude-paths: ["backend/**"]` on the root entry. That drops the `backend` directory entry from the scan, so the descent into it never begins.

This is the only supported instrument for the job, per the current docs:

- `directory` (singular) takes no wildcards.
- `directories` (plural) adds globbing and `*`, but globbing *into* more directories is the opposite of what is needed — there is no switch that turns the one-level descent off.
- `exclude-paths` is documented as *"paths of directories and files that Dependabot should ignore when scanning for manifests and dependencies"*, supports `**` for recursive matching, and its patterns are relative to that entry's `directory`. Each `package-ecosystem` entry has its own list, so this narrows the root entry without touching the backend one.

The `/backend` entry still covers all three requirements files plus `backend/pyproject.toml` — `pyproject.toml` is only ever read from an entry's own directory and never from a subdirectory, which is why the fix narrows the root entry rather than deleting the backend one.

---

# 2. `transformers` majors are now ignored on the `/backend` entry

#60 (`transformers >=4.40,<5` → `>=5.14.1,<6`) was closed with prejudice. Without an ignore rule the monthly run regenerates it forever.

The `<5` cap is a guard on a published number, not a deferred upgrade — `backend/requirements.txt:45-61` already documents it, and every claim below is quoted from there:

- Nothing in the metadata enforces the cap. setfit 1.1.3 declares `transformers>=4.41.0` with no upper bound; sentence-transformers 5.2.2 allows `<6.0.0`. A resolver will install 5.x.
- Tested 2026-08-02, 5.x breaks setfit: `ImportError: cannot import name 'default_logdir' from 'transformers.training_args'`.
- The failure is **silent**. `HybridClassifier` catches that ImportError and degrades to the rules layer, so the API keeps answering and the benchmark keeps printing `0.9791` — the RULES figure — under the cascade's name. `backend/tests/test_evaluate_classifier_layer_guard.py` records this as observed, not hypothesised.
- `0.9791` is published on the System Card, the portfolio and a résumé.

So lifting this needs a setfit release supporting transformers 5 **and** a decision to re-measure and republish the number — not a green CI run. The comment in the file says exactly that, so the next person does not have to reconstruct it.

**Scoped to the major only**, via `update-types: ["version-update:semver-major"]` rather than a `versions` range:

```yaml
ignore:
  - dependency-name: "transformers"
    update-types: ["version-update:semver-major"]
```

4.x patch and minor updates keep flowing, which matters because the cap holds open `PYSEC-2026-2288` / `-2289` / `-2290` and `PYSEC-2025-217` — recorded in `backend/requirements.txt` as accepted cost rather than hidden. A `versions` range would have been a broader gag than intended.

Syntax taken from the current options reference (`ignore` accepts `dependency-name`, `versions`, `update-types`; the supported `update-types` values are `version-update:semver-patch`, `-minor`, `-major`), not from memory.

---

# Verified

- **GitHub's own validator accepts it.** Pushing this branch triggered the Dependabot app's `.github/dependabot.yml` check — *"Dependabot config file validation — All changes look good"*, conclusion `success`. That is the authoritative check on key legality, and it means neither `exclude-paths` nor the `ignore` block is rejected as an unknown key. (Caveat: I did not negative-control *that* validator — doing so would mean pushing a deliberately broken config. The SchemaStore run below was negative-controlled instead.)
- **Parses.** PyYAML `safe_load`: 4 update blocks; `exclude-paths` on the root pip entry only; `ignore` on the `/backend` entry only.
- **Schema legal.** Validated against SchemaStore `dependabot-2.0.json` — 0 errors.
- **The schema check was negative-controlled**, because a schema that ignores unknown keys would pass anything. Rejected as expected: misspelled `exclude-pathz`, unknown `banana` key, bogus `interval`, `exclude-paths` as a string, a block with no `directory`, `version: 1`, misspelled `update-typez`, a bogus semver level, `ignore` as a mapping instead of a list, and a wrong `dep-name` key. The pass is therefore meaningful, not vacuous.
- **Semantics asserted from the parsed document**, not eyeballed: the ignore blocks major (`True`) and not minor or patch (`False`, `False`), carries no `versions` key, and sits on the `/backend` entry alone — the root entry has none, since `transformers` is not pinned there.
- **Comments intact.** All ten pre-existing anchors still present (the `labels:` note, the `ml/demo/space` + `ml/wandb` + `apps/macos` omissions, the codeql-action lockstep note, `pnpm.overrides`, the Scorecard note), against a negative control that correctly returns 0.
- **No repo-side linting exists for this file** — verified, not assumed: no workflow under `.github/workflows/` references `dependabot.yml`, `yamllint`, `actionlint`, `action-validator`, `check-jsonschema` or `ajv` (positive-controlled against a search that does match). Nor is any such CLI installed locally.
- Rebased onto current `main`.

# Not verified here — needs the Dependabot tab

That GitHub *acts on* `exclude-paths`, as opposed to merely accepting it. The config-error failure mode is now ruled out by the check above; the remaining one is a **silent no-op**. In `dependabot-core` the `exclude-paths` filtering (`FileFiltering.should_exclude_path?`, `FileFetchers::Base#filter_excluded`) sits behind the `enable_exclude_paths_subdirectory_manifest_files` experiment, which is server-side and not inspectable from here. The docs carry no preview or beta marker and the validator accepts the key, so it should be on — but an unhonoured key would be a no-op, not an error, and that is precisely the outcome worth guarding against.

**After merge:** trigger a manual run on the root pip entry from the Dependabot tab and read the job log. `filter_excluded` logs `DEBUG filter_excluded: entries=<n>, exclude_paths=["backend/**"]` followed by a reduced entry count. That line present with the pattern means it took; the line absent, or `exclude_paths=[]`, means the flag is off. The `ignore` rule shows up as the absence of a transformers PR on the `/backend` run.

If the flag turns out to be off, an **untested** flag-independent fallback would be a single pip entry with `directories: ["/", "/backend"]` and `groups.<name>.group-by: dependency-name` — neither I nor the docs confirm how one block handles overlapping directories, so it would need trying. It is not proposed here regardless, because it collapses the separate review posture this config deliberately wants for the size-budgeted Vercel manifest.
