### PR TITLE
chore(backend): cap transformers in pyproject, move ruff config under [lint]

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,13 @@ dependencies = [
     "aioimaplib>=2.0.0",
     "keyring>=25.7.0",
     "sentence-transformers>=2.2.0",
+    # The <5 cap is load-bearing: under transformers 5.x setfit fails to import and
+    # HybridClassifier silently degrades to the rules layer, so the benchmark keeps
+    # printing the rules score under the cascade's name. Full rationale, including
+    # the CVEs the cap holds open, is in requirements.txt next to the same pin --
+    # not duplicated here. Editable installs resolve from this file, so it must
+    # carry the cap too.
+    "transformers>=4.40,<5",
     "setfit>=1.0.0",
     "scikit-learn>=1.3.0",
     "numpy>=1.24.0",
@@ -72,9 +79,17 @@ Issues = "https://github.com/yadava5/applied/issues"
 # Tool Configuration
 # ============================================================================
 
+# Lint settings live under [tool.ruff.lint]. They used to sit at the top level,
+# which ruff still accepts but warns about ("The top-level linter settings are
+# deprecated in favour of their counterparts in the `lint` section"). Since the CI
+# ruff step is continue-on-error, the day ruff drops the legacy keys the step would
+# go quiet without going red -- moved ahead of the ruff floor bump for that reason.
+# Relocation only: same families, same ignores, same per-file ignores.
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
@@ -92,10 +107,10 @@ ignore = [
     "B904",   # raise without from inside except
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["jobtracker"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ARG"]
 
 [tool.mypy]


### PR DESCRIPTION
Two metadata truth-ups in `backend/pyproject.toml`. Both are about protection that everyone believes is in place and partly isn't. No behaviour change to the app, no lint findings fixed.

---

## 1. The transformers side door

`backend/requirements.txt:45-62` caps `transformers>=4.40,<5` and documents the reason at length: under transformers 5.x, setfit fails to import, `HybridClassifier` catches the `ImportError` and degrades to the rules layer, and the benchmark then keeps printing the **rules** macro-F1 under the cascade's name. That figure is published on the System Card, the portfolio and a résumé. `backend/tests/test_evaluate_classifier_layer_guard.py` records the failure as observed, not hypothesised.

`backend/pyproject.toml` carried **no transformers constraint at all** — only `sentence-transformers>=2.2.0`. setfit's own metadata permits 5.x. So the cap only ever covered requirements-file installs; `pip install -e backend` resolved the broken combination.

Confirmed on this tree rather than taken on trust:

| | resolved `transformers` |
|---|---|
| `uv pip compile backend/pyproject.toml` — before | **5.15.0** |
| `uv pip compile backend/pyproject.toml` — after | **4.57.6** |

And in a throwaway venv holding exactly that "before" resolution (`setfit==1.1.3` + `transformers==5.15.0`), `import setfit` reproduces the documented failure verbatim:

```
ImportError: cannot import name 'default_logdir' from 'transformers.training_args'
```

So the side door was open today, and at a transformers *newer* than the 5.14.1 recorded in the note — the failure did not go away upstream.

The comment added here points at `requirements.txt` instead of duplicating the rationale, so the CVE accounting (PYSEC-2026-2288 / -2289 / -2290, PYSEC-2025-217) stays in one place.

Checked and **not** a second door: the repo-root `requirements.txt` — the Vercel deploy surface — deliberately excludes torch / transformers / setfit entirely, and says so.

## 2. Ruff config migrated off the deprecated layout

`select`, `ignore`, `[tool.ruff.isort]` and `[tool.ruff.per-file-ignores]` moved under `[tool.ruff.lint]`. `target-version` and `line-length` stay at the top level — they are not lint settings.

Why this lands *before* the ruff floor bump (#57, `>=0.1.0` → `>=0.16.1`): ruff 0.16.2 still honours the legacy keys, but only with a warning on **stderr** —

```
warning: The top-level linter settings are deprecated in favour of their counterparts
in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
```

The CI ruff step is `continue-on-error: true`. The day ruff drops those keys, the lint signal collapses to the E/F defaults — or the step errors outright — and CI stays **green** either way. That is this repo's signature defect, a check that cannot fail.

### Proof the signal is alive, not just the count

Same ruff binary (0.16.2 — what the bump targets), run from `backend/` as CI does:

| | findings | stderr |
|---|---|---|
| before (legacy layout) | **409** | deprecation warning |
| after (migrated) | **409** | clean |

`diff` of the full findings list, of `--statistics`, and of the entire `--show-settings` dump: **all three byte-identical**. This is a relocation, verified as one.

Family breakdown after migration — the configured families all still fire, which is what rules out a config that is being silently ignored:

| family | count | | family | count |
|---|---|---|---|---|
| UP (pyupgrade) | 314 | | W | 6 |
| I (isort) | 31 | | B (bugbear) | 5 |
| F (pyflakes) | 27 | | C4 (comprehensions) | 3 |
| SIM (simplify) | 12 | | E | 1 |
| ARG (unused-args) | 10 | | **total** | **409** |

Had the config been dropped you would see E/F only; instead I, B, C4, UP, ARG and SIM are all represented. `per-file-ignores` is still applied too: **0** ARG findings under `tests/`, **10** elsewhere.

On 409 vs the **379** recorded on 2026-08-07: that is not a regression and not a finding. It was measured on a different tree with a then-current ruff, and new rules land inside existing families across ruff releases. The discriminator here is before-equals-after with one binary, which holds exactly.

### mypy

Config unchanged; checked for the same masking risk. mypy 2.3.0, `strict = true`, from `backend/`:

- **1184 errors in 78 files (checked 107 source files)** — per-file listings, no plugin import error, no traceback, empty stderr.
- `Cannot find implementation or library stub for ... pydantic` does **not** appear.
- The pydantic plugin was confirmed **positively**, not by absence of an error: two config files identical except for the `plugins` line, run on the same probe file, give different results. Without the plugin, mypy's native `dataclass_transform` support flags `Probe(count="not an int")` as `[arg-type]`; with `plugins = ["pydantic.mypy"]` the plugin's synthesised `__init__` (default `init_typed = false`) accepts it. The plugin is loading and changing analysis.

107 checked vs CI's 92 on 2026-08-07 is tree growth — `find backend -name '*.py'` returns 107.

### Policy

Per `.github/workflows/backend-ci.yml:63-85`: no findings fixed, no `--fix`, no per-rule ignores added, nothing loosened. The dev-tool floors in `[project.optional-dependencies]` are untouched — the ruff floor bump is #57's job.

---

## Verification

- ruff 0.16.2 before/after as above; three byte-identical diffs.
- mypy 2.3.0 as above, plugin confirmed by differential.
- `pytest --collect-only -q` → **565 tests collected**, matching the baseline.
- `tests/test_evaluate_classifier_layer_guard.py` → **10 passed**.
- `pyproject.toml` parses under `tomllib`; `[tool.pytest.ini_options]`, `[tool.mypy]` and the migrated `[tool.ruff.lint]` tables all read back with their values intact.

**Not run here:** the full 565-test backend suite (CI covers it; `test_rls_postgres.py` also wants a live Docker daemon).

Environment: Python 3.11.14, matching CI, in a throwaway venv from `backend/requirements-dev.txt`.
