### PR TITLE
ci(vercel): stop deploying commits neither project can build from

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -215,15 +215,66 @@ skips, `exit 1` builds). **The reasoning lives in the header of
 lists are an allowlist: a new build input that is not added there will never
 deploy.
 
-Dependabot branches are still skipped by branch-name prefix, exactly as before.
 A branch's first preview always builds, so the e2e browser pass always has a
 preview URL.
 
-Two things this does **not** do. It does not lower the Hobby plan's
-100-deployments-per-day count: Vercel's docs are explicit that "canceled builds
-are counted as full deployments … and will still count towards your deployment
-quotas and concurrent build slots." What it saves is build minutes and the
-single Hobby concurrent-build slot (seconds instead of a full Next.js build),
-and it stops no-op commits from replacing a good production deployment. And it
-does not replace `git.deploymentEnabled`, which is the only repo-side setting
-that stops a deployment from being *created* at all.
+### The ignore step does not save quota — read this before "optimising" it
+
+An Ignored Build Step skip still costs a deployment. This is the opposite of
+the intuitive reading, so here it is verbatim, from
+<https://vercel.com/docs/project-configuration/project-settings#ignored-build-step>:
+
+> Canceled builds are counted as full deployments as they execute a build
+> command in the build step. This means that any canceled builds initiated
+> using the ignore build step will still count towards your deployment quotas
+> and concurrent build slots.
+
+The Hobby cap is 100 deployments per day, and this repo has hit it. What a skip
+buys is build minutes, the single Hobby concurrent-build slot released in well
+under a second instead of a full Next.js build, and a production deployment
+that no-op commits stop replacing. Worth having — but it is not the cap.
+
+### `git.deploymentEnabled` is the part that saves quota
+
+Both `vercel.json` files also carry:
+
+```json
+"git": { "deploymentEnabled": { "dependabot/**": false, "dependabot/*": false } }
+```
+
+Vercel never *triggers* a deployment for these branches, so nothing is created
+and nothing is counted. Dependabot previews were already being thrown away by
+the ignore step; this stops paying a deployment for the privilege. Dependabot
+branches never need a preview URL — the Claude-in-Chrome e2e pass only ever
+runs against real feature work.
+
+**The `**` is load-bearing.** These patterns are
+[minimatch](https://github.com/isaacs/minimatch), where `*` does not cross a
+`/`. Real branch names here look like
+`dependabot/pip/backend/beautifulsoup4-gte-4.15.0` — three slashes — so a
+lone `dependabot/*` would have matched *nothing* and silently done nothing.
+`dependabot/*` is kept alongside `dependabot/**` only as insurance against a
+matcher that treats `*` as crossing `/`; where rules conflict Vercel takes the
+permissive one, and both of these are `false`, so they cannot fight.
+
+`main` has no branch protection and no rulesets, so no Vercel status is a
+required check and a missing or skipped one cannot block a merge. Vercel's
+documented commit statuses are terminal in any case — a commit status reports
+that it "successfully deployed or failed, or skipped its Vercel deployment" —
+so there is no pending-forever state to get stuck on.
+
+### The dashboard "Skip deployments when there are no changes…" toggle is inert here
+
+Do not bother enabling it. Vercel's built-in
+[skipping of unaffected projects](https://vercel.com/docs/monorepos#skipping-unaffected-projects)
+requires npm/yarn/pnpm/Bun **workspaces**, "detected using the lockfile at the
+repository root". This repo has no root `package.json`, no root lockfile and no
+`pnpm-workspace.yaml` — the lockfile is `apps/web/pnpm-lock.yaml`. The
+documented fallback is that everything counts as a global change and "deploy
+all applications in the repository", followed by: "If your project does not
+meet these requirements, you can use the Ignored Build Step." That is exactly
+what the guard above is.
+
+If a root workspace definition is ever added, the toggle becomes the *better*
+lever and should replace the guard: unlike the Ignored Build Step it "does not
+occupy concurrent build slots".

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -194,3 +194,36 @@ routers not yet mounted in `main_cloud` — the full-model classifier story is
 carried by the ML demo (`ml/demo`, Hugging Face Spaces) and the web `/demo`
 fixture. Until an owner completes Path C's Google setup, the deployed
 `/settings` page honestly reports Gmail as "not enabled on this deployment."
+
+## Which commits deploy
+
+Both Vercel projects build from this one repo, so every commit used to trigger
+two deployments — including workflow bumps and backend dependency updates that
+can change neither bundle. `vercel-ignore-build.sh` is now the Ignored Build
+Step for both, wired up through `ignoreCommand`:
+
+| Project          | Root Directory | Config                | Builds when these change                                             |
+| ---------------- | -------------- | --------------------- | -------------------------------------------------------------------- |
+| `jobtracker-api` | repo root      | `vercel.json`         | `api/`, `requirements.txt`, `backend/jobtracker/`, `vercel.json`, `.vercelignore` |
+| `jobtracker-web` | `apps/web`     | `apps/web/vercel.json`| `apps/web/`, `.vercelignore`                                          |
+
+`ignoreCommand` in `vercel.json` overrides whatever the dashboard's Ignored
+Build Step says, so the guard is version-controlled rather than a dashboard
+field — but JSON has no comments, and the exit codes are inverted (`exit 0`
+skips, `exit 1` builds). **The reasoning lives in the header of
+`vercel-ignore-build.sh`; read it before touching either config.** The path
+lists are an allowlist: a new build input that is not added there will never
+deploy.
+
+Dependabot branches are still skipped by branch-name prefix, exactly as before.
+A branch's first preview always builds, so the e2e browser pass always has a
+preview URL.
+
+Two things this does **not** do. It does not lower the Hobby plan's
+100-deployments-per-day count: Vercel's docs are explicit that "canceled builds
+are counted as full deployments … and will still count towards your deployment
+quotas and concurrent build slots." What it saves is build minutes and the
+single Hobby concurrent-build slot (seconds instead of a full Next.js build),
+and it stops no-op commits from replacing a good production deployment. And it
+does not replace `git.deploymentEnabled`, which is the only repo-side setting
+that stops a deployment from being *created* at all.

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "bash ../../vercel-ignore-build.sh web"
+  "ignoreCommand": "bash ../../vercel-ignore-build.sh web",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/**": false,
+      "dependabot/*": false
+    }
+  }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ../../vercel-ignore-build.sh web"
+}

--- a/vercel-ignore-build.sh
+++ b/vercel-ignore-build.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" guard — path-filtered builds.
+#
+# Two Vercel projects build from this one repository:
+#
+#   jobtracker-web  Root Directory apps/web        -> apps/web/vercel.json
+#   jobtracker-api  Root Directory <repo root>     -> ./vercel.json
+#
+# so *every* commit triggers *two* deployments. Most of that is waste. Four
+# production builds of the web app in a single hour came from commits that
+# cannot change the web bundle at all (three GitHub Actions version bumps and
+# a Python dependency the cloud function never installs). This script answers
+# one question per project: did this commit touch anything the project
+# actually builds from?
+#
+# ---------------------------------------------------------------------------
+# EXIT CODES ARE INVERTED. READ THIS BEFORE EDITING.
+# ---------------------------------------------------------------------------
+#
+#     exit 0  ->  SKIP the build (the deployment is marked CANCELED)
+#     exit 1  ->  BUILD as normal
+#
+# Vercel's docs, verbatim: "If the command exits with code 1, the build
+# continues as normal. If the command exits with code 0, the build is
+# immediately aborted, and the deployment state is set to CANCELED." Any code
+# >= 1 builds, so a crash in this script — 127 for a missing file, 128 for a
+# git error — lands on BUILD, not on SKIP. That is deliberate, see below.
+#
+# ---------------------------------------------------------------------------
+# THIS SCRIPT MUST FAIL OPEN.
+# ---------------------------------------------------------------------------
+#
+# A wrong SKIP silently stops deploying real changes: the site keeps serving
+# the previous build and nothing anywhere reports an error. A wrong BUILD
+# costs one wasted deployment. The two are not symmetric, so every uncertain
+# path here — no git checkout, unreadable history, an unknown project name, a
+# base commit we cannot resolve — exits 1 and builds.
+#
+# The shallow-clone case is the one that actually bites. Vercel clones with
+# `git clone --depth=10`, so on a young or freshly-created branch `HEAD^` can
+# be absent, and `VERCEL_GIT_PREVIOUS_SHA` (the last *successful* deployment
+# for this project and branch) can point outside those ten commits. Both are
+# checked with `git cat-file -e` before use; if neither yields a base commit
+# we cannot compute a diff, so we build.
+#
+# ---------------------------------------------------------------------------
+# WHY THE BASE IS NOT JUST `HEAD^`.
+# ---------------------------------------------------------------------------
+#
+# `git diff HEAD^ HEAD` only sees the newest commit. Push two commits to main
+# at once — N-1 touching apps/web, N touching only .github — and a HEAD^-only
+# guard skips the build and the web change never ships. VERCEL_GIT_PREVIOUS_SHA
+# is the last thing this project actually deployed on this branch, so diffing
+# against it covers everything that has accumulated since. `HEAD^` is only the
+# production fallback for when Vercel does not supply it.
+#
+# On previews there is deliberately no `HEAD^` fallback: with no previous
+# deployment the branch has no preview URL yet, and the e2e pass needs one. A
+# branch's first build always happens.
+#
+# ---------------------------------------------------------------------------
+# MAINTENANCE: THE PATH LISTS ARE AN ALLOWLIST.
+# ---------------------------------------------------------------------------
+#
+# A commit that touches nothing in a project's list is skipped for that
+# project. A NEW BUILD INPUT THAT IS NOT ADDED HERE WILL NEVER DEPLOY. If you
+# add a directory that either deployment reads from, add it below in the same
+# commit.
+#
+set -u
+
+readonly SKIP=0
+readonly BUILD=1
+
+log() { printf '[vercel-ignore-build] %s\n' "$*" >&2; }
+
+# Run from the repository root so every pathspec below is root-relative and
+# reads the same for both projects, whatever Root Directory Vercel started us
+# in (the ignore command runs inside the project's Root Directory).
+cd "$(dirname "$0")" 2>/dev/null || { log 'cannot cd to script dir; building'; exit "$BUILD"; }
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -z "$repo_root" ]; then
+  log 'no git checkout here; building'
+  exit "$BUILD"
+fi
+cd "$repo_root" || exit "$BUILD"
+
+project="${1:-}"
+
+# Preserved from the previous dashboard command, which was
+#   if [ "${VERCEL_GIT_COMMIT_REF#dependabot/}" != "$VERCEL_GIT_COMMIT_REF" ]; ...
+# i.e. a plain prefix match on the branch name. Dependabot branches are
+# lockfile churn; their previews are not worth a deployment. This does nothing
+# once the PR is merged, because the merge lands on main — which is the gap the
+# path filtering below closes.
+case "${VERCEL_GIT_COMMIT_REF:-}" in
+  dependabot/*)
+    log "branch ${VERCEL_GIT_COMMIT_REF} is a Dependabot branch; skipping"
+    exit "$SKIP"
+    ;;
+esac
+
+case "$project" in
+  api)
+    # The Python cloud function. api/index.py is the entrypoint, the ROOT
+    # requirements.txt is what Vercel pip-installs (backend/requirements.txt is
+    # deliberately a different, much heavier file and is not used here), and
+    # vercel.json's `includeFiles` ships backend/jobtracker/**. vercel.json
+    # itself carries the function config, headers and CSP; .vercelignore is
+    # read from the repo root for every project in this repo and decides what
+    # survives into the build.
+    paths=(api requirements.txt backend/jobtracker vercel.json .vercelignore)
+    ;;
+  web)
+    # The Next.js app. apps/web is self-contained: its own package.json and
+    # pnpm-lock.yaml, no workspace: deps, no transpilePackages, no
+    # outputFileTracingRoot. The root vercel.json is NOT an input — Vercel
+    # reads configuration from the Root Directory, so this project reads
+    # apps/web/vercel.json. The root .vercelignore IS an input: it once
+    # excluded apps/web and every web build failed with NEXT_NO_VERSION.
+    paths=(apps/web .vercelignore)
+    ;;
+  *)
+    log "unknown project '${project}'; building"
+    exit "$BUILD"
+    ;;
+esac
+
+# VERCEL_GIT_COMMIT_SHA is the commit being deployed, so it equals HEAD in a
+# real build. Reading it through a variable is what makes this script testable
+# against historical commits without a deployment.
+head_sha="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+if ! git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+  log "head ${head_sha} is not in this clone; building"
+  exit "$BUILD"
+fi
+
+base_sha="${VERCEL_GIT_PREVIOUS_SHA:-}"
+if [ -n "$base_sha" ] && ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+  log "VERCEL_GIT_PREVIOUS_SHA ${base_sha} is outside the shallow clone; falling back"
+  base_sha=''
+fi
+if [ -z "$base_sha" ] && [ "${VERCEL_ENV:-}" = 'production' ]; then
+  base_sha="$(git rev-parse --verify -q "${head_sha}^" 2>/dev/null || true)"
+fi
+if [ -z "$base_sha" ]; then
+  log 'no usable base commit; building'
+  exit "$BUILD"
+fi
+
+# `git diff --quiet` exits 0 for "no difference" and 1 for "differences", which
+# is the inversion Vercel wants already. Anything else (128 and friends) is an
+# error and falls through to BUILD.
+if git diff --quiet "$base_sha" "$head_sha" -- "${paths[@]}"; then
+  log "${project}: no changes in ${paths[*]} between ${base_sha} and ${head_sha}; skipping"
+  exit "$SKIP"
+fi
+
+log "${project}: changes found in ${paths[*]}; building"
+exit "$BUILD"

--- a/vercel-ignore-build.sh
+++ b/vercel-ignore-build.sh
@@ -14,6 +14,22 @@
 # one question per project: did this commit touch anything the project
 # actually builds from?
 #
+# What it does NOT do is lower the Hobby plan's 100-deployments-per-day cap.
+# Vercel's docs are explicit, and this is the opposite of the intuitive
+# reading, so it is written down here rather than re-derived later:
+#
+#   "Canceled builds are counted as full deployments as they execute a build
+#    command in the build step. This means that any canceled builds initiated
+#    using the ignore build step will still count towards your deployment
+#    quotas and concurrent build slots."
+#   -- https://vercel.com/docs/project-configuration/project-settings#ignored-build-step
+#
+# What a skip here buys is build minutes, the single Hobby concurrent-build
+# slot released in well under a second instead of a full Next.js build, and a
+# production deployment that no-op commits stop replacing. Cutting the
+# *number* of deployments needs `git.deploymentEnabled`, which lives in both
+# vercel.json files and stops one being created at all.
+#
 # ---------------------------------------------------------------------------
 # EXIT CODES ARE INVERTED. READ THIS BEFORE EDITING.
 # ---------------------------------------------------------------------------
@@ -91,9 +107,16 @@ project="${1:-}"
 # Preserved from the previous dashboard command, which was
 #   if [ "${VERCEL_GIT_COMMIT_REF#dependabot/}" != "$VERCEL_GIT_COMMIT_REF" ]; ...
 # i.e. a plain prefix match on the branch name. Dependabot branches are
-# lockfile churn; their previews are not worth a deployment. This does nothing
-# once the PR is merged, because the merge lands on main — which is the gap the
-# path filtering below closes.
+# dependency churn; their previews are not worth a deployment. This does
+# nothing once the PR is merged, because the merge lands on main — which is the
+# gap the path filtering below closes.
+#
+# This is now a BACKSTOP, not the primary mechanism. `git.deploymentEnabled`
+# in both vercel.json files stops Dependabot deployments from being *created*
+# at all, which is the only thing that actually saves quota — reaching this
+# branch of the script means a deployment was created anyway, so skip it.
+# Note the prefix match here is on the whole ref and is not glob-based, so
+# unlike the minimatch patterns in vercel.json it needs no `**`.
 case "${VERCEL_GIT_COMMIT_REF:-}" in
   dependabot/*)
     log "branch ${VERCEL_GIT_COMMIT_REF} is a Dependabot branch; skipping"

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "ignoreCommand": "bash vercel-ignore-build.sh api",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/**": false,
+      "dependabot/*": false
+    }
+  },
   "functions": {
     "api/index.py": {
       "maxDuration": 60,

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
+  "ignoreCommand": "bash vercel-ignore-build.sh api",
   "functions": {
     "api/index.py": {
       "maxDuration": 60,


### PR DESCRIPTION
Both Vercel projects build from this one repo, so **every commit deployed both**. Most of it is waste — in a single hour, four *production* builds of the web app came from three GitHub Actions version bumps and one Python backend dependency, none of which can change the web bundle.

The existing Ignored Build Step only skipped branches literally named `dependabot/*`. That does nothing after merge, because a merged PR lands on `main`. This closes that gap with path filtering.

Two mechanisms, because they solve different halves of the problem. Two commits, correspondingly — the first commit's message reports 29 verification cases against what is now 38 and omits the `dc1711e` row; the second commit states the correction, because amending needs a force push that this environment denies.

## 1. `git.deploymentEnabled` — the half that saves quota

```json
"git": { "deploymentEnabled": { "dependabot/**": false, "dependabot/*": false } }
```

In **both** `vercel.json` files, since each project reads config from its own Root Directory. Vercel never *triggers* a deployment for a disabled branch — *"Specify branches that should not trigger a deployment upon commits"* — so nothing is created and nothing is counted. Dependabot previews were already being thrown away by the ignore step; this stops paying a deployment for the privilege. They never need a preview URL, because the Claude-in-Chrome e2e pass only ever runs against real feature work.

**The `**` is load-bearing.** These are [minimatch](https://github.com/isaacs/minimatch) patterns, where `*` does not cross a `/` (`noglobstar` is documented as "Disable `**` matching against multiple folder names", which only makes sense because plain `*` never does). Real branch names in this repo, from PR history:

```
dependabot/pip/backend/beautifulsoup4-gte-4.15.0
dependabot/pip/requests-gte-2.34.2
```

Two and three slashes. **A lone `dependabot/*` would have matched nothing and silently done nothing** — the exact defect shape this repo keeps producing. `dependabot/*` is kept alongside `dependabot/**` purely as insurance against a matcher that treats `*` as crossing `/`; where rules conflict Vercel takes the permissive one, and both of these are `false`, so they cannot fight.

**Merging is not affected.** `main` has no branch protection (`404 Branch not protected`) and no rulesets (`[]`), so no Vercel status is a required check — a missing or skipped one cannot block a merge. Vercel's documented commit statuses are terminal in any case: a status reports that the commit *"successfully deployed or failed, or skipped its Vercel deployment"*. There is no pending-forever state. What I could **not** determine from the docs is whether `deploymentEnabled: false` posts a "skipped" status or no status at all; given the above, either is harmless here.

## 2. The path-filtered guard — the half that saves build time

`vercel-ignore-build.sh` (repo root) answers one question per project: did this commit touch anything the project actually builds from? It is wired up through `ignoreCommand`, which per Vercel's docs **"overrides the Ignored Build Step in Project Settings"** — so the guard is version-controlled instead of a dashboard field. `jobtracker-web` reads `apps/web/vercel.json` because Vercel reads config from the **Root Directory**; `jobtracker-api` reads the root `vercel.json`.

| Project | Root Directory | Config | Builds when these change |
| --- | --- | --- | --- |
| `jobtracker-api` | repo root | `vercel.json` | `api/`, `requirements.txt`, `backend/jobtracker/`, `vercel.json`, `.vercelignore` |
| `jobtracker-web` | `apps/web` | `apps/web/vercel.json` | `apps/web/`, `.vercelignore` |

`backend/requirements.txt` is deliberately **not** an api input — the cloud function installs the root `requirements.txt`; the backend one is the heavy-ML file. The root `vercel.json` is **not** a web input, but the root `.vercelignore` is: it once excluded `apps/web` and every web build failed with `NEXT_NO_VERSION`.

The script sits at the repo root rather than under `scripts/`, which `.vercelignore` strips before the ignore command runs (confirmed in the build log below). The guard itself is deliberately *not* in either path list — it is a gate, not a build input, so a commit that only edits it deploys nothing and the new logic applies from the next commit onward.

## Two properties, because getting either backwards is silent

**Exit codes are inverted.** `exit 0` **skips**, `exit 1` **builds**. Any code `>= 1` builds, so a crash lands on BUILD.

**The script fails open.** A wrong SKIP stops deploying real changes with nothing anywhere reporting an error; a wrong BUILD costs one deployment. Vercel shallow-clones with `--depth=10`, so `HEAD^` and `VERCEL_GIT_PREVIOUS_SHA` can both be absent — each is checked with `git cat-file -e` before use, and an unresolvable base builds. Previews have no `HEAD^` fallback on purpose, so a branch's **first build always happens** and the e2e browser pass always has a preview URL.

The base is `VERCEL_GIT_PREVIOUS_SHA` (the last commit actually deployed for this project and branch), not `HEAD^`. Push two commits to `main` at once — N-1 touching `apps/web`, N touching only `.github` — and a `HEAD^`-only guard skips the build and the web change never ships.

The script keeps its Dependabot branch-name prefix check, but it is now a **backstop**: section 1 stops those deployments being created at all, so reaching that line means one was created anyway. Note it is a shell `case` glob, where `*` *does* cross `/` — so unlike the minimatch patterns above it needs no `**`. Both behaviours are positively controlled in the table below with the real multi-slash branch names.

## Commit → decision

Verified by driving the **real script** — not a reimplementation of its path list — against real commits from this history. 38 cases, all passing, no deployment spent.

| Commit | What it touches | api | web |
| --- | --- | --- | --- |
| `48cc260` | `apps/web/**` only | SKIP | **BUILD** |
| `dc1711e` | `api/index.py` only | **BUILD** | SKIP |
| `a0c7e6e` | `backend/requirements-migrate.txt` | SKIP | SKIP |
| `66176e7` | `.github/workflows/**` only | SKIP | SKIP |
| `6e02617` | root `requirements.txt` (+ `backend/requirements.txt`) | **BUILD** | SKIP |
| `07ad6f4` | `backend/jobtracker/cloud/` + `apps/web/` | **BUILD** | **BUILD** |
| `c701462` | `backend/jobtracker/` + `apps/web/` + `ml/` + `scripts/` | **BUILD** | **BUILD** |
| `38ab378` | root `vercel.json` only | **BUILD** | SKIP |
| `fd34a70` | `.vercelignore` only | **BUILD** | **BUILD** |

Behavioural cases:

| Scenario | Decision |
| --- | --- |
| ref `dependabot/pip/requests-gte-2.34.2` (real, 2 slashes) | SKIP |
| ref `dependabot/pip/backend/beautifulsoup4-gte-4.15.0` (real, 3 slashes) | SKIP |
| ref `feat/dependabot-notes` (not a prefix match) | BUILD |
| preview, no previous deployment (branch's first build) | **BUILD** |
| preview, previous deployment known, nothing relevant since | SKIP |
| `VERCEL_GIT_PREVIOUS_SHA` outside the shallow clone, production | falls back to `HEAD^` |
| `VERCEL_GIT_PREVIOUS_SHA` outside the shallow clone, preview | **BUILD** |
| root commit, no `HEAD^` | **BUILD** |
| head SHA not in the clone | **BUILD** |
| unknown project name argument | **BUILD** |
| web change sits between last deployed SHA and HEAD | **BUILD** (a `HEAD^`-only guard would wrongly skip) |

Every pathspec in both allowlists has at least one BUILD row above, so a typo in any one of them would fail a case rather than silently mean "never changed". Both `ignoreCommand` strings were also run verbatim from their real Root Directory — `bash ../../vercel-ignore-build.sh web` with CWD `apps/web`, and `bash vercel-ignore-build.sh api` from the root — not just by absolute path.

## The ignore step does not save quota — the quote, so nobody re-derives it wrong

This is the opposite of the intuitive reading and it is the single most re-derivable mistake here, so it is recorded verbatim in the script header, in `DEPLOY.md`, and here. From <https://vercel.com/docs/project-configuration/project-settings#ignored-build-step>:

> Canceled builds are counted as full deployments as they execute a build command in the build step. This means that any canceled builds initiated using the ignore build step will still count towards your deployment quotas and concurrent build slots.

Corroborated at <https://vercel.com/docs/monorepos#ignoring-the-build-step>: *"Canceled builds initiated using the Ignored Build Step count towards your deployment and concurrent build limits."*

So section 2 buys build minutes, the single Hobby concurrent-build slot released in under a second instead of a full Next.js build, and a production deployment that no-op commits stop replacing. It does **not** buy headroom against the 100/day cap. Only section 1 does.

## The dashboard "Skip deployments when there are no changes to the Root Directory" toggle is inert here

Asked directly, so recorded directly: **do not click it — it will do nothing on this repo.** Vercel's built-in [skipping of unaffected projects](https://vercel.com/docs/monorepos#skipping-unaffected-projects) requires npm/yarn/pnpm/Bun **workspaces**, *"detected using the lockfile at the repository root"*. Verified with a positive control that there is no root `package.json`, no root lockfile and no `pnpm-workspace.yaml` — the only lockfile is `apps/web/pnpm-lock.yaml`. The documented fallback is that everything counts as a global change and *"deploy all applications in the repository"*, followed by *"If your project does not meet these requirements, you can use the Ignored Build Step."* This PR is that substitute, not a duplicate of the toggle.

It is free and reversible to flip, so one Dependabot merge would confirm it empirically. And if a root workspace definition is ever added, the toggle becomes the **better** lever and should replace the guard — unlike the Ignored Build Step it *"does not occupy concurrent build slots"*.

## Confirmed in a real build

This PR's own `jobtracker-web` preview build log:

```
Cloning github.com/yadava5/applied (Branch: ci/vercel-path-filtered-builds, Commit: 9f0cdf1)
Found .vercelignore (repository root)
Removed 256 ignored files defined in .vercelignore
Running "bash ../../vercel-ignore-build.sh web"
[vercel-ignore-build] no usable base commit; building
Running "vercel build"
```

Four things that were assumptions are now observed facts:

1. **`vercel.json`'s `ignoreCommand` really does override the dashboard.** Vercel ran `bash ../../vercel-ignore-build.sh web`, not the dependabot-prefix command still sitting in Project Settings.
2. **The repo root is present in the `apps/web` build container**, so the relative path resolves — "Include source files outside of the Root Directory" is on for this project.
3. **`.vercelignore` is applied at clone time, before the ignore command runs.** That is why the guard lives at the repo root and not under `scripts/`, which `.vercelignore` strips.
4. **The preview fail-open works as designed.** No previous deployment for this branch, so no usable base, so it built — the branch has a preview URL for the e2e browser pass.

The `jobtracker-api` guard has not been observed in situ: its check came back `Deployment rate limited — retry in 24 hours`, which is the problem this PR is about. **Expect that check to fail again on the current push, for reasons unrelated to this change** — the account is at its daily cap. The api command has no relative-path traversal, so the remaining risk there is lower than the web one that is now proven.
