### PR TITLE
feat(stage): make assessment a real application status

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -221,6 +221,46 @@ jobs:
               )
           PY
 
+      - name: Run migration suite (real Postgres)
+        # tests/test_migrations_postgres.py applies the WHOLE Alembic chain to a
+        # bare database and checks what the SQLite suites structurally cannot:
+        # enum labels. `sa.Enum` renders as VARCHAR on SQLite, so a migration
+        # that adds the wrong label — the lowercase API value instead of the
+        # member NAME Postgres actually stores — passes 600 green tests and then
+        # 500s on the first write in production. It runs here because this is
+        # the job with a Postgres; it is NOT in the `test` job for the same
+        # reason the RLS suite is not.
+        env:
+          JOBTRACKER_ENVIRONMENT: test
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
+          JOBTRACKER_TEST_PG_ADMIN_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+        run: |
+          pytest tests/test_migrations_postgres.py -q \
+            --junit-xml="$RUNNER_TEMP/migration-results.xml"
+
+      - name: Assert the migration suite actually ran
+        # Same guard, same reason: this module skips itself when no Postgres is
+        # reachable, and a skip is green.
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse(
+              os.path.join(os.environ["RUNNER_TEMP"], "migration-results.xml")
+          ).getroot()
+          suite = root if root.tag == "testsuite" else root.find("testsuite")
+          total = int(suite.get("tests", 0))
+          skipped = int(suite.get("skipped", 0))
+          print(f"Migration suite: {total} tests, {skipped} skipped")
+          if total == 0 or skipped:
+              sys.exit(
+                  "Migration tests did not run. Every enum label in the chain is "
+                  "UNVERIFIED by this build."
+              )
+          PY
+
   cloud-smoke:
     # Smoke-test the cloud FastAPI entrypoint (`api/index.py` /
     # `jobtracker.main_cloud`) under the exact env used on Vercel:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-534%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-634%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -375,13 +375,15 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**534 tests collected, 0 skipped.** These figures were recorded on 2026-08-11 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 534 `test_*` functions across 37 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity and RLS work, three of which brought their own module. The bold 534 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**634 tests collected, 0 skipped.** These figures were recorded on 2026-08-12 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 542 `test_*` functions across 38 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity, RLS and migration-chain work, four of which brought their own module (`test_status_vocabulary.py`, `test_application_identity.py`, `test_rls_postgres.py`, `test_migrations_postgres.py`). The bold 634 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
 Those tests drive the production machinery, not a fixture: `jobtracker.database.connection.get_session` with its real GUC and `search_path` handling, against a non-`BYPASSRLS` role, asserting that a raw query with the application-level `WHERE user_id = ...` filter *removed* still returns nothing for another tenant.
 
-**Coverage**, from the same run: **58.29%** overall — 9,335 statements, 3,894 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.7%**; `auth` 80.5%; `database` 77.4%. What pulls the average down is `jobtracker/scripts` at 2,358 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
+`test_migrations_postgres.py` rides in the same job, for a defect the rest of the suite is structurally blind to: on SQLite, `sa.Enum` renders as `VARCHAR`, so a migration can add an enum label in the wrong case and every other test stays green while production 500s on the first write. It applies the whole Alembic chain to a bare database through the real CLI, then asserts the `applicationstatus` labels are the Python enum's member names in declaration order, that a row round-trips, and that the lowercase spelling is genuinely rejected. It is guarded by the same "did it actually run" JUnit check as the RLS suite.
+
+**Coverage**, from the same run: **58.60%** overall — 9,418 statements, 3,899 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.9%**; `auth` 80.5%; `database` 77.5%. What pulls the average down is `jobtracker/scripts` at 2,358 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -534,9 +536,9 @@ applied/
 │   │   ├── credentials/     # types · desktop (Keychain) · cloud (Fernet)
 │   │   ├── database/        # models, connection (the RLS GUC listener lives here)
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
-│   ├── alembic/versions/    # 11 revisions incl. the RLS + InitPlan-hoist migrations
+│   ├── alembic/versions/    # 12 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 37 modules
+│   └── tests/               # 38 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/apps/web/components/applications/AddApplicationForm.tsx
+++ b/apps/web/components/applications/AddApplicationForm.tsx
@@ -13,15 +13,19 @@ import {
   selectClass,
   textareaClass,
 } from "@/components/ui/formStyles";
+import { APPLICATION_STATUSES } from "@/lib/dashboard/status";
 
-const STATUS_OPTIONS = [
-  "applied",
-  "interviewing",
-  "offered",
-  "rejected",
-  "accepted",
-  "withdrawn",
-] as const;
+/**
+ * The stage vocabulary, imported rather than restated.
+ *
+ * This dialog held the last hand-written copy: six values, missing `ghosted`
+ * (which the API accepts) — one of the three lists that disagreed when setting
+ * a card to `assessment` answered 422. The card's `<select>` was fixed by
+ * deleting its literal and importing this one; this one was left behind, so it
+ * would have been the single place a filed-by-hand application could not be
+ * filed as an assessment.
+ */
+const STATUS_OPTIONS = APPLICATION_STATUSES;
 
 type Mode = "live" | "demo";
 

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -422,7 +422,7 @@ export function PipelineBoard({
   for (const app of applications) {
     let counts = companyStages.get(app.company);
     if (!counts) {
-      counts = { applied: 0, interviewing: 0, offered: 0, rejected: 0 };
+      counts = { applied: 0, assessment: 0, interviewing: 0, offered: 0, rejected: 0 };
       companyStages.set(app.company, counts);
     }
     counts[stageOf(shownStatus(app))] += 1;
@@ -510,7 +510,7 @@ export function PipelineBoard({
    */
   const spineCounts: Record<StageKey, number> = stageTotals
     ? { ...stageTotals }
-    : { applied: 0, interviewing: 0, offered: 0, rejected: 0 };
+    : { applied: 0, assessment: 0, interviewing: 0, offered: 0, rejected: 0 };
   if (stageTotals) {
     for (const app of applications) {
       const pending = pendingMoves[app.id];

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -168,10 +168,16 @@ export function PipelinePulse({
   const arrow = recent > prior ? "↑" : recent < prior ? "↓" : "→";
 
   // --- ageing (open rows only — a closed row's age answers nothing) ---------
+  //
+  // `assessment` is open, and naming it here is not optional: this is a stage
+  // ALLOW-list, not a `stageOf` lookup, so TypeScript would not have noticed
+  // its absence — assessment rows would simply have vanished from the ageing
+  // ladder and from `openTotal`. Same defect family as `stageOf`'s
+  // `?? "applied"` fallback, in a different disguise.
   const openAges = applications
     .filter((app) => {
       const stage = stageOf(app.status);
-      return stage === "applied" || stage === "interviewing";
+      return stage === "applied" || stage === "assessment" || stage === "interviewing";
     })
     .map((app) => daysBetween(filedAt(app), today));
   const ages = bucketAges(openAges);

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -751,12 +751,25 @@ export interface components {
          *     body models, ``GET /applications/statuses``, the rollup's rank tables, the
          *     web's ``<select>`` — derives from here rather than restating it, because
          *     three hand-written copies is exactly how the board came to offer a stage
-         *     (``assessment``) the API answers with a 422.
+         *     (``assessment``) that the API answered with a 422. The word is settable now;
+         *     the lesson is not about the word but about the copies.
          *
-         *     ``assessment`` is deliberately NOT a member: see :data:`CATEGORY_TO_STATUS`.
+         *     ``assessment`` IS a member, as of 2026-08-12: see :data:`CATEGORY_TO_STATUS`
+         *     for the decision and why it changed.
+         *
+         *     DECLARATION ORDER IS THE API'S ORDER. ``APPLICATION_STATUSES``, the
+         *     endpoint's list and the web's mirror all take their order from here, so a
+         *     member is inserted at its lifecycle position, never appended.
+         *
+         *     The member NAMES are what Postgres stores — SQLModel/SQLAlchemy persist an
+         *     enum's name, not its value — so the ``applicationstatus`` type holds
+         *     ``'ASSESSMENT'`` while the API speaks ``'assessment'``. Adding a member
+         *     therefore needs a migration that adds the UPPERCASE label
+         *     (``b9e42f7c10ad``), and the SQLite suites cannot see that difference because
+         *     ``sa.Enum`` renders as ``VARCHAR`` there.
          * @enum {string}
          */
-        ApplicationStatus: "applied" | "interviewing" | "offered" | "rejected" | "accepted" | "withdrawn" | "ghosted";
+        ApplicationStatus: "applied" | "assessment" | "interviewing" | "offered" | "rejected" | "accepted" | "withdrawn" | "ghosted";
         /**
          * ApplicationStatusUpdate
          * @description Body for a user's status correction (PATCH /applications/{id}).
@@ -1346,18 +1359,22 @@ export interface components {
          *
          *     Every field is DERIVED from :class:`ApplicationStatus` /
          *     :data:`CATEGORY_TO_STATUS` at import time, so this endpoint and the 422 a
-         *     bad ``PATCH`` earns cannot disagree. It exists because they did: the board
-         *     offered ``assessment``, the file-by-hand dialog offered six of the seven,
-         *     and the API accepted a different seven.
+         *     bad ``PATCH`` earns cannot disagree. It exists because they did: three
+         *     hand-written copies of the vocabulary, all different — the board's card
+         *     offered a value the API refused, the file-by-hand dialog offered fewer than
+         *     the API accepted, and only the enum was right.
          *
          *     - ``statuses`` — the settable stages, in lifecycle order. THE list.
          *     - ``default`` — what a new row starts at.
          *     - ``category_to_status`` — how a classifier verdict maps onto a stage, for
-         *       a client that wants to show ``assessment`` mail under ``interviewing``.
-         *       A category absent from this map asserts no stage.
+         *       a client that wants to file mail under the stage it implies (an
+         *       ``interview`` message means the row is ``interviewing``). A category
+         *       absent from this map asserts no stage.
          *     - ``classifier_categories`` — everything the classifier can emit. A
          *       SUPERSET of the mapping's keys and NOT interchangeable with ``statuses``;
-         *       confusing the two is the original defect.
+         *       confusing the two is the original defect. They overlap on ``applied`` and
+         *       — since 2026-08-12 — ``assessment``, which is precisely when the two get
+         *       conflated again, so both lists keep being served.
          */
         StatusVocabularyResponse: {
             /** Statuses */

--- a/apps/web/lib/dashboard/board.ts
+++ b/apps/web/lib/dashboard/board.ts
@@ -22,15 +22,18 @@
  * under it now agree either way — nothing in `closed` claims to be a rejection.
  *
  * The membership change is still worth making, and it is one file: `STAGES`
- * grows a fifth stage owning `withdrawn` (and `ghosted`, which today has no
- * stage at all and so falls through `stageOf`'s `?? "applied"` into the applied
- * column and into `inMotion`), `counts`/`PipelineSummary` gain that key, and
- * the board's `lg:grid-cols-4` becomes 5. Doing it there fixes the funnel and
- * the tiles in the same stroke; doing it here would fix only the board.
+ * grows a stage owning `withdrawn`, `counts`/`PipelineSummary` gain that key,
+ * and the board's column count follows `STAGES` on its own. Doing it there
+ * fixes the funnel and the tiles in the same stroke; doing it here would fix
+ * only the board. (`ghosted`, named here as the same defect, has had an
+ * explicit home in the `rejected` stage since; `assessment` got a stage of its
+ * own on 2026-08-12, which is what took the board from four columns to five.)
  *
  * `stages` is a parameter rather than an import so this module stays
- * import-free and `node --test` can load it under type stripping (`summary.ts`
- * value-imports through the `@/` alias, which Node cannot resolve).
+ * import-free — a shape worth keeping, though no longer a necessity:
+ * `summary.ts` value-imports relatively now (`./dates.ts`), so `node --test`
+ * can load it too, and the stage test reads the real `STAGES` instead of a
+ * copy of them.
  */
 import type { StageDef, StageKey } from "./summary";
 

--- a/apps/web/lib/dashboard/status.ts
+++ b/apps/web/lib/dashboard/status.ts
@@ -18,10 +18,14 @@
  * not cosmetic: it is what lets a later test assert this list equals the
  * endpoint's outright, instead of comparing sorted sets and missing a member.
  *
- * `assessment` is absent on purpose. It is a classifier CATEGORY that maps to
- * the `interviewing` stage (`CATEGORY_TO_STATUS`), which is what `summary.ts`
- * already does when it groups `interviewing`/`interview`/`assessment` into one
- * column; the card's old `<select>` was the only thing treating it as a stage.
+ * `assessment` is PRESENT, as of 2026-08-12, and that is a reversal: it used to
+ * be absent here on the grounds that it was only a classifier category that
+ * mapped to `interviewing`. It is a stage now — the decision and its reasons
+ * are in `CATEGORY_TO_STATUS` in `backend/jobtracker/database/models.py`, and
+ * `summary.ts` gives it a column of its own rather than folding it in. Note
+ * what that means for this file's own history: the card's old `<select>` was
+ * offering the right word for the wrong reason, and the fix was still to delete
+ * the second list, not to keep it.
  *
  * Reading `GET /applications/statuses` at runtime would close the loop
  * entirely, but it needs a proxy route (`app/api/...`) to carry the JWT, so it
@@ -35,6 +39,7 @@
 /** Every status the API's PATCH accepts, in the enum's own declaration order. */
 export const APPLICATION_STATUSES = [
   "applied",
+  "assessment",
   "interviewing",
   "offered",
   "rejected",

--- a/apps/web/lib/dashboard/summary.ts
+++ b/apps/web/lib/dashboard/summary.ts
@@ -8,7 +8,14 @@
  * has exactly one implementation to audit.
  */
 import type { components } from "@/lib/api/schema";
-import { filedAt } from "@/lib/dashboard/dates";
+// Relative, not `@/lib/dashboard/dates`, and that is the whole reason this
+// module is unit-testable: `node --test` strips types but cannot resolve the
+// `@/` alias, so ONE value-import through it made the entire stage vocabulary
+// untestable — which is why `tests/unit/application-status.test.mjs` used to
+// carry a hand-written copy of `STAGES` and could not have caught a stage
+// losing its statuses. The type-only import above is erased before Node sees
+// it, so it may keep the alias.
+import { filedAt } from "./dates.ts";
 
 /**
  * A board row, as the cloud backend actually serves it. The name on the wire is
@@ -19,8 +26,8 @@ import { filedAt } from "@/lib/dashboard/dates";
  */
 export type Application = components["schemas"]["CloudApplicationResponse"];
 
-/** The four pipeline stages, in flow order, with their semantic accent. */
-export type StageKey = "applied" | "interviewing" | "offered" | "rejected";
+/** The five pipeline stages, in flow order, with their semantic accent. */
+export type StageKey = "applied" | "assessment" | "interviewing" | "offered" | "rejected";
 
 export interface StageDef {
   key: StageKey;
@@ -38,9 +45,27 @@ export const STAGES: StageDef[] = [
   // luminance fix only (measured 9.25:1 solid, 3.62:1 at the 55% wash).
   { key: "applied", label: "applied", statuses: ["applied"], color: "var(--stage-applied)" },
   {
+    // A stage of its own since 2026-08-12, and NOT folded into `interviewing`
+    // any more. The reasons are in `CATEGORY_TO_STATUS`
+    // (`backend/jobtracker/database/models.py`); the reason it matters HERE is
+    // `stageOf`'s `?? "applied"` fallback: leaving `assessment` out of every
+    // stage would not fail a build, it would quietly file every assessment row
+    // under `applied` — the same bug `ghosted` had, documented four lines down.
+    //
+    // Colour: the sky of the viz sub-palette. The board already borrows that
+    // palette for its chromatic stages (`interviewing` is the embeddings
+    // purple), and the alternative — `--amber` — already means "needs your
+    // attention" everywhere else in this dashboard, including the pulse's
+    // "due ≤7d" rung that assessment rows will populate.
+    key: "assessment",
+    label: "assessment",
+    statuses: ["assessment"],
+    color: "var(--viz-rules)",
+  },
+  {
     key: "interviewing",
     label: "interviewing",
-    statuses: ["interviewing", "interview", "assessment"],
+    statuses: ["interviewing", "interview"],
     color: "var(--viz-embeddings)",
   },
   { key: "offered", label: "offered", statuses: ["offered", "offer", "accepted"], color: "var(--green)" },
@@ -86,13 +111,16 @@ export function qualifierOf(status: string): string | null {
 export interface PipelineSummary {
   total: number;
   thisWeek: number;
-  /** applied + interviewing — live, not-yet-resolved applications. */
+  /** applied + assessment + interviewing — live, not-yet-resolved applications. */
   inMotion: number;
   /** offered + accepted. */
   offers: number;
   /** rejected + withdrawn. */
   closed: number;
-  /** Share of applications that advanced past "applied" (interviewing+offered). */
+  /**
+   * Share of applications that advanced past "applied"
+   * (assessment + interviewing + offered).
+   */
   advancedPct: number;
   /** Per-stage counts, in flow order. */
   stages: { stage: StageDef; count: number }[];
@@ -117,6 +145,7 @@ export function summarizeCounts(
 ): PipelineSummary {
   const counts: Record<StageKey, number> = {
     applied: 0,
+    assessment: 0,
     interviewing: 0,
     offered: 0,
     rejected: 0,
@@ -126,13 +155,20 @@ export function summarizeCounts(
   for (const [status, n] of Object.entries(statusCounts)) {
     const stage = stageOf(status);
     counts[stage] += n;
-    if (stage === "interviewing" || stage === "offered") advanced += n;
+    // `assessment` counts as ADVANCED: the employer answered and asked for
+    // something, which is precisely what "past applied" means. Excluding it
+    // would make the number fall on the day the stage shipped, for rows that
+    // did not move — the old fold counted them under `interviewing`.
+    if (stage === "assessment" || stage === "interviewing" || stage === "offered") advanced += n;
   }
 
   return {
     total,
     thisWeek,
-    inMotion: counts.applied + counts.interviewing,
+    // `assessment` is IN MOTION: an unmet deadline is the most live an
+    // application ever gets. It is not resolved, so it is not in `closed`, and
+    // the three buckets still partition the board.
+    inMotion: counts.applied + counts.assessment + counts.interviewing,
     offers: counts.offered,
     closed: counts.rejected,
     advancedPct: total > 0 ? Math.round((advanced / total) * 100) : 0,
@@ -150,6 +186,7 @@ export function summarizeCounts(
 export function stageCountsOf(summary: PipelineSummary): Record<StageKey, number> {
   const counts: Record<StageKey, number> = {
     applied: 0,
+    assessment: 0,
     interviewing: 0,
     offered: 0,
     rejected: 0,

--- a/apps/web/lib/demo/demoData.ts
+++ b/apps/web/lib/demo/demoData.ts
@@ -26,6 +26,12 @@
 import { todayISO } from "@/lib/dashboard/age";
 import { dueDayISO } from "@/lib/dashboard/deadline";
 
+/**
+ * The statuses the FIXTURES use — a subset of the API's vocabulary, not a
+ * mirror of it. It deliberately does not grow with `ApplicationStatus`: adding
+ * `assessment` here would type-check while no fixture used it, which is a
+ * promise the demo does not keep. It grows when a fixture is re-filed.
+ */
 export type DemoStatus = "applied" | "interviewing" | "offered" | "rejected";
 
 export interface DemoApplication {
@@ -133,9 +139,13 @@ const APPLICATION_SEEDS: DemoSeed[] = [
   // Assessments with deadlines ×3 — the landing's own opening problem ("its
   // 48-hour deadline passes unseen") demonstrated in all three states: one
   // comfortably ahead, one inside the DUE_SOON_DAYS window, one already
-  // missed. Status is `interviewing` (an assessment mail advances the row;
-  // `assessment` is a classifier category, not an API status — see
-  // lib/dashboard/status.ts), and every deadline here is mail-extracted
+  // missed. Status is `interviewing`, and as of 2026-08-12 that is STALE
+  // rather than principled: `assessment` became a real API status (see
+  // lib/dashboard/status.ts), so these three rows should be filed at it. They
+  // are deliberately left alone here because their offsets and columns are the
+  // contract `demo.spec.ts` asserts, and re-filing them is a demo change with
+  // its own e2e run — not part of the vocabulary change. Every deadline here is
+  // mail-extracted
   // (`due_source: "mail"` via the adapter): this account is auto-filed, and
   // the e2e sets/clears the one "user" deadline through the sheet instead.
   // The offsets are the contract demo.spec.ts asserts (due in 9d / due in 2d /

--- a/apps/web/tests/unit/application-status.test.mjs
+++ b/apps/web/tests/unit/application-status.test.mjs
@@ -5,7 +5,8 @@
  * The bugs these guard, both measured on the live app:
  *
  *  1. The card's <select> carried its own literal array including
- *     `assessment` — a value the API has never accepted. Choosing it answered
+ *     `assessment` — a value the API did not accept at the time. Choosing it
+ *     answered
  *
  *       422 · Input should be 'applied', 'interviewing', 'offered', 'rejected',
  *             'accepted', 'withdrawn' or 'ghosted'
@@ -13,7 +14,9 @@
  *     while `ghosted`, which the API DOES accept, was absent from the dropdown.
  *     The list now lives in `lib/dashboard/status.ts` and the component imports
  *     it, so the assertion below is the dropdown's contents, not a parallel
- *     model of them.
+ *     model of them. `assessment` became a real API status on 2026-08-12 and is
+ *     back in the list — through the one definition, which is the fix; the bug
+ *     was the second list, not the word.
  *  2. A `withdrawn` application sat in a column whose `aria-label` read
  *     `rejected — 1`. The user withdrew; the board said they were rejected.
  *
@@ -30,6 +33,7 @@ import {
   statusOptions,
   statusSelectValue,
 } from "../../lib/dashboard/status.ts";
+import { STAGES, stageOf, summarizeCounts } from "../../lib/dashboard/summary.ts";
 
 /**
  * Exactly the values named in the API's own 422, in the order it named them —
@@ -37,20 +41,28 @@ import {
  * `GET /applications/statuses` serves. Written out here rather than derived, so
  * a change to the frontend list has to be made deliberately in two places.
  */
-const API_ACCEPTS = ["applied", "interviewing", "offered", "rejected", "accepted", "withdrawn", "ghosted"];
-
-/** The four stages as `summary.ts` declares them (membership is not ours). */
-const STAGES_FIXTURE = [
-  { key: "applied", label: "applied", statuses: ["applied"], color: "var(--text-muted)" },
-  {
-    key: "interviewing",
-    label: "interviewing",
-    statuses: ["interviewing", "interview", "assessment"],
-    color: "var(--viz-embeddings)",
-  },
-  { key: "offered", label: "offered", statuses: ["offered", "offer", "accepted"], color: "var(--green)" },
-  { key: "rejected", label: "rejected", statuses: ["rejected", "rejection", "withdrawn"], color: "var(--red)" },
+const API_ACCEPTS = [
+  "applied",
+  "assessment",
+  "interviewing",
+  "offered",
+  "rejected",
+  "accepted",
+  "withdrawn",
+  "ghosted",
 ];
+
+/**
+ * The stages, imported from `summary.ts` — not a copy of them.
+ *
+ * This was a hand-written fixture until 2026-08-12, because `summary.ts`
+ * value-imported through the `@/` alias and `node --test` cannot resolve it. A
+ * fixture asserts the fixture: it would have gone on passing while `STAGES`
+ * lost a stage's statuses entirely, and `stageOf`'s `?? "applied"` fallback
+ * would have filed those rows under `applied` in silence. That import is now
+ * relative, so this reads the real thing.
+ */
+const STAGES_FIXTURE = STAGES;
 
 test("the settable stages are exactly the ones the API accepts, in its order", () => {
   // Same members AND same order as `ApplicationStatus` / the list
@@ -59,15 +71,21 @@ test("the settable stages are exactly the ones the API accepts, in its order", (
   assert.deepEqual([...APPLICATION_STATUSES], API_ACCEPTS);
 });
 
-test("the value that returned 422 is not offered, and the one that was missing is", () => {
-  assert.equal(isApplicationStatus("assessment"), false);
+test("both values the dropdown used to get wrong are offered, and offered once", () => {
+  // `assessment` was in the dropdown while the API refused it (422); `ghosted`
+  // was accepted by the API and missing from the dropdown. One list, both fixed.
+  assert.equal(isApplicationStatus("assessment"), true);
   assert.equal(isApplicationStatus("ghosted"), true);
+  // A classifier category that is NOT a stage stays out — the two vocabularies
+  // now share a member, which is exactly when they start being conflated.
+  assert.equal(isApplicationStatus("follow_up"), false);
+  assert.equal(isApplicationStatus("needs_review"), false);
 
   const offered = statusOptions("applied");
   assert.equal(
-    offered.some((o) => o.value === "assessment"),
-    false,
-    "assessment is back in the dropdown; the API answers 422 to it",
+    offered.filter((o) => o.value === "assessment").length,
+    1,
+    "assessment must appear exactly once — it is one stage, not a legacy alias",
   );
   assert.deepEqual(
     offered.filter((o) => !o.disabled).map((o) => o.value),
@@ -77,13 +95,26 @@ test("the value that returned 422 is not offered, and the one that was missing i
 
 test("a row holding an unaccepted status shows THAT, disabled — never a substitute", () => {
   // The old control fell back to "applied" for anything it did not recognize,
-  // i.e. it displayed a stage the row was not at.
-  const options = statusOptions("assessment");
-  assert.deepEqual(options[0], { value: "assessment", label: "assessment (legacy)", disabled: true });
-  assert.equal(statusSelectValue("assessment"), "assessment");
+  // i.e. it displayed a stage the row was not at. `interview` (the classifier's
+  // word, not the API's) stands in for the case `assessment` used to cover.
+  const options = statusOptions("interview");
+  assert.deepEqual(options[0], { value: "interview", label: "interview (legacy)", disabled: true });
+  assert.equal(statusSelectValue("interview"), "interview");
   assert.deepEqual(
     options.slice(1).map((o) => o.value),
     [...APPLICATION_STATUSES],
+  );
+
+  // ... and a row at `assessment` is no longer one of those cases: it is a
+  // real stage, so nothing about it is disabled.
+  const assessment = statusOptions("assessment");
+  assert.deepEqual(
+    assessment.map((o) => o.value),
+    [...APPLICATION_STATUSES],
+  );
+  assert.equal(
+    assessment.some((o) => o.disabled),
+    false,
   );
 
   const unknown = statusOptions(null);
@@ -108,7 +139,7 @@ test("the resolved column is headed `closed`, and nothing else is renamed", () =
   const columns = boardColumns(STAGES_FIXTURE);
   assert.deepEqual(
     columns.map((c) => c.label),
-    ["applied", "interviewing", "offered", "closed"],
+    ["applied", "assessment", "interviewing", "offered", "closed"],
   );
   // Keys (membership) and colours are passed through untouched: the board still
   // groups exactly as `stageOf`/`summarizeCounts` do.
@@ -122,6 +153,40 @@ test("the resolved column is headed `closed`, and nothing else is renamed", () =
   );
 });
 
+test("every settable status is claimed by a stage — none reaches the fallback", () => {
+  // `stageOf` answers `applied` for anything it does not recognise, so a status
+  // missing from every stage does not throw, does not fail a build and does not
+  // look wrong: it is silently counted as applied. That is how `ghosted` was
+  // counted as in-motion, and it is the one way `assessment` could have been
+  // added everywhere else and still shown up in the wrong column.
+  for (const status of APPLICATION_STATUSES) {
+    const owner = STAGES.find((stage) => stage.statuses.includes(status));
+    assert.ok(owner, `"${status}" belongs to no stage; stageOf would file it under "applied"`);
+    assert.equal(stageOf(status), owner.key);
+  }
+
+  // ... and `assessment` specifically is its own stage, not folded anywhere.
+  assert.equal(stageOf("assessment"), "assessment");
+  assert.equal(stageOf("interviewing"), "interviewing");
+});
+
+test("assessment counts as in motion and as advanced, and never as applied", () => {
+  const summary = summarizeCounts({ applied: 2, assessment: 3, interviewing: 1, rejected: 4 }, 10, 0);
+  const counts = Object.fromEntries(summary.stages.map(({ stage, count }) => [stage.key, count]));
+
+  assert.deepEqual(counts, { applied: 2, assessment: 3, interviewing: 1, offered: 0, rejected: 4 });
+  // The board is in flow order, so the new stage is second.
+  assert.deepEqual(
+    summary.stages.map(({ stage }) => stage.key),
+    ["applied", "assessment", "interviewing", "offered", "rejected"],
+  );
+  // An unmet deadline is the most live an application gets: in motion, and past
+  // applied. 4 of 10 rows advanced (3 assessment + 1 interviewing).
+  assert.equal(summary.inMotion, 6);
+  assert.equal(summary.advancedPct, 40);
+  assert.equal(summary.closed, 4);
+});
+
 test("a card states its own status whenever its column heading does not", () => {
   // The measured bug: withdrawn under a heading that claimed "rejected".
   assert.equal(cardQualifier("withdrawn", "closed"), "withdrawn");
@@ -130,6 +195,12 @@ test("a card states its own status whenever its column heading does not", () => 
   // `ghosted` has no column of its own — `stageOf` drops it into `applied` —
   // so the card must say so rather than pass for a live application.
   assert.equal(cardQualifier("ghosted", "applied"), "ghosted");
+
+  // `assessment` has a column of its own now, so a card in it adds nothing —
+  // under the old fold it sat below a heading that read "interviewing" and had
+  // to contradict it, which is the same shape as the withdrawn/rejected bug.
+  assert.equal(cardQualifier("assessment", "assessment"), null);
+  assert.equal(cardQualifier("assessment", "interviewing"), "assessment");
 
   // The heading already said it: no badge.
   assert.equal(cardQualifier("applied", "applied"), null);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,13 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    // Lets a module that `node --test` has to load spell its relative import
+    // with the real filename (`./dates.ts`). Node's type stripping resolves
+    // ESM specifiers literally — no extension search, no `@/` alias — so this
+    // is what makes `lib/dashboard/summary.ts` (the single implementation of
+    // stage semantics) unit-testable instead of hand-copied into a fixture.
+    // Safe with `noEmit`, which is the only mode this project type-checks in.
+    "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,

--- a/backend/alembic/versions/b9e42f7c10ad_assessment_application_status.py
+++ b/backend/alembic/versions/b9e42f7c10ad_assessment_application_status.py
@@ -1,0 +1,117 @@
+"""assessment becomes a real application status
+
+Revision ID: b9e42f7c10ad
+Revises: b7c31e0d94aa
+Create Date: 2026-08-12 10:20:00.000000
+
+Adds ``ASSESSMENT`` to the ``applicationstatus`` Postgres enum so the stage the
+product now records is a stage the database can hold. The decision, and why it
+reversed, is recorded in :data:`jobtracker.database.models.CATEGORY_TO_STATUS`;
+this file is only the schema half of it.
+
+Why the label is UPPERCASE
+--------------------------
+
+SQLModel/SQLAlchemy persist an enum's **name**, not its value. The initial
+migration created
+
+    sa.Enum('APPLIED', 'INTERVIEWING', ..., name='applicationstatus')
+
+so the type's labels are the member names while the API speaks the lowercase
+values. ``ADD VALUE 'assessment'`` would have succeeded as DDL and then failed
+on every write with
+
+    invalid input value for enum applicationstatus: "ASSESSMENT"
+
+— a green migration followed by a 500. The SQLite suites cannot catch that:
+``sa.Enum`` renders as ``VARCHAR`` there, so any label spelling round-trips.
+``backend/tests/test_migrations_postgres.py`` runs this migration against a real
+Postgres and asserts the labels equal ``[s.name for s in ApplicationStatus]`` in
+order, which is the check that can actually fail.
+
+``BEFORE 'INTERVIEWING'`` places the label at its lifecycle position in
+``pg_enum``'s sort order, matching the enum's declaration order — cosmetic for
+correctness, but it keeps ``ORDER BY status`` and any future
+``enum_range()``-based query in lifecycle order rather than insertion order.
+
+Why the autocommit block
+------------------------
+
+``backend/alembic/env.py`` wraps ALL pending revisions in ONE transaction (it
+does not set ``transaction_per_migration``). A new enum label cannot be USED in
+the transaction that added it — Postgres raises 55P04 "unsafe use of new value
+of enum type". Nothing later in the current chain touches the label, so today
+the hazard is latent rather than live; the block is here so the next revision
+that does touch it (a backfill, a check constraint, a data migration) does not
+have to discover this the hard way on a fresh environment running
+``alembic upgrade head`` once. The preceding transaction is committed on entry,
+which is safe here because this revision does nothing else.
+
+Forward-only, like ``b7c31e0d94aa``
+-----------------------------------
+
+Postgres has no ``DROP VALUE``. The downgrade therefore remaps rows
+(``ASSESSMENT`` → ``INTERVIEWING``, the fold this change undid) and leaves the
+label in the type, inert. That loses the distinction the rows recorded — real
+data loss, not a clean rollback, the same honesty the deadlines migration states
+about dropping ``due_at``.
+
+Two caveats on the downgrade, both about who runs it:
+
+- ``applications`` has ``FORCE ROW LEVEL SECURITY`` (``a8d4ec5fba26``), so the
+  UPDATE only touches rows the running role can see. Run it as the migration
+  role (``DIRECT_URL``, i.e. the owner/superuser that bypasses RLS); a
+  non-BYPASSRLS role would silently remap zero rows and report success.
+- Re-running the upgrade afterwards is a no-op (``IF NOT EXISTS``), but it does
+  NOT restore the remapped rows. There is nothing left to restore them from.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b9e42f7c10ad'
+down_revision: Union[str, Sequence[str], None] = 'b7c31e0d94aa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _is_postgres() -> bool:
+    """True when the current Alembic context targets PostgreSQL.
+
+    Checked per-invocation rather than cached, matching ``a8d4ec5fba26``.
+    """
+
+    return op.get_context().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+
+    if not _is_postgres():
+        # SQLite (desktop + tests) has no enum type to alter: `sa.Enum` renders
+        # as VARCHAR with no CHECK constraint, so the new member is already
+        # storable. A no-op keeps `alembic upgrade head` usable under both
+        # dialects without branching in env.py.
+        return
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE applicationstatus "
+            "ADD VALUE IF NOT EXISTS 'ASSESSMENT' BEFORE 'INTERVIEWING'"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema — lossy, and forward-only on the type itself."""
+
+    # Runs on every dialect: the rows hold the enum NAME as text under SQLite
+    # too, so a downgraded desktop install would otherwise keep a status its
+    # code no longer knows.
+    op.execute(
+        "UPDATE applications SET status = 'INTERVIEWING' WHERE status = 'ASSESSMENT'"
+    )
+    # The 'ASSESSMENT' label deliberately STAYS in the Postgres type. There is
+    # no `ALTER TYPE ... DROP VALUE`; dropping and recreating the type would
+    # mean rewriting every dependent column and re-granting, to remove a label
+    # that costs nothing while unused.

--- a/backend/jobtracker/cloud/applications.py
+++ b/backend/jobtracker/cloud/applications.py
@@ -336,18 +336,22 @@ class StatusVocabularyResponse(BaseModel):
 
     Every field is DERIVED from :class:`ApplicationStatus` /
     :data:`CATEGORY_TO_STATUS` at import time, so this endpoint and the 422 a
-    bad ``PATCH`` earns cannot disagree. It exists because they did: the board
-    offered ``assessment``, the file-by-hand dialog offered six of the seven,
-    and the API accepted a different seven.
+    bad ``PATCH`` earns cannot disagree. It exists because they did: three
+    hand-written copies of the vocabulary, all different — the board's card
+    offered a value the API refused, the file-by-hand dialog offered fewer than
+    the API accepted, and only the enum was right.
 
     - ``statuses`` — the settable stages, in lifecycle order. THE list.
     - ``default`` — what a new row starts at.
     - ``category_to_status`` — how a classifier verdict maps onto a stage, for
-      a client that wants to show ``assessment`` mail under ``interviewing``.
-      A category absent from this map asserts no stage.
+      a client that wants to file mail under the stage it implies (an
+      ``interview`` message means the row is ``interviewing``). A category
+      absent from this map asserts no stage.
     - ``classifier_categories`` — everything the classifier can emit. A
       SUPERSET of the mapping's keys and NOT interchangeable with ``statuses``;
-      confusing the two is the original defect.
+      confusing the two is the original defect. They overlap on ``applied`` and
+      — since 2026-08-12 — ``assessment``, which is precisely when the two get
+      conflated again, so both lists keep being served.
     """
 
     statuses: list[str]

--- a/backend/jobtracker/cloud/pipeline.py
+++ b/backend/jobtracker/cloud/pipeline.py
@@ -512,12 +512,19 @@ _STAGE_RANK: dict[str, int] = {
 }
 
 # Application lifecycle status (ApplicationStatus values) by ascending progress.
-# Used to roll a stage rank up to a status and to advance monotonically.
+# Used to advance monotonically (:func:`advance_application_status`).
+#
+# NOT the same scale as ``_STAGE_RANK`` above, and since ``assessment`` became a
+# status (2026-08-12) the two no longer even share a maximum: stage ranks top
+# out at 4 (``offer``), status ranks at 5 (``accepted``). Only ``_STAGE_RANK``
+# values may be passed to :func:`_rank_to_status`; a status rank fed to it would
+# read one stage too high.
 _STATUS_RANK: dict[str, int] = {
     "applied": 1,
-    "interviewing": 2,
-    "offered": 3,
-    "accepted": 4,
+    "assessment": 2,
+    "interviewing": 3,
+    "offered": 4,
+    "accepted": 5,
 }
 
 # A stored status the mail signal must never silently override (a manual/terminal
@@ -1081,10 +1088,21 @@ class ReviewItem:
 
 
 def _rank_to_status(rank: int) -> str:
+    """Roll a ``_STAGE_RANK`` value (a mail CATEGORY's rank) up to a status.
+
+    Takes a stage rank, never a status rank — see the note on ``_STATUS_RANK``.
+    Since ``assessment`` became a status the mapping is 1:1 with the stage
+    ranks (1 applied, 2 assessment, 3 interview→interviewing, 4 offer→offered);
+    rank 2 used to fold up into ``interviewing``, which is the fold this change
+    removes.
+    """
+
     if rank >= 4:
         return "offered"
-    if rank >= 2:
+    if rank >= 3:
         return "interviewing"
+    if rank >= 2:
+        return "assessment"
     return "applied"
 
 
@@ -1408,8 +1426,11 @@ def advance_application_status(current: str, incoming: str) -> str:
     two things:
 
     - a TERMINAL status (rejected/accepted/withdrawn/ghosted) is never left, and
-    - an in-flight row only moves FORWARD (applied → interviewing → offered),
-      or to ``rejected`` on a rejection. It never downgrades.
+    - an in-flight row only moves FORWARD (applied → assessment → interviewing
+      → offered), or to ``rejected`` on a rejection. It never downgrades — so a
+      re-test mailed to a row already at ``interviewing`` leaves it there, and
+      that deadline still lands, because ``due_at`` is recomputed from the mail
+      independently of the status.
 
     What it does NOT know is who owns the row. "Never overrides a status the
     USER settled" is a separate rule that lives entirely in the callers, all in

--- a/backend/jobtracker/database/models.py
+++ b/backend/jobtracker/database/models.py
@@ -86,12 +86,26 @@ class ApplicationStatus(str, Enum):
     body models, ``GET /applications/statuses``, the rollup's rank tables, the
     web's ``<select>`` — derives from here rather than restating it, because
     three hand-written copies is exactly how the board came to offer a stage
-    (``assessment``) the API answers with a 422.
+    (``assessment``) that the API answered with a 422. The word is settable now;
+    the lesson is not about the word but about the copies.
 
-    ``assessment`` is deliberately NOT a member: see :data:`CATEGORY_TO_STATUS`.
+    ``assessment`` IS a member, as of 2026-08-12: see :data:`CATEGORY_TO_STATUS`
+    for the decision and why it changed.
+
+    DECLARATION ORDER IS THE API'S ORDER. ``APPLICATION_STATUSES``, the
+    endpoint's list and the web's mirror all take their order from here, so a
+    member is inserted at its lifecycle position, never appended.
+
+    The member NAMES are what Postgres stores — SQLModel/SQLAlchemy persist an
+    enum's name, not its value — so the ``applicationstatus`` type holds
+    ``'ASSESSMENT'`` while the API speaks ``'assessment'``. Adding a member
+    therefore needs a migration that adds the UPPERCASE label
+    (``b9e42f7c10ad``), and the SQLite suites cannot see that difference because
+    ``sa.Enum`` renders as ``VARCHAR`` there.
     """
 
     APPLIED = "applied"
+    ASSESSMENT = "assessment"
     INTERVIEWING = "interviewing"
     OFFERED = "offered"
     REJECTED = "rejected"
@@ -126,26 +140,55 @@ class EmailCategory(str, Enum):
 # What a classifier verdict means for the application it belongs to — the ONE
 # statement of the category → stage mapping.
 #
-# ``assessment`` is the interesting one, and it is a CATEGORY, not a stage. A
-# message can *be* an assessment request ("complete this take-home"), which is
-# why the classifier predicts it; the application it belongs to is at the
-# interviewing stage, which is what the tracker records. That was already the
-# behaviour in two independent places (``pipeline._STAGE_RANK`` ranks it between
-# applied and interview, and the orphan reconciler filed it as ``interviewing``)
-# and in the web's own stage grouping, which folds
-# ``interviewing``/``interview``/``assessment`` into one column. Promoting it to
-# an ``ApplicationStatus`` would mean an ``ALTER TYPE applicationstatus ADD
-# VALUE`` against live Postgres to encode a distinction the product does not
-# make. So the mapping is stated here once, and the board's <select> offers
-# stages only.
+# ``assessment`` is the interesting one, and it is BOTH a category and a stage.
+# It maps to itself.
+#
+# This reverses the decision recorded here until 2026-08-12, which folded it
+# into ``interviewing`` on the grounds that "the product does not make that
+# distinction". The product's owner does, on his own mail, and that is the
+# authority that settles a vocabulary question: a real message from Roblox was
+# five self-serve timed tasks with a seven-day expiry — no human, no scheduling,
+# no call — and the board said "interviewing" about it. A tracker whose one
+# screen names the wrong thing is wrong, however consistent it is internally.
+#
+# What actually changed, beyond the owner's verdict:
+#
+# - An EXPIRY is a different kind of time from a scheduled slot. Since
+#   ``b7c31e0d94aa`` a row carries ``due_at``, so the difference between "you
+#   must act before Friday" and "someone will meet you on Friday" is now a
+#   fact the schema can hold; a stage that says which one this is makes the
+#   deadline legible instead of decorative.
+# - The rollup had ALREADY ranked it separately (``pipeline._STAGE_RANK`` has
+#   ranked ``assessment`` between applied and interview since it was written).
+#   The old decision cited that ranking as evidence the distinction was not
+#   made, when it was in fact evidence that everything except the enum made it.
+# - The cost cited against it — an ``ALTER TYPE applicationstatus ADD VALUE``
+#   against live Postgres — is real but one-way and cheap; ``b9e42f7c10ad``
+#   does it, forward-only, because Postgres has no ``DROP VALUE``.
+#
+# Deliberately UNCHANGED, so this stays a vocabulary change and not a redesign:
+#
+# - the classifier's category vocabulary (:class:`EmailCategory`, nine values)
+#   and the corpus labelled with it — no retraining, no relabelling;
+# - the terminal set (rejected/accepted/withdrawn/ghosted) — an assessment is
+#   in-flight, so ``assessment`` is not terminal;
+# - the monotonic rule in ``pipeline.advance_application_status`` — mail may
+#   still only push a row FORWARD, so a re-test mailed to a row already at
+#   ``interviewing`` leaves it at ``interviewing`` (its deadline still lands,
+#   because ``due_at`` is recomputed independently of status);
+# - application identity (employer + req_id-or-role) — a second requisition is
+#   still a separate row that starts its own journey.
 #
 # Categories absent from this map (``follow_up``, ``needs_review``, ``other``)
 # assert no stage at all: a follow-up is chasing an application, not a stage of
-# one, and the other two are noise or a holding pen.
+# one, and the other two are noise or a holding pen. That is what keeps the two
+# vocabularies distinct now that they overlap by one member: a category is a
+# claim about a MESSAGE, a status is a fact about an APPLICATION, and only the
+# six categories below say anything about the second.
 CATEGORY_TO_STATUS: dict[EmailCategory, ApplicationStatus] = {
     EmailCategory.APPLIED: ApplicationStatus.APPLIED,
     EmailCategory.PENDING_APPLICATION: ApplicationStatus.APPLIED,
-    EmailCategory.ASSESSMENT: ApplicationStatus.INTERVIEWING,
+    EmailCategory.ASSESSMENT: ApplicationStatus.ASSESSMENT,
     EmailCategory.INTERVIEW: ApplicationStatus.INTERVIEWING,
     EmailCategory.OFFER: ApplicationStatus.OFFERED,
     EmailCategory.REJECTION: ApplicationStatus.REJECTED,

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -39,3 +39,12 @@ pyinstaller>=6.3.0            # Bundle Python as standalone executable
 # isolation, and it spent months skipped because it needed a hand-exported
 # env var. See the module docstring.
 testcontainers[postgres]>=4.15.0
+
+# The SYNC Postgres driver, for Alembic only — never for the app, which is
+# async (asyncpg, in requirements.txt) and does not import this.
+# `alembic/env.py` rewrites a `postgresql+asyncpg` URL to `postgresql+psycopg`
+# because Alembic is purely synchronous, so without this package no migration
+# can be run against Postgres anywhere except a machine that happens to have it:
+# not in CI, not on a fresh laptop. That is how the migration chain came to be
+# exercised only by production. tests/test_migrations_postgres.py needs it.
+psycopg[binary]>=3.2.0

--- a/backend/tests/test_migrations_postgres.py
+++ b/backend/tests/test_migrations_postgres.py
@@ -1,0 +1,380 @@
+"""The Alembic chain, exercised against a REAL Postgres.
+
+WHY THIS MODULE EXISTS
+----------------------
+
+Every other suite in this repo runs on SQLite, where ``sa.Enum`` renders as
+``VARCHAR`` with no constraint. That makes the entire class of enum-label bugs
+invisible: a migration can add the wrong label, in the wrong case, or none at
+all, and 600-odd tests stay green while production 500s on the first write.
+
+The specific bug this was written for: SQLModel/SQLAlchemy persist an enum's
+**name**, so ``applicationstatus`` holds ``'ASSESSMENT'`` while the API speaks
+``'assessment'``. ``ALTER TYPE ... ADD VALUE 'assessment'`` would have been
+valid DDL and then failed every write with ``invalid input value for enum
+applicationstatus: "ASSESSMENT"``. Nothing on SQLite can tell those two apart.
+
+So this module asserts, on Postgres 16:
+
+1. the whole chain applies to a bare database in ONE ``upgrade head``
+   invocation — the way a fresh environment is built, and the case
+   ``env.py``'s single wrapping transaction makes fragile;
+2. the type's labels are exactly ``[s.name for s in ApplicationStatus]``, in
+   the enum's declaration order;
+3. a row written through SQLAlchemy as ``ApplicationStatus.ASSESSMENT``
+   round-trips — and the lowercase spelling is genuinely rejected, so #2 is
+   load-bearing rather than decorative;
+4. the forward-only downgrade remaps rows and leaves the label in place.
+
+Postgres, like ``test_rls_postgres.py``: an explicit
+``JOBTRACKER_TEST_PG_ADMIN_URL`` wins (CI's service container), otherwise a
+throwaway ``postgres:16`` is started via testcontainers, and only a machine
+with neither skips. Alembic is synchronous, so the URL is rewritten to
+``postgresql+psycopg`` — the same swap ``alembic/env.py`` performs.
+
+THE AUTH SHIM IS NOT TEST SCAFFOLDING. ``a8d4ec5fba26`` creates policies over
+``auth.uid()``, which Postgres resolves when the policy is created, so
+``upgrade head`` cannot run on a database that has no ``auth`` schema. In
+production Supabase provides it. Here the fixture provides the same two objects
+before the chain runs; without them this module would report a failure that
+says nothing about the migrations.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.exc import DBAPIError
+
+from jobtracker.database.models import Application, ApplicationStatus
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+ALEMBIC_INI = BACKEND_DIR / "alembic.ini"
+
+# The revision under test, and its parent — named so a rename of the file
+# cannot silently turn the downgrade test into a test of some other revision.
+ASSESSMENT_REVISION = "b9e42f7c10ad"
+PARENT_REVISION = "b7c31e0d94aa"
+
+OWNER = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+def _resolve_admin_url() -> tuple[str | None, Any]:
+    """Find a Postgres, starting one if that is what it takes.
+
+    Same three-step resolution as ``test_rls_postgres.py``, and for the same
+    reason: a suite that skips unless a human exported an environment variable
+    is a suite that never runs, and a skip is green.
+    """
+
+    explicit = os.environ.get("JOBTRACKER_TEST_PG_ADMIN_URL")
+    if explicit:
+        return explicit, None
+
+    try:
+        from testcontainers.community.postgres import PostgresContainer
+    except Exception:  # pragma: no cover - machine without the test extra
+        return None, None
+
+    try:
+        container = PostgresContainer("postgres:16")
+        container.start()
+    except Exception:  # pragma: no cover - no docker daemon, or it refused
+        return None, None
+
+    return container.get_connection_url(), container
+
+
+ADMIN_URL, _OWNED_CONTAINER = _resolve_admin_url()
+
+
+def teardown_module(module) -> None:  # noqa: ANN001 - pytest hook signature
+    """Stop the container we started, if we started one."""
+
+    if _OWNED_CONTAINER is not None:
+        _OWNED_CONTAINER.stop()
+
+
+pytestmark = pytest.mark.skipif(
+    not ADMIN_URL,
+    reason=(
+        "No Postgres available: set JOBTRACKER_TEST_PG_ADMIN_URL, or run Docker "
+        "so a throwaway postgres:16 can be started. Skipping leaves the "
+        "migration chain — and every enum label in it — UNVERIFIED on this run, "
+        "because the SQLite suites render sa.Enum as VARCHAR and cannot see it."
+    ),
+)
+
+
+def _sync_url() -> str:
+    """The admin URL with a synchronous driver, whatever scheme it arrived in.
+
+    Alembic is purely synchronous. CI hands this module the ``+asyncpg`` URL it
+    gives the RLS suite, and testcontainers offers ``+psycopg2``; both become
+    ``+psycopg`` (v3), which is what ``alembic/env.py`` itself swaps to.
+    """
+
+    return (
+        make_url(ADMIN_URL)
+        .set(drivername="postgresql+psycopg")
+        .render_as_string(hide_password=False)
+    )
+
+
+def _alembic(command_name: str, revision: str) -> str:
+    """Run one Alembic command against the test database, in a SUBPROCESS.
+
+    ``DIRECT_URL`` is how production points Alembic at the non-pooler Postgres,
+    and it is the first URL ``env.py`` looks for — so this drives exactly the
+    resolution path a deploy uses, through the same CLI a deploy invokes.
+
+    A subprocess rather than ``alembic.command`` in-process, and not for
+    tidiness: ``env.py`` calls ``fileConfig(alembic.ini)``, which reconfigures
+    the ROOT logging config of whatever process runs it. In-process that
+    silently disabled propagation for every logger pytest was capturing, and two
+    unrelated tests in ``test_reopen_after_rejection.py`` — which assert on the
+    "Reopened" log line — went red purely from import order. Measured, not
+    theorised.
+    """
+
+    env = dict(os.environ, DIRECT_URL=_sync_url())
+    proc = subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", str(ALEMBIC_INI), command_name, revision],
+        cwd=str(BACKEND_DIR),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"alembic {command_name} {revision} failed ({proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    return proc.stdout + proc.stderr
+
+
+def _enum_labels(engine: Engine, type_name: str = "applicationstatus") -> list[str]:
+    """The type's labels in ``pg_enum`` sort order — i.e. lifecycle order."""
+
+    with engine.connect() as c:
+        return [
+            row[0]
+            for row in c.execute(
+                text(
+                    "SELECT e.enumlabel FROM pg_enum e "
+                    "JOIN pg_type t ON t.oid = e.enumtypid "
+                    "WHERE t.typname = :name ORDER BY e.enumsortorder"
+                ),
+                {"name": type_name},
+            )
+        ]
+
+
+def _insert_application(engine: Engine, status: ApplicationStatus, company: str) -> int:
+    """Insert one row THROUGH SQLAlchemy, so the Enum bind processor is used.
+
+    Raw SQL would prove nothing here: the question is what the ORM sends for
+    ``ApplicationStatus.ASSESSMENT``, not what Postgres accepts when a test
+    types the label by hand.
+    """
+
+    now = datetime(2026, 8, 12, 12, 0, 0)
+    with engine.begin() as c:
+        return c.execute(
+            sa.insert(Application.__table__)
+            .values(
+                user_id=OWNER,
+                company=company,
+                position="Software Engineer",
+                status=status,
+                created_at=now,
+                updated_at=now,
+            )
+            .returning(Application.__table__.c.id)
+        ).scalar_one()
+
+
+@pytest.fixture
+def engine() -> Iterator[Engine]:
+    """A bare database with Supabase's auth objects and nothing else."""
+
+    eng = sa.create_engine(_sync_url(), poolclass=sa.pool.NullPool)
+    with eng.begin() as c:
+        c.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        c.execute(text("CREATE SCHEMA public"))
+        c.execute(text("CREATE SCHEMA IF NOT EXISTS auth"))
+        c.execute(text("CREATE TABLE IF NOT EXISTS auth.users (id uuid primary key)"))
+        c.execute(
+            text(
+                "CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid "
+                "LANGUAGE sql STABLE AS $$ "
+                "SELECT nullif(current_setting('request.jwt.claims', true)::jsonb "
+                "->> 'sub', '')::uuid $$"
+            )
+        )
+        c.execute(
+            text("INSERT INTO auth.users(id) VALUES (:a) ON CONFLICT DO NOTHING"),
+            {"a": str(OWNER)},
+        )
+    try:
+        yield eng
+    finally:
+        eng.dispose()
+
+
+@pytest.fixture
+def migrated(engine: Engine) -> Engine:
+    """``alembic upgrade head`` — one invocation, from empty, like a new env."""
+
+    _alembic("upgrade", "head")
+    return engine
+
+
+# =============================================================================
+# The chain applies, and the type says what the enum says
+# =============================================================================
+
+
+def test_the_whole_chain_applies_to_a_bare_database_in_one_invocation(
+    migrated: Engine,
+) -> None:
+    """A fresh environment runs every revision in a single upgrade.
+
+    ``env.py`` wraps ALL pending revisions in ONE transaction (it does not set
+    ``transaction_per_migration``), which is why ``b9e42f7c10ad`` adds its enum
+    label inside an ``autocommit_block``: a label added and then USED in the
+    same transaction raises 55P04. Running the chain revision-by-revision would
+    not exercise that at all, so this deliberately goes straight to ``head``.
+    """
+
+    with migrated.connect() as c:
+        assert c.execute(
+            text("SELECT to_regclass('public.applications')")
+        ).scalar_one() is not None
+        assert (
+            c.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            == ASSESSMENT_REVISION
+        )
+
+
+def test_the_enum_labels_are_the_python_enum_names_in_order(migrated: Engine) -> None:
+    """THE check the SQLite suites cannot make.
+
+    Labels are the member NAMES (uppercase), not the API values, because that
+    is what SQLAlchemy persists — and ``ASSESSMENT`` sits where the enum
+    declares it, between ``APPLIED`` and ``INTERVIEWING``, because the migration
+    added it ``BEFORE 'INTERVIEWING'``.
+    """
+
+    labels = _enum_labels(migrated)
+
+    assert labels == [s.name for s in ApplicationStatus]
+    assert labels[:3] == ["APPLIED", "ASSESSMENT", "INTERVIEWING"]
+    # The API's spelling is NOT a label. If this ever passes, the migration
+    # added the value instead of the name and every write is about to 500.
+    assert "assessment" not in labels
+
+
+def test_an_assessment_row_round_trips_through_sqlalchemy(migrated: Engine) -> None:
+    """Write ``ApplicationStatus.ASSESSMENT``, read it back, unchanged.
+
+    The production failure this stands in for: the enum member exists in Python
+    and the type does not know its label, so every insert of an assessment row
+    fails — on the write path only, i.e. after deploy, not at migration time.
+    """
+
+    app_id = _insert_application(migrated, ApplicationStatus.ASSESSMENT, "Roblox")
+
+    with migrated.connect() as c:
+        stored = c.execute(
+            sa.select(Application.__table__.c.status).where(
+                Application.__table__.c.id == app_id
+            )
+        ).scalar_one()
+        raw = c.execute(
+            text("SELECT status::text FROM applications WHERE id = :id"), {"id": app_id}
+        ).scalar_one()
+
+    assert stored is ApplicationStatus.ASSESSMENT
+    assert stored.value == "assessment"  # what the API serves
+    assert raw == "ASSESSMENT"  # what the database stores
+
+    # Every other member still round-trips too — a migration that fixed one
+    # label by breaking the type would otherwise pass the assertions above.
+    for status in ApplicationStatus:
+        got = _insert_application(migrated, status, f"Co-{status.name}")
+        with migrated.connect() as c:
+            assert (
+                c.execute(
+                    sa.select(Application.__table__.c.status).where(
+                        Application.__table__.c.id == got
+                    )
+                ).scalar_one()
+                is status
+            )
+
+
+def test_the_lowercase_spelling_is_rejected_by_the_type(migrated: Engine) -> None:
+    """The positive control for the test above.
+
+    If Postgres accepted ``'assessment'`` as well, "the labels are uppercase"
+    would be an observation with no consequence. It is not: the wrong case is a
+    hard error, which is exactly why the migration had to add ``'ASSESSMENT'``.
+    """
+
+    with pytest.raises(DBAPIError) as excinfo:
+        with migrated.begin() as c:
+            c.execute(
+                text(
+                    "INSERT INTO applications "
+                    "(user_id, company, position, status, created_at, updated_at) "
+                    "VALUES (:u, 'Lowercase Co', 'SWE', 'assessment', now(), now())"
+                ),
+                {"u": str(OWNER)},
+            )
+
+    assert "invalid input value for enum applicationstatus" in str(excinfo.value)
+
+
+# =============================================================================
+# ... and the downgrade is honest about being lossy
+# =============================================================================
+
+
+def test_the_downgrade_remaps_rows_and_leaves_the_label(migrated: Engine) -> None:
+    """Forward-only, stated as a test rather than only as a docstring.
+
+    Postgres has no ``DROP VALUE``, so the label survives the downgrade. The
+    ROWS do not: an assessment becomes an interview, which is the fold this
+    change removed and is real data loss on the way back — the same shape as
+    ``b7c31e0d94aa`` dropping ``due_at``.
+    """
+
+    assessment_id = _insert_application(migrated, ApplicationStatus.ASSESSMENT, "Roblox")
+    applied_id = _insert_application(migrated, ApplicationStatus.APPLIED, "Untouched Co")
+
+    _alembic("downgrade", "-1")
+
+    with migrated.connect() as c:
+        assert (
+            c.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            == PARENT_REVISION
+        )
+        rows = dict(
+            c.execute(text("SELECT id, status::text FROM applications")).all()
+        )
+
+    assert rows[assessment_id] == "INTERVIEWING"
+    assert rows[applied_id] == "APPLIED"  # nothing else is touched
+    # The label is inert, not gone.
+    assert "ASSESSMENT" in _enum_labels(migrated)

--- a/backend/tests/test_scan_classify.py
+++ b/backend/tests/test_scan_classify.py
@@ -196,8 +196,10 @@ async def test_a_scanned_message_is_stored_and_then_corrected(cloud_app):
 
     The message reaches the store, the user's category is the stored verdict,
     the row is marked as theirs, and an application is filed at the stage
-    ``assessment`` maps to (``interviewing`` — assessment is a CATEGORY, not a
-    stage; see CATEGORY_TO_STATUS).
+    ``assessment`` maps to — which, since 2026-08-12, is ``assessment`` itself
+    rather than ``interviewing`` (see CATEGORY_TO_STATUS). This assertion is the
+    end-to-end proof of that change: correcting a mail to ``assessment`` now
+    files a row that SAYS assessment.
 
     Mutation: dropping ``data.message`` in the endpoint → fails (404).
     """
@@ -233,7 +235,7 @@ async def test_a_scanned_message_is_stored_and_then_corrected(cloud_app):
             await session.exec(select(Application).where(Application.id == body["application_id"]))
         ).first()
     assert app is not None
-    assert app.status == ApplicationStatus.INTERVIEWING
+    assert app.status == ApplicationStatus.ASSESSMENT
     assert app.user_id == uuid.UUID(OWNER)
 
 

--- a/backend/tests/test_status_vocabulary.py
+++ b/backend/tests/test_status_vocabulary.py
@@ -8,15 +8,25 @@ Measured against the live app on 2026-08-10: setting a card's stage to
   ``ghosted``;
 - the API enum: 7 values, no ``assessment``, WITH ``ghosted``.
 
-``assessment`` is a classifier CATEGORY, not a stage. A message can *be* an
-assessment request, which is why the classifier predicts it; the application it
-belongs to is at the interviewing stage. That was already the behaviour
-everywhere the two meet (``pipeline._STAGE_RANK`` ranks it between applied and
-interview and ``_rank_to_status`` folds it into ``interviewing``; the orphan
-reconciler files it as ``interviewing``; the web's own stage grouping puts
-``interviewing``/``interview``/``assessment`` in one column). Promoting it to an
-``ApplicationStatus`` would mean an ``ALTER TYPE applicationstatus ADD VALUE``
-against live Postgres to encode a distinction the product does not make.
+``assessment`` is a stage AND a classifier category — as of 2026-08-12. It is
+the one member the two vocabularies share, and it got there by reversing the
+decision this module used to assert.
+
+The old decision folded it into ``interviewing`` because "the product does not
+make that distinction". The product's OWNER does. The mail that settled it was
+five self-serve timed tasks with a seven-day expiry — no human, no scheduling,
+no call — and the board said "interviewing" about it, on the one screen he
+looks at. The distinction was also already made everywhere except the enum:
+``pipeline._STAGE_RANK`` has always ranked ``assessment`` between applied and
+interview, and since ``b7c31e0d94aa`` a row carries ``due_at``, so an expiry and
+a scheduled slot are already different facts in the schema.
+
+What did NOT change, and must not be quietly changed later: the classifier's
+nine-value :class:`EmailCategory` vocabulary and the corpus labelled with it;
+the terminal set; the monotonic rule (an in-flight row only moves forward, so
+``interviewing`` + an assessment mail stays ``interviewing``); and application
+identity. See :data:`jobtracker.database.models.CATEGORY_TO_STATUS` for the
+full statement.
 
 So :class:`ApplicationStatus` is the single definition, ``APPLICATION_STATUSES``
 is derived from it, and these tests fail if any of the four backend restatements
@@ -50,6 +60,7 @@ USER_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 # has to be made deliberately rather than absorbed by a derived assertion.
 EXPECTED_STATUSES = (
     "applied",
+    "assessment",
     "interviewing",
     "offered",
     "rejected",
@@ -132,16 +143,87 @@ def test_the_canonical_list_is_derived_from_the_enum() -> None:
     assert DEFAULT_APPLICATION_STATUS.value in APPLICATION_STATUSES
 
 
-def test_assessment_is_a_classifier_category_and_not_a_stage() -> None:
-    """The decision, stated where a future change has to walk past it."""
+def test_assessment_is_a_stage_as_well_as_a_classifier_category() -> None:
+    """The decision, stated where a future change has to walk past it.
+
+    The mirror image of the test that stood here until 2026-08-12. If this ever
+    starts failing, the fold back into ``interviewing`` was reinstated, and the
+    enum, the rank tables, the Postgres type and the web's mirror all have to
+    have moved with it.
+    """
 
     from jobtracker.cloud import pipeline
 
     assert "assessment" in pipeline.CANONICAL_CATEGORIES
-    assert "assessment" not in APPLICATION_STATUSES
-    assert CATEGORY_TO_STATUS[EmailCategory.ASSESSMENT] is ApplicationStatus.INTERVIEWING
-    # ... and the rollup independently agrees, which is why it is not a stage.
-    assert pipeline._rank_to_status(pipeline._STAGE_RANK["assessment"]) == "interviewing"
+    assert "assessment" in APPLICATION_STATUSES
+    assert CATEGORY_TO_STATUS[EmailCategory.ASSESSMENT] is ApplicationStatus.ASSESSMENT
+    # ... and the rollup agrees: the stage rank it always had now rolls up to
+    # itself instead of folding one stage further along.
+    assert pipeline._rank_to_status(pipeline._STAGE_RANK["assessment"]) == "assessment"
+    # It sits between applied and interviewing, in the enum and in the ranks.
+    assert APPLICATION_STATUSES.index("assessment") == 1
+    assert (
+        pipeline._STATUS_RANK["applied"]
+        < pipeline._STATUS_RANK["assessment"]
+        < pipeline._STATUS_RANK["interviewing"]
+    )
+    # An assessment is in flight, not settled.
+    assert "assessment" not in pipeline._TERMINAL_STATUSES
+
+
+def test_the_two_vocabularies_still_are_not_the_same_list() -> None:
+    """Sharing one member must not make them interchangeable.
+
+    ``assessment`` is now in both, which is exactly when the original defect —
+    treating a classifier category as a stage — becomes easy to reintroduce. A
+    category is a claim about a MESSAGE; a status is a fact about an
+    APPLICATION; the overlap is one word, not a relationship.
+    """
+
+    from jobtracker.cloud import pipeline
+
+    categories = set(pipeline.CANONICAL_CATEGORIES)
+    statuses = set(APPLICATION_STATUSES)
+
+    assert categories & statuses == {"applied", "assessment"}
+    # Categories that are not stages, and stages that are not categories.
+    assert {"follow_up", "needs_review", "other", "interview", "offer", "rejection"} <= categories
+    assert not {"follow_up", "needs_review", "other"} & statuses
+    assert {"interviewing", "offered", "rejected", "withdrawn", "ghosted"} <= statuses
+    assert not {"withdrawn", "ghosted"} & categories
+
+
+def test_the_monotonic_rule_survived_assessment_becoming_a_stage() -> None:
+    """Which moves advance a row, stated as a decision rather than left to luck.
+
+    ``applied`` → ``assessment`` → ``interviewing`` advances, because that is
+    the order the ranks put them in. ``interviewing`` + an assessment mail STAYS
+    ``interviewing``: mail may only push a row forward, and a re-test does not
+    un-interview anybody. That is deliberate and it costs nothing, because the
+    deadline that re-test carries lands via ``due_at``, which is recomputed from
+    the mail independently of the status. A second requisition is a separate row
+    under the existing identity rules and starts its own journey.
+    """
+
+    from jobtracker.cloud.pipeline import advance_application_status as advance
+
+    assert advance("applied", "assessment") == "assessment"
+    assert advance("assessment", "interviewing") == "interviewing"
+    assert advance("assessment", "offered") == "offered"
+    assert advance("applied", "interviewing") == "interviewing"
+
+    # Backwards moves are refused, including the new one.
+    assert advance("interviewing", "assessment") == "interviewing"
+    assert advance("assessment", "applied") == "assessment"
+    assert advance("offered", "assessment") == "offered"
+
+    # A rejection still wins from any in-flight stage, and a terminal status is
+    # still never left.
+    assert advance("assessment", "rejected") == "rejected"
+    assert advance("rejected", "assessment") == "rejected"
+    assert advance("accepted", "assessment") == "accepted"
+    assert advance("withdrawn", "assessment") == "withdrawn"
+    assert advance("ghosted", "assessment") == "ghosted"
 
 
 def test_the_rollup_rank_tables_account_for_every_canonical_status() -> None:
@@ -216,10 +298,16 @@ async def test_the_statuses_endpoint_serves_exactly_the_canonical_list(
 
     assert body["statuses"] == list(EXPECTED_STATUSES)
     assert body["default"] == "applied"
-    assert body["category_to_status"]["assessment"] == "interviewing"
-    # The categories are a DIFFERENT vocabulary and stay visibly different.
+    assert body["category_to_status"]["assessment"] == "assessment"
+    # The categories are a DIFFERENT vocabulary and stay visibly different —
+    # they now overlap on `assessment` (and `applied`), which is the whole
+    # reason the endpoint keeps serving both lists rather than one.
     assert "assessment" in body["classifier_categories"]
-    assert "assessment" not in body["statuses"]
+    assert "assessment" in body["statuses"]
+    assert "follow_up" in body["classifier_categories"]
+    assert "follow_up" not in body["statuses"]
+    assert "ghosted" in body["statuses"]
+    assert "ghosted" not in body["classifier_categories"]
     assert set(body["category_to_status"]) <= set(body["classifier_categories"])
     assert set(body["category_to_status"].values()) <= set(body["statuses"])
 
@@ -262,13 +350,14 @@ async def test_every_canonical_status_is_accepted_by_the_patch_endpoint(
     assert resp.json()["status"] == status_value
 
 
-async def test_a_classifier_category_is_not_settable_as_a_stage(
-    client: AsyncClient,
-) -> None:
-    """``assessment`` is deliberately a 422, and the message names the real list.
+async def test_assessment_is_settable_as_a_stage(client: AsyncClient) -> None:
+    """The mirror of the test that asserted this was a 422.
 
-    If this ever starts passing, the decision above was reversed and the enum,
-    the Postgres type and the rank tables all have to have moved with it.
+    Measured on the live app on 2026-08-10, setting a card to ``assessment``
+    answered ``422 · Input should be 'applied', 'interviewing', ...``. It is a
+    stage now, so it must answer 200 and the row must actually hold it — not be
+    silently coerced to ``interviewing``, which is the failure this whole change
+    exists to end.
     """
 
     created = await client.post(
@@ -283,7 +372,37 @@ async def test_a_classifier_category_is_not_settable_as_a_stage(
         json={"status": "assessment"},
         headers=_headers(),
     )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "assessment"
+
+    fetched = await client.get(f"/applications/{app_id}", headers=_headers())
+    assert fetched.json()["application"]["status"] == "assessment"
+
+
+async def test_a_category_that_is_not_a_stage_is_still_not_settable(
+    client: AsyncClient,
+) -> None:
+    """The guard the inverted test above used to provide, kept alive.
+
+    ``assessment`` moved; the RULE did not. A classifier category that asserts
+    no stage — ``follow_up`` is the clearest, a nudge is not a stage of anything
+    — is still a 422, and the message still names the real list.
+    """
+
+    created = await client.post(
+        "/applications",
+        json={"company": "Acme", "position": "SWE"},
+        headers=_headers(),
+    )
+    app_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/applications/{app_id}",
+        json={"status": "follow_up"},
+        headers=_headers(),
+    )
     assert resp.status_code == 422
+    assert "assessment" in resp.text
     assert "interviewing" in resp.text
 
 

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -1,10 +1,10 @@
 {
   "$comment": "Recorded facts for README.md \u2014 figures that require executing something. Regenerate with `python3 scripts/readme_facts.py --record`, then apply with `--write`. Do not hand-edit: the point of this file is that these numbers have a command behind them.",
-  "recordedAt": "2026-08-11",
+  "recordedAt": "2026-08-12",
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 534,
+      "value": 634,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,19 +12,19 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 58.29,
+      "value": 58.6,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 9335,
+      "value": 9418,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3894,
+      "value": 3899,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
-      "value": 87.7,
+      "value": 87.9,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageAuth": {
@@ -32,7 +32,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageDatabase": {
-      "value": 77.4,
+      "value": 77.5,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScriptsStatements": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 534,
+    "passed": 634,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
`assessment` becomes a real `ApplicationStatus` instead of being folded into `interviewing`.

The mail that settled it was five self-serve timed tasks with a seven-day expiry — no human, no scheduling, no call — and the board called it "interviewing". Everything except the enum already made the distinction: `pipeline._STAGE_RANK` has always ranked `assessment` between applied and interview, and since `b7c31e0d94aa` a row carries `due_at`, so an expiry and a scheduled slot are already different facts in the schema.

## What moves

- `ApplicationStatus.ASSESSMENT` between `APPLIED` and `INTERVIEWING` (declaration order is the API's order); `CATEGORY_TO_STATUS[ASSESSMENT] → ASSESSMENT`; `_STATUS_RANK` 1..5; `_rank_to_status` stops folding rank 2.
- Migration `b9e42f7c10ad` adds the **UPPERCASE** label (SQLModel persists an enum's *name*: `'assessment'` would have been valid DDL and then a 500 on every write), inside an `autocommit_block` because `env.py` wraps all pending revisions in one transaction. Forward-only — Postgres has no way to remove a label, so the downgrade remaps rows and leaves it inert.
- Web: `status.ts`, a `StageDef` of its own in `summary.ts` (counted in `inMotion` and `advancedPct`), `PipelinePulse`'s open-rows filter, regenerated `schema.d.ts`, and `AddApplicationForm`'s last hand-written copy of the list now imports the canonical one.

## Unchanged on purpose

The nine-value classifier vocabulary and its corpus, the terminal set, the monotonic rule (`interviewing` + a re-test stays `interviewing`; its deadline still lands via `due_at`) and application identity. All four are stated in `CATEGORY_TO_STATUS`'s rationale and pinned by tests.

## The check the rest of the suite cannot make

`backend/tests/test_migrations_postgres.py` applies the whole Alembic chain to a real `postgres:16` through the CLI and asserts the enum labels equal `[s.name for s in ApplicationStatus]` in order, that a row round-trips, that the lowercase spelling is rejected, and that the downgrade is lossy-but-safe. On SQLite `sa.Enum` renders as `VARCHAR`, so none of that is observable there. It runs in `rls-postgres` behind the same "did it actually run" JUnit guard.

Mutation-tested: lowercasing the label fails 4 of 5 migration tests **while the migration itself still succeeds** — exactly the shape of the bug.

## Verification

Backend 634 passed / 0 failed (baseline 625 on `4a022b5`); migration module 5/5 against `postgres:16` both via testcontainers and in the CI shape; web 171 unit / lint / typecheck / `next build`; OpenAPI drift gate clean; `readme_facts --check` green after `--record` (which also caught up 91 tests three earlier commits had left stale in the artifact).

**Not done, deliberately:** `apps/macos` (task #82); the three demo fixtures still filed as `interviewing` (their offsets are `demo.spec.ts`'s contract); and the production database — this lands the migration, it does not apply it.

**Still owed:** the browser e2e pass. `summary.ts` now value-imports `./dates.ts` relatively (with `allowImportingTsExtensions`) so the stage test can read the real `STAGES` instead of a hand-written copy; Playwright's own TS transform has not been exercised against that nested `.ts` → `.ts` chain.
