### PR TITLE
chore(deps): bump zod to 4.4.3 and migrate lib/env.ts to the zod 4 API

### DIFF
--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -14,27 +14,63 @@
  */
 import { z } from "zod";
 
+/**
+ * zod 4 removed `required_error`/`invalid_type_error` in favour of a single
+ * `error` callback, so the "you forgot to set this" case is no longer a
+ * separate option — the schema has to discriminate for itself. A key that is
+ * absent from `process.env` reaches the callback as an `invalid_type` issue
+ * whose `input` is `undefined`; anything else is a value that was set but is
+ * the wrong shape.
+ *
+ * Keeping the two messages apart is the entire point of this file: "is
+ * required" tells you to add the variable to `.env.local` or the Vercel
+ * project, while "must be a valid URL" tells you the value you already set is
+ * wrong. Collapsing them into one string would still fail the build, but
+ * would fail it uninformatively.
+ */
+const missingOrInvalid =
+  (missing: string, invalid: string) =>
+  (issue: { input: unknown }): string =>
+    issue.input === undefined ? missing : invalid;
+
 const publicSchema = z.object({
-  NEXT_PUBLIC_SUPABASE_URL: z
-    .string({ required_error: "NEXT_PUBLIC_SUPABASE_URL is required" })
-    .url("NEXT_PUBLIC_SUPABASE_URL must be a valid URL"),
+  // `z.url()` rather than the now-deprecated `z.string().url()`: zod 4 models
+  // string formats as ZodString subclasses on the top-level namespace.
+  NEXT_PUBLIC_SUPABASE_URL: z.url({
+    error: missingOrInvalid(
+      "NEXT_PUBLIC_SUPABASE_URL is required",
+      "NEXT_PUBLIC_SUPABASE_URL must be a valid URL",
+    ),
+  }),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z
-    .string({ required_error: "NEXT_PUBLIC_SUPABASE_ANON_KEY is required" })
+    .string({
+      error: missingOrInvalid(
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY is required",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY must be a string",
+      ),
+    })
+    // A check-level message still outranks the schema-level `error` above, so
+    // an empty-but-present key keeps its own wording.
     .min(1, "NEXT_PUBLIC_SUPABASE_ANON_KEY must not be empty"),
 });
 
 const serverSchema = z.object({
-  BACKEND_API_URL: z
-    .string({ required_error: "BACKEND_API_URL is required" })
-    .url("BACKEND_API_URL must be a valid URL"),
+  BACKEND_API_URL: z.url({
+    error: missingOrInvalid(
+      "BACKEND_API_URL is required",
+      "BACKEND_API_URL must be a valid URL",
+    ),
+  }),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
 });
 
 type PublicEnv = z.infer<typeof publicSchema>;
 type ServerEnv = z.infer<typeof serverSchema>;
 
+// zod 4 removed `ZodError.errors`; `.issues` was always the real property and
+// is now the only one.
 function formatZodError(err: z.ZodError): string {
-  return err.errors
+  return err.issues
     .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
     .join("\n");
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "tailwind-merge": "^3.5.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@playwright/test':
         specifier: ^1.48.0
@@ -2272,8 +2272,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3472,8 +3472,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4643,8 +4643,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
**Supersedes #49.** Dependabot opened that one as a plain version bump, but zod 4 is a breaking API change: the bump alone does not compile. This PR carries the same dependency change *plus* the code migration it needs.

## Why #49 could not merge

On zod 4.4.3, `apps/web/lib/env.ts` produces exactly five TypeScript errors:

```
lib/env.ts(19,15): error TS2769: No overload matches this call.
    ... 'required_error' does not exist in type '{ error?: ...; message?: ... }'
lib/env.ts(22,15): error TS2769: No overload matches this call.  (same cause)
lib/env.ts(28,15): error TS2769: No overload matches this call.  (same cause)
lib/env.ts(37,14): error TS2339: Property 'errors' does not exist on type 'ZodError<unknown>'.
lib/env.ts(38,11): error TS7006: Parameter 'issue' implicitly has an 'any' type.
```

Two removals cause all five:

- **`required_error` is gone.** zod 4 collapsed the separate `required_error` / `invalid_type_error` options into a single `error` callback that must discriminate for itself — an absent key reaches the callback as an `invalid_type` issue whose `input` is `undefined`. Keeping the two messages apart is the whole point of this file: *"is required"* tells you to set the variable, *"must be a valid URL"* tells you the value you already set is wrong.
- **`ZodError.errors` is gone**, renamed to `.issues` (line 38 is a cascade off line 37).

The two URL fields also move from the now-deprecated `z.string().url()` to `z.url()`, which is the shape zod 4 intends — string formats are `ZodString` subclasses on the top-level `z` namespace.

## Scope

`lib/env.ts` is the **only** zod consumer in `apps/web`. Grepping `zod` across every `.ts`/`.tsx`/`.mjs`/`.js`/`.json` in the app returns that single import plus one unrelated comment in `lib/api/server.ts`. Nothing in `lib/dashboard/*`, `components/dashboard/*` or `AddApplicationForm.tsx` touches zod, so there is no overlap with #131. `apps/macos`, `backend/` and `ml/` are untouched.

## Verification

Run in `apps/web` with pnpm 10.33.0 / node 24.9.0.

| Check | Result |
| --- | --- |
| `pnpm typecheck` (before migration) | 5 errors, lines 19/22/28/37/38 |
| `pnpm typecheck` (after) | clean |
| `pnpm lint` | clean |
| `pnpm test:unit` | 169 pass, 0 fail |
| `pnpm build` | succeeds, 30 routes |
| `pnpm install --frozen-lockfile` | up to date — the lockfile CI installs from |

Lockfile diff is 9 insertions / 9 deletions, identical in size to #49's: no unrelated resolution churn.

### Mutation test of the validator

This schema exists to fail loudly, and a migration that leaves it silently accepting everything would not show up as a type error. So the validator was mutation-tested directly, one **fresh process per scenario** (ESM module caching would otherwise fake a pass on the second import), and with vars genuinely *deleted* rather than blanked — only a truly absent var takes the `invalid_type` / `input === undefined` path that replaced `required_error`.

```
[green]                 ACCEPTED — no error thrown
[unset-public-url]      REJECTED — [env] invalid public environment variables:
  - NEXT_PUBLIC_SUPABASE_URL: NEXT_PUBLIC_SUPABASE_URL is required
[unset-backend-url]     REJECTED — [env] invalid server environment variables:
  - BACKEND_API_URL: BACKEND_API_URL is required
[malformed-public-url]  REJECTED — [env] invalid public environment variables:
  - NEXT_PUBLIC_SUPABASE_URL: NEXT_PUBLIC_SUPABASE_URL must be a valid URL
[empty-anon-key]        REJECTED — [env] invalid public environment variables:
  - NEXT_PUBLIC_SUPABASE_ANON_KEY: NEXT_PUBLIC_SUPABASE_ANON_KEY must not be empty
```

The last two are permissiveness controls: a var that is *set but wrong* must still reject, with its own wording, and it does.

And the app genuinely refuses to start — `next build` with `NEXT_PUBLIC_SUPABASE_URL` absent exits 1:

```
  Collecting page data using 9 workers ...
Error: [env] invalid public environment variables:
  - NEXT_PUBLIC_SUPABASE_URL: NEXT_PUBLIC_SUPABASE_URL is required
> Build error occurred
Error: Failed to collect page data for /api/account/delete
```

Restoring the variable returns the build to green (the 30-route build above).

### One thing that was not safe to assume

zod 4 reimplemented URL validation as a `ZodString` subclass rather than keeping the v3 refinement, so `z.url()` was probed before use: it still accepts `http://localhost:8000`, which is what `frontend-ci.yml` sets for `BACKEND_API_URL` and what local dev uses. It still rejects `""` and `"not-a-url"`.

## Notes

- Vercel checks on this PR are expected to be red — the account is at its daily deployment cap. Nothing here affects deployability.
- Playwright/e2e was deliberately not run here; it is covered separately.
- The env schema still has no permanent regression test. The mutation run above was a throwaway harness, deleted. Worth adding a `tests/unit/env.test.mjs` at some point, but that is scope beyond this bump.
