### PR TITLE
fix(classifier): scope the embeddings layer to a single user

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-634%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-643%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -375,7 +375,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**634 tests collected, 0 skipped.** These figures were recorded on 2026-08-12 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 542 `test_*` functions across 38 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity, RLS and migration-chain work, four of which brought their own module (`test_status_vocabulary.py`, `test_application_identity.py`, `test_rls_postgres.py`, `test_migrations_postgres.py`). The bold 634 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**643 tests collected, 0 skipped.** These figures were recorded on 2026-08-12 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 551 `test_*` functions across 39 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity, RLS and migration-chain work, four of which brought their own module (`test_status_vocabulary.py`, `test_application_identity.py`, `test_rls_postgres.py`, `test_migrations_postgres.py`). The bold 643 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
@@ -383,7 +383,7 @@ Those tests drive the production machinery, not a fixture: `jobtracker.database.
 
 `test_migrations_postgres.py` rides in the same job, for a defect the rest of the suite is structurally blind to: on SQLite, `sa.Enum` renders as `VARCHAR`, so a migration can add an enum label in the wrong case and every other test stays green while production 500s on the first write. It applies the whole Alembic chain to a bare database through the real CLI, then asserts the `applicationstatus` labels are the Python enum's member names in declaration order, that a row round-trips, and that the lowercase spelling is genuinely rejected. It is guarded by the same "did it actually run" JUnit check as the RLS suite.
 
-**Coverage**, from the same run: **58.60%** overall — 9,418 statements, 3,899 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.9%**; `auth` 80.5%; `database` 77.5%. What pulls the average down is `jobtracker/scripts` at 2,358 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
+**Coverage**, from the same run: **59.19%** overall — 9,455 statements, 3,859 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **87.9%**; `auth` 80.5%; `database` 77.5%. What pulls the average down is `jobtracker/scripts` at 2,357 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -538,7 +538,7 @@ applied/
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
 │   ├── alembic/versions/    # 12 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 38 modules
+│   └── tests/               # 39 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/backend/jobtracker/classifier/embeddings.py
+++ b/backend/jobtracker/classifier/embeddings.py
@@ -10,14 +10,56 @@ Embeddings are stored in SQLite (email_embeddings table) for persistence.
 """
 
 import logging
+import uuid
 from typing import Optional
 
 import numpy as np
 
 from jobtracker.config import settings
-from jobtracker.database.models import EmailCategory
+from jobtracker.database.models import LOCAL_USER_ID, EmailCategory
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Ownership
+# =============================================================================
+#
+# Every row in ``email_embeddings`` belongs to exactly one user, and this layer
+# may only ever see one user's rows at a time. Two defences, mirroring the ones
+# ``setfit_model.py`` already applies to layer 3:
+#
+#   1. The corpus read carries a ``WHERE user_id = ...``.
+#   2. The loaded rows are re-checked against the requested owner, derived from
+#      the rows themselves rather than from a caller's promise, so a refactor
+#      that deletes the ``WHERE`` as "redundant" fails loudly instead of
+#      silently pooling tenants.
+#
+# Defence 2 is unreachable while defence 1 holds — that is the point of belt
+# and braces. Postgres RLS is a third layer underneath both, but it cannot
+# help here: the in-memory cache below serves later requests without issuing a
+# query at all, so no policy is ever evaluated. Scoping has to be stated in
+# this file.
+
+
+class CrossUserEmbeddingError(RuntimeError):
+    """Raised when a loaded corpus contains rows owned by more than one user."""
+
+
+def resolve_embedding_user_id() -> uuid.UUID:
+    """Owner whose examples this layer may read and write, for this request.
+
+    Reads the RLS identity bound by the cloud auth dependency (see
+    ``database.connection.set_current_user_id``) and falls back to the
+    ``LOCAL_USER_ID`` sentinel that every desktop row carries. Deliberately a
+    three-line twin of ``setfit_model.resolve_training_user_id`` rather than a
+    shared import: ``setfit_model`` pulls torch, and the cloud import graph
+    must never reach it from here.
+    """
+
+    from jobtracker.database import get_current_user_id
+
+    return get_current_user_id() or LOCAL_USER_ID
 
 
 # =============================================================================
@@ -212,39 +254,97 @@ class EmbeddingsClassifier:
         self._model = EmbeddingModel()
         self._known_embeddings: list[tuple[np.ndarray, EmailCategory]] = []
         self._loaded = False
+        # WHOSE examples ``_known_embeddings`` currently holds. This instance is
+        # a process-global singleton (see ``get_embeddings_classifier``), so a
+        # bare ``_loaded`` boolean meant the first request to warm the cache
+        # answered every later request in the same process — including
+        # requests from a different user. The cache is keyed by owner instead.
+        self._loaded_user_id: Optional[uuid.UUID] = None
+        # Set by ``pin_empty_corpus`` for the evaluation harness only.
+        self._pinned = False
 
     def is_available(self) -> bool:
         """Check if the embedding model is available."""
         return self._model.is_available()
 
-    async def load_known_embeddings(self):
-        """Load all known embeddings from the database."""
-        if self._loaded:
+    async def _load_rows(self, session, *, user_id: uuid.UUID) -> list:
+        """Read exactly one owner's stored examples.
+
+        Split out from :meth:`load_known_embeddings` so the ownership check
+        there can be exercised the way a dropped ``WHERE`` would present.
+        """
+
+        from sqlalchemy import select
+
+        from jobtracker.database.models import EmailEmbedding
+
+        result = await session.exec(
+            select(EmailEmbedding).where(EmailEmbedding.user_id == user_id)
+        )
+        # ``exec`` yields Row tuples for a SQLAlchemy select, model instances
+        # for a SQLModel one. Normalise so the ownership check can read
+        # ``.user_id`` either way.
+        return [row[0] if hasattr(row, "__getitem__") else row for row in result.all()]
+
+    @staticmethod
+    def _assert_single_user_corpus(rows: list, *, user_id: uuid.UUID) -> None:
+        """Refuse a corpus that contains anyone but ``user_id``."""
+
+        foreign = {row.user_id for row in rows if row.user_id != user_id}
+        if not foreign:
+            return
+        raise CrossUserEmbeddingError(
+            "Embedding corpus is not single-user: requested "
+            f"user_id={user_id}, but it also contains {sorted(map(str, foreign))}. "
+            "Layer 2 may only ever compare against the caller's own examples."
+        )
+
+    async def load_known_embeddings(self, *, user_id: Optional[uuid.UUID] = None):
+        """Load one user's known embeddings from the database.
+
+        Args:
+            user_id: Whose examples to load. Defaults to the identity bound to
+                the current request; there is deliberately no "all users"
+                value.
+        """
+        if self._pinned:
+            return
+
+        target = user_id or resolve_embedding_user_id()
+
+        if self._loaded and self._loaded_user_id == target:
             return
 
         try:
-            from sqlalchemy import select
-
             from jobtracker.database import get_session
-            from jobtracker.database.models import EmailEmbedding
 
             self._known_embeddings = []
+            self._loaded = False
+            self._loaded_user_id = None
 
             async with get_session() as session:
-                result = await session.exec(select(EmailEmbedding))
-                embeddings = result.all()
+                rows = await self._load_rows(session, user_id=target)
+                self._assert_single_user_corpus(rows, user_id=target)
 
-                for row in embeddings:
-                    # Extract from Row if needed
-                    emb = row[0] if hasattr(row, "__getitem__") else row
+                for emb in rows:
                     if emb.embedding:
                         embedding_array = bytes_to_embedding(emb.embedding)
                         category = EmailCategory(emb.label)
                         self._known_embeddings.append((embedding_array, category))
 
             self._loaded = True
-            logger.info(f"Loaded {len(self._known_embeddings)} known embeddings")
+            self._loaded_user_id = target
+            logger.info(
+                "Loaded %d known embeddings for user %s",
+                len(self._known_embeddings),
+                target,
+            )
 
+        except CrossUserEmbeddingError:
+            # Must escape the catch-all below: a corpus that pools tenants is
+            # not a degraded classification, it is a bug that has to be seen.
+            self._known_embeddings = []
+            raise
         except Exception as e:
             logger.error(f"Failed to load known embeddings: {e}")
             self._known_embeddings = []
@@ -253,20 +353,30 @@ class EmbeddingsClassifier:
         """Check if there are any known examples for similarity matching."""
         return len(self._known_embeddings) > 0
 
-    async def get_example_count(self) -> int:
-        """Get count of embeddings from database (for status reporting)."""
+    async def get_example_count(self, *, user_id: Optional[uuid.UUID] = None) -> int:
+        """Count one user's stored embeddings (for status reporting).
+
+        Scoped like every other read here. The previous raw
+        ``SELECT COUNT(*) FROM email_embeddings`` reported the whole table,
+        which on a multi-tenant database is another user's row count.
+        """
+        target = user_id or resolve_embedding_user_id()
         try:
-            from sqlalchemy import func, select, text
+            from sqlalchemy import func, select
 
             from jobtracker.database import get_session
+            from jobtracker.database.models import EmailEmbedding
 
             async with get_session() as session:
-                # Use raw SQL for simple count to avoid ORM complexity
                 result = await session.exec(
-                    text("SELECT COUNT(*) FROM email_embeddings")
+                    select(func.count())
+                    .select_from(EmailEmbedding)
+                    .where(EmailEmbedding.user_id == target)
                 )
                 row = result.first()
-                return row[0] if row else 0
+                if row is None:
+                    return 0
+                return int(row[0] if hasattr(row, "__getitem__") else row)
         except Exception:
             return 0
 
@@ -274,6 +384,8 @@ class EmbeddingsClassifier:
         self,
         subject: str,
         body: str,
+        *,
+        user_id: Optional[uuid.UUID] = None,
     ) -> Optional[tuple[EmailCategory, float]]:
         """
         Classify an email using embedding similarity.
@@ -281,6 +393,8 @@ class EmbeddingsClassifier:
         Args:
             subject: Email subject
             body: Email body text
+            user_id: Whose examples may be compared against. Defaults to the
+                identity bound to the current request.
 
         Returns:
             (category, confidence) if similar example found, None otherwise
@@ -288,8 +402,10 @@ class EmbeddingsClassifier:
         if not self.is_available():
             return None
 
-        # Ensure known embeddings are loaded
-        await self.load_known_embeddings()
+        target = user_id or resolve_embedding_user_id()
+
+        # Ensure this user's known embeddings are loaded
+        await self.load_known_embeddings(user_id=target)
 
         if not self.has_known_examples():
             return None
@@ -316,6 +432,8 @@ class EmbeddingsClassifier:
         subject: str,
         body: str,
         category: EmailCategory,
+        *,
+        user_id: Optional[uuid.UUID] = None,
     ):
         """
         Add a new labeled example to the embeddings store.
@@ -327,10 +445,17 @@ class EmbeddingsClassifier:
             subject: Email subject
             body: Email body
             category: Correct category (from user)
+            user_id: Who made the correction. Defaults to the identity bound
+                to the current request. Scoping the reads without stamping
+                this would be worse than the leak it fixes — every correction
+                would land on ``LOCAL_USER_ID`` and real users would then
+                match against an empty corpus forever.
         """
         if not self.is_available():
             logger.warning("Cannot add example: embedding model not available")
             return
+
+        target = user_id or resolve_embedding_user_id()
 
         # Create embedding
         text = f"{subject}\n\n{body}"
@@ -346,9 +471,15 @@ class EmbeddingsClassifier:
             from jobtracker.database.models import EmailEmbedding
 
             async with get_session() as session:
-                # Check if already exists
+                # Check if already exists — for this owner. ``email_id`` is
+                # globally unique today, but matching on it alone would let a
+                # correction silently overwrite a row it does not own if that
+                # ever stops being true.
                 result = await session.exec(
-                    select(EmailEmbedding).where(EmailEmbedding.email_id == email_id)
+                    select(EmailEmbedding).where(
+                        EmailEmbedding.user_id == target,
+                        EmailEmbedding.email_id == email_id,
+                    )
                 )
                 existing = result.first()
 
@@ -361,6 +492,7 @@ class EmbeddingsClassifier:
                 else:
                     # Create new
                     new_embedding = EmailEmbedding(
+                        user_id=target,
                         email_id=email_id,
                         label=category.value,
                         embedding=embedding_to_bytes(embedding),
@@ -370,18 +502,42 @@ class EmbeddingsClassifier:
 
                 await session.commit()
 
-            # Add to in-memory cache
-            self._known_embeddings.append((embedding, category))
+            # Add to the in-memory cache only when it already holds THIS
+            # owner's corpus. Appending into a cache warmed by someone else is
+            # the write-side version of the leak this scoping exists to close.
+            if self._loaded and self._loaded_user_id == target:
+                self._known_embeddings.append((embedding, category))
             logger.info(
-                f"Added embedding for email {email_id} with label {category.value}"
+                "Added embedding for email %s with label %s (user %s)",
+                email_id,
+                category.value,
+                target,
             )
 
         except Exception as e:
             logger.error(f"Failed to save embedding: {e}")
 
+    def pin_empty_corpus(self) -> None:
+        """Serve no examples to anyone until :meth:`reload` is called.
+
+        The evaluation harness's ``deterministic`` profile needs layer 2 to
+        contribute nothing, so a benchmark score never depends on whatever
+        happens to be in the local database. It used to express that by
+        setting ``_loaded = True`` with an empty list; now that the load
+        short-circuit is keyed by owner, that would no longer hold for a
+        caller whose identity differs from the cached one. Say it explicitly
+        instead of relying on the shape of the cache key.
+        """
+        self._known_embeddings = []
+        self._loaded = True
+        self._loaded_user_id = None
+        self._pinned = True
+
     def reload(self):
         """Force reload of known embeddings on next classify call."""
         self._loaded = False
+        self._loaded_user_id = None
+        self._pinned = False
         self._known_embeddings = []
 
 

--- a/backend/jobtracker/scripts/evaluate_classifier.py
+++ b/backend/jobtracker/scripts/evaluate_classifier.py
@@ -336,9 +336,11 @@ def _configure_hybrid_profile(classifier: HybridClassifier, profile: str) -> Non
         classifier.set_lite_mode(True)
         embeddings = getattr(classifier, "_embeddings", None)
         if embeddings is not None:
-            # Prevent DB/stateful embedding examples from affecting benchmark outcomes.
-            embeddings._known_embeddings = []
-            embeddings._loaded = True
+            # Prevent DB/stateful embedding examples from affecting benchmark
+            # outcomes. Must go through ``pin_empty_corpus``: the layer's load
+            # cache is keyed by owner, so poking ``_loaded`` alone no longer
+            # stops a re-read for a caller with a different identity.
+            embeddings.pin_empty_corpus()
         return
 
     raise ValueError(f"Unsupported hybrid profile: {profile}")

--- a/backend/tests/test_embeddings_are_user_scoped.py
+++ b/backend/tests/test_embeddings_are_user_scoped.py
@@ -1,0 +1,398 @@
+"""Classifier layer 2 (embeddings) must never read another user's examples.
+
+``email_embeddings`` carries a ``user_id`` column and is one of the eight
+tables under RLS (see ``alembic/versions/a8d4ec5fba26``), so the row store is
+per-tenant by construction. The *reader* was not: ``load_known_embeddings``
+issued a bare ``select(EmailEmbedding)`` and every stored example — whoever
+owned it — became a candidate neighbour for whoever happened to be asking.
+
+Two independent leaks live in that one layer, and only one of them is
+something RLS could have caught:
+
+1. **The query.** On Postgres a policy would have clipped the unscoped
+   ``SELECT`` back to the caller. On SQLite (desktop, and every test in this
+   repo) there is no RLS at all, so the ``WHERE`` is the only defence. Same
+   reasoning as ``test_training_is_single_user.py``, which says it outright:
+   "RLS is additive security, not the primary check."
+
+2. **The cache.** ``EmbeddingsClassifier`` is a process-global singleton
+   (``get_embeddings_classifier``) holding ``_known_embeddings`` behind a
+   boolean ``_loaded`` flag. The first request to touch it populated that
+   list; every later request in the same process short-circuited on
+   ``_loaded`` and reused it. No query runs on the second request, so **no
+   policy is ever evaluated** — RLS cannot see this one, on any backend. The
+   cache must therefore be keyed by owner, not by "have we loaded yet".
+
+The writes matter as much as the reads: ``add_example`` built an
+``EmailEmbedding`` with no ``user_id``, so every cloud correction landed on
+the ``LOCAL_USER_ID`` sentinel. Scoping reads without stamping writes would
+turn a leak into silent data loss (real users would match nothing), so both
+directions are pinned here.
+
+The e5-small-v2 model is stubbed throughout — these tests are about ownership,
+and must not download 80 MB to say so.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from jobtracker.classifier.embeddings import (
+    EmbeddingModel,
+    EmbeddingsClassifier,
+    embedding_to_bytes,
+)
+from jobtracker.database.connection import user_id_scope
+from jobtracker.database.models import LOCAL_USER_ID, EmailCategory, EmailEmbedding
+
+USER_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+USER_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+# =============================================================================
+# Deterministic stand-in vectors
+# =============================================================================
+#
+# A's example and B's example are orthogonal unit vectors, so a query equal to
+# one of them scores cosine 1.0 against it and 0.0 against the other — well
+# either side of the 0.85 acceptance threshold. A match reported for the wrong
+# vector is unambiguously the wrong user's row, never a near miss.
+
+_DIM = EmbeddingModel.EMBEDDING_DIM
+
+
+def _unit(axis: int) -> np.ndarray:
+    vector = np.zeros(_DIM, dtype=np.float32)
+    vector[axis] = 1.0
+    return vector
+
+
+VEC_A = _unit(0)
+VEC_B = _unit(1)
+VEC_UNRELATED = _unit(2)
+
+# Markers the stub encoder recognises inside "<subject>\n\n<body>".
+TEXT_LIKE_A = "MATCHES-A"
+TEXT_LIKE_B = "MATCHES-B"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+async def embeddings_db(monkeypatch: pytest.MonkeyPatch):
+    """In-memory DB wired in as ``jobtracker.database.get_session``.
+
+    ``embeddings.py`` imports ``get_session`` *inside* each method body, so
+    patching the attribute on the package is picked up by late binding.
+    """
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    @asynccontextmanager
+    async def _fake_get_session() -> AsyncIterator[AsyncSession]:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            yield session
+
+    import jobtracker.database as database_pkg
+
+    monkeypatch.setattr(database_pkg, "get_session", _fake_get_session)
+
+    async def _seed(
+        user_id: uuid.UUID,
+        category: EmailCategory,
+        vector: np.ndarray,
+        *,
+        email_id: int,
+    ) -> None:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            session.add(
+                EmailEmbedding(
+                    user_id=user_id,
+                    email_id=email_id,
+                    label=category.value,
+                    embedding=embedding_to_bytes(vector),
+                )
+            )
+            await session.commit()
+
+    async def _rows() -> list[EmailEmbedding]:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            result = await session.exec(select(EmailEmbedding))
+            return list(result.all())
+
+    yield SimpleNamespace(seed=_seed, rows=_rows)
+
+    await engine.dispose()
+
+
+@pytest.fixture
+def stub_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap e5-small-v2 for a lookup table so nothing is downloaded."""
+
+    def _encode(_self: EmbeddingModel, text: str) -> np.ndarray:
+        if TEXT_LIKE_A in text:
+            return VEC_A
+        if TEXT_LIKE_B in text:
+            return VEC_B
+        return VEC_UNRELATED
+
+    monkeypatch.setattr(EmbeddingModel, "is_available", lambda _self: True)
+    monkeypatch.setattr(EmbeddingModel, "encode", _encode)
+
+
+async def _seed_both_users(embeddings_db) -> None:
+    """One example each, orthogonal, different labels."""
+
+    await embeddings_db.seed(USER_A, EmailCategory.OFFER, VEC_A, email_id=1)
+    await embeddings_db.seed(USER_B, EmailCategory.REJECTION, VEC_B, email_id=2)
+
+
+def _labels(classifier: EmbeddingsClassifier) -> list[EmailCategory]:
+    return [category for _vector, category in classifier._known_embeddings]
+
+
+# =============================================================================
+# 1. The corpus read is scoped to the caller
+# =============================================================================
+
+
+async def test_load_known_embeddings_reads_only_the_bound_user(
+    embeddings_db, stub_model
+) -> None:
+    """Two owners in the table; a load sees exactly the bound one."""
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        await classifier.load_known_embeddings()
+
+    assert _labels(classifier) == [EmailCategory.OFFER], (
+        "user A's embeddings layer loaded another tenant's examples: "
+        f"{_labels(classifier)}"
+    )
+
+
+async def test_a_prediction_cannot_be_decided_by_another_users_example(
+    embeddings_db, stub_model
+) -> None:
+    """The claim, stated as behaviour.
+
+    User A asks about a message whose embedding is *identical* to user B's
+    stored ``rejection`` example and unrelated to anything A owns. A has no
+    neighbour for it, so the honest answer is "no match". Any verdict at all
+    here is B's label deciding A's classification.
+    """
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        result = await classifier.classify(TEXT_LIKE_B, "body text")
+
+    assert result is None, (
+        "user A's prediction was decided by user B's stored example: "
+        f"got {result}"
+    )
+
+
+# =============================================================================
+# 2. The per-process cache is keyed by owner, not by "already loaded"
+# =============================================================================
+
+
+async def test_cached_examples_do_not_survive_a_change_of_user(
+    embeddings_db, stub_model
+) -> None:
+    """The variant RLS cannot catch.
+
+    ``get_embeddings_classifier()`` hands the same instance to every request
+    in a process, so this two-load sequence on one instance is exactly what a
+    request from A followed by a request from B does. B's load must re-read,
+    not short-circuit on a flag that A set.
+    """
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        await classifier.load_known_embeddings()
+    with user_id_scope(USER_B):
+        await classifier.load_known_embeddings()
+
+    assert _labels(classifier) == [EmailCategory.REJECTION], (
+        "user B was served user A's cached examples: " f"{_labels(classifier)}"
+    )
+
+
+async def test_a_warm_process_does_not_answer_the_next_user_from_cache(
+    embeddings_db, stub_model
+) -> None:
+    """Same shape, driven through ``classify()`` — the real request path.
+
+    A's request warms the process. B then asks about a message identical to
+    A's ``offer`` example. B owns no such example, so B must get no match.
+    """
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        await classifier.classify(TEXT_LIKE_A, "body text")
+
+    with user_id_scope(USER_B):
+        result = await classifier.classify(TEXT_LIKE_A, "body text")
+
+    assert result is None, (
+        "a warm process answered user B out of user A's cache: " f"got {result}"
+    )
+
+
+# =============================================================================
+# 3. Counts and writes carry the same owner
+# =============================================================================
+
+
+async def test_example_count_counts_only_the_bound_user(
+    embeddings_db, stub_model
+) -> None:
+    """``GET /classify/status`` reports a per-user total, not a global one."""
+
+    await embeddings_db.seed(USER_A, EmailCategory.OFFER, VEC_A, email_id=1)
+    await embeddings_db.seed(USER_B, EmailCategory.REJECTION, VEC_B, email_id=2)
+    await embeddings_db.seed(USER_B, EmailCategory.INTERVIEW, VEC_UNRELATED, email_id=3)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        count = await classifier.get_example_count()
+
+    assert count == 1, f"status leaked other tenants' example counts: {count}"
+
+
+async def test_add_example_stamps_the_bound_user(embeddings_db, stub_model) -> None:
+    """A correction must be owned by whoever made it.
+
+    Without this, scoping the read alone would leave every cloud user reading
+    an empty corpus while their corrections piled up on ``LOCAL_USER_ID``.
+    """
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_B):
+        await classifier.add_example(
+            email_id=7,
+            subject=TEXT_LIKE_B,
+            body="body text",
+            category=EmailCategory.REJECTION,
+        )
+
+    rows = await embeddings_db.rows()
+    assert len(rows) == 1
+    assert rows[0].user_id == USER_B, (
+        "correction was written under the wrong owner: "
+        f"{rows[0].user_id} (LOCAL_USER_ID is {LOCAL_USER_ID})"
+    )
+
+
+async def test_add_example_does_not_append_into_another_users_cache(
+    embeddings_db, stub_model
+) -> None:
+    """Appending to a warm cache is a write-side version of the same leak."""
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A):
+        await classifier.load_known_embeddings()
+
+    with user_id_scope(USER_B):
+        await classifier.add_example(
+            email_id=9,
+            subject=TEXT_LIKE_B,
+            body="body text",
+            category=EmailCategory.INTERVIEW,
+        )
+
+    assert _labels(classifier) == [EmailCategory.OFFER], (
+        "user B's new example was appended into user A's loaded cache: "
+        f"{_labels(classifier)}"
+    )
+
+
+# =============================================================================
+# 4. Belt and braces: the corpus is re-checked after loading
+# =============================================================================
+#
+# Defence 3 (the ``WHERE``) makes this unreachable, which is the point — it
+# exists so that a future refactor deleting the filter as "redundant" fails
+# loudly instead of quietly pooling tenants again. Exercised by substituting
+# the row loader, which is what a dropped filter looks like from the caller's
+# side. Same construction as ``test_training_is_single_user.py``.
+
+
+async def test_a_dropped_filter_raises_instead_of_pooling(
+    embeddings_db, stub_model, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobtracker.classifier.embeddings import CrossUserEmbeddingError
+
+    await _seed_both_users(embeddings_db)
+
+    async def _unfiltered(_self, session, *, user_id):  # noqa: ANN001 - test double
+        result = await session.exec(select(EmailEmbedding))
+        return list(result.all())
+
+    monkeypatch.setattr(EmbeddingsClassifier, "_load_rows", _unfiltered)
+
+    classifier = EmbeddingsClassifier()
+    with user_id_scope(USER_A), pytest.raises(CrossUserEmbeddingError):
+        await classifier.load_known_embeddings()
+
+    assert classifier._known_embeddings == []
+
+
+# =============================================================================
+# 5. Keying the cache by owner must not silently re-arm the eval harness
+# =============================================================================
+
+
+async def test_pinned_empty_corpus_holds_for_every_user(
+    embeddings_db, stub_model
+) -> None:
+    """``evaluate_classifier``'s ``deterministic`` profile must stay deterministic.
+
+    It pins layer 2 to an empty corpus so a benchmark never depends on local
+    database state. An owner-keyed load cache would otherwise re-read for any
+    caller whose identity differs from the pinned one — turning a reproducible
+    score back into a stateful one, with every existing assertion still green.
+    """
+
+    await _seed_both_users(embeddings_db)
+
+    classifier = EmbeddingsClassifier()
+    classifier.pin_empty_corpus()
+
+    for owner in (USER_A, USER_B):
+        with user_id_scope(owner):
+            await classifier.load_known_embeddings()
+        assert classifier._known_embeddings == [], (
+            f"pinned corpus was re-read from the database for {owner}"
+        )

--- a/backend/tests/test_evaluate_classifier.py
+++ b/backend/tests/test_evaluate_classifier.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from jobtracker.classifier.embeddings import EmbeddingsClassifier
 from jobtracker.scripts.evaluate_classifier import (
     PROMOTION_MARGIN,
     _configure_hybrid_profile,
@@ -175,15 +176,19 @@ def test_compare_against_baseline_flags_f1_regression() -> None:
     assert any("per_label.applied.f1" in msg for msg in failures)
 
 
-class _FakeEmbeddings:
-    def __init__(self) -> None:
-        self._known_embeddings = [("x", "y")]
-        self._loaded = False
-
-
 class _FakeHybridClassifier:
+    """Stands in for ``HybridClassifier``, but holds a REAL layer-2 instance.
+
+    The embeddings half used to be a hand-written double carrying just
+    ``_known_embeddings`` / ``_loaded``. That let the double drift away from
+    the class it imitated: when layer 2 gained an owner-keyed load cache, a
+    hand-written double would have kept this test green while the
+    ``deterministic`` profile silently started re-reading the database.
+    """
+
     def __init__(self) -> None:
-        self._embeddings = _FakeEmbeddings()
+        self._embeddings = EmbeddingsClassifier()
+        self._embeddings._known_embeddings = [("x", "y")]
         self.lite_mode_enabled = False
 
     def set_lite_mode(self, enabled: bool) -> None:

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 634,
+      "value": 643,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,15 +12,15 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 58.6,
+      "value": 59.19,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 9418,
+      "value": 9455,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
-      "value": 3899,
+      "value": 3859,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageCloud": {
@@ -36,7 +36,7 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScriptsStatements": {
-      "value": 2358,
+      "value": 2357,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageScripts": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 634,
+    "passed": 643,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
## What the query actually was

`EmbeddingsClassifier.load_known_embeddings()` read the whole table:

```python
result = await session.exec(select(EmailEmbedding))
```

No `WHERE`, on a table that has a `user_id` column. Layer 2 compared an
incoming message against every stored example in the database — whoever owned
it — and returned the nearest neighbour's label as the verdict. Two more sites
had the same gap:

- `get_example_count()` ran `SELECT COUNT(*) FROM email_embeddings`, so
  `GET /classify/status` reported the whole table's row count.
- `add_example()` constructed `EmailEmbedding(...)` with no `user_id`, so every
  correction landed on the `LOCAL_USER_ID` sentinel regardless of who made it.

## Severity, stated honestly

This is **not** live cross-tenant leakage in production today, and I would
rather say that than overstate it.

- **The cloud serving path never reaches this layer.** `HybridClassifier`
  sets `_cloud_rules_only = settings.deployment == "cloud"` and `classify()`
  returns after the rules layer without touching `self._embeddings`.
  `vercel.json` sets `JOBTRACKER_DEPLOYMENT=cloud` and `api/index.py` force-sets
  it again. Verified by running a cloud-mode classifier: after a full
  `classify()`, `_embeddings_instance is None` and
  `'jobtracker.classifier.embeddings' in sys.modules` is `False` — the module
  is not even imported.
- **`email_embeddings` is under RLS**, so on Supabase the unscoped *reads*
  would be clipped back to the caller anyway. I could **not** verify that
  empirically — this environment has no `psql` and no database credentials —
  so I am marking it unverified rather than reasoning it through.
- **The desktop path that does run this layer is SQLite**, where there is no
  RLS at all, and is single-user by construction (every row carries
  `LOCAL_USER_ID`).

So: unscoped in Python, gated off in cloud, unprotected but single-tenant on
desktop. The gate is one environment variable, not a scoping guarantee.

## The part RLS could not have saved

`get_embeddings_classifier()` returns a **process-global singleton** holding
`_known_embeddings` behind a boolean `_loaded` flag. The first request to warm
it answered every later request in the same process. The second request issues
no query at all, so no RLS policy is ever evaluated — the database cannot see
this one on any backend. This is the headline finding, and the reproduction is
blunt:

```
AssertionError: a warm process answered user B out of user A's cache:
got (<EmailCategory.OFFER: 'offer'>, 1.0)
```

The cache is now keyed by owner rather than by "have we loaded yet".

### What that does *not* close

Keying the cache by owner fixes the **sequential** case, which is the one that
was reproducible and the one that fires on every request today. It does not
make the layer concurrency-safe. `load_known_embeddings` still mutates
`self._known_embeddings` on a shared instance, and `classify()` reads that
attribute after awaiting — so two interleaved requests from different users in
one ASGI process (A between its load and `find_most_similar`, B loading in that
window) would still let A score against B's list.

Closing that means returning the rows from the load and passing them into
`find_most_similar`, rather than reading them back off `self`. It is left out
deliberately: the only configuration with request concurrency is cloud, and
cloud never reaches layer 2 (above), so it is unreachable today and a wider
change than this PR should carry. Recording it here so it is not mistaken for
solved.

## The fix

Mirrors what `setfit_model.py` already does for layer 3, which was hardened for
exactly this and left layer 2 behind:

1. A `WHERE user_id = ...` on the corpus read.
2. A post-load check derived from the rows themselves, so a refactor that
   deletes the filter as "redundant" raises `CrossUserEmbeddingError` instead
   of quietly pooling tenants.
3. The load cache keyed by owner; `add_example` appends only into a cache that
   already holds that owner's corpus.
4. Writes stamped with the resolved owner. Scoping reads without this would be
   worse than the leak — every correction would pile up on `LOCAL_USER_ID`
   while real users matched an empty corpus.

`resolve_embedding_user_id()` is a deliberate three-line twin of
`resolve_training_user_id` rather than a shared import: the real one lives in
`setfit_model`, which pulls torch, and the cloud import graph must never reach
it from here. `HybridClassifier.classify`'s signature is **unchanged** — the
layer resolves the owner from the request-bound RLS identity ContextVar, so
none of its ~8 call sites move.

## One regression this nearly introduced

Keying the load cache by owner silently breaks `evaluate_classifier`'s
`deterministic` profile, which pinned `_loaded = True` with an empty list to
bypass database state — it would have started re-reading for any caller whose
identity differed, turning a reproducible benchmark back into a stateful one
**with every existing assertion still green**. That intent is now an explicit
`pin_empty_corpus()`, and the test double is a real `EmbeddingsClassifier` so
it cannot drift from the class it imitates again.

## Verification

| run | result |
|---|---|
| new tests, unmodified code | **8 failed** (7 on behaviour, 1 on the not-yet-existing guard class) |
| new tests, after fix | **9 passed** |
| mutation: revert `embeddings.py` alone | **9 failed** |
| mutation: restore | **9 passed** |

The first row is 8 rather than 9 because the ninth case
(`test_pinned_empty_corpus_holds_for_every_user`) was added later, once the
owner-keyed cache turned out to threaten the eval harness. The mutation rows
are the authoritative revert-to-red evidence and cover all nine.

212 tests pass across 16 affected files: the new file plus
`evaluate_classifier`, its layer guard, `training_is_single_user`,
`setfit_model`, `database`, `main_cloud`, `api_phase5`, `user_id_scoping`,
`scan_classify`, `status_vocabulary`, `weekly_labeling_workflow`,
`training_corpus_integrity`, `account_deletion_covers_every_table`, `api` and
`api_phase2` — the last five chosen because they exercise `email_embeddings`
writes and `/classify/status`, which are the two call sites this PR changed
outside the read path.

Ruff is clean on the new test file; `embeddings.py` keeps the file's existing
`Optional[...]` idiom (pre-existing `UP045`), and the rewrite of
`get_example_count` removed a pre-existing unused-import `F401`.

Rebased onto `origin/main` after #131 merged. Touches none of #131's files.

**Not run, for `labrat`:** the full backend suite, and the browser/e2e pass.

## Noted, not fixed

`api/classification.py:462` filters `EmailEmbedding` by `email_id` only. That
is incidentally safe because `email_id` is globally unique, and the endpoint is
desktop-only (not mounted in `main_cloud`), where writing under `LOCAL_USER_ID`
is correct. Flagging it so the inconsistency is on the record.
