### PR TITLE
fix(api): make the cloud docs opt-in and stop /health asserting an environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/tests-689%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/tests-696%20collected%20%C2%B7%200%20skipped-brightgreen" alt="Tests">
   <img src="https://img.shields.io/badge/rules%20macro--F1-0.9791%20(CI%20floor%200.95)-2b9348" alt="Rules macro-F1">
   <img src="https://img.shields.io/badge/Next.js-16.2-000000?logo=nextdotjs&logoColor=white" alt="Next.js">
   <img src="https://img.shields.io/badge/React-19.2-61dafb?logo=react&logoColor=black" alt="React">
@@ -375,7 +375,7 @@ python -m jobtracker.scripts.benchmark_classifier_latency --require-semantic --o
 
 ## Testing
 
-**689 tests collected, 0 skipped.** These figures were recorded on 2026-08-12 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 578 `test_*` functions across 42 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity, RLS and migration-chain work, four of which brought their own module (`test_status_vocabulary.py`, `test_application_identity.py`, `test_rls_postgres.py`, `test_migrations_postgres.py`). The bold 689 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
+**696 tests collected, 0 skipped.** These figures were recorded on 2026-08-12 by `python3 scripts/readme_facts.py --record`, which runs `pytest tests -q --cov=jobtracker` in the project's Python 3.11.14 venv and writes `docs/readme-facts.json`; `--check` fails the build when this page and that artifact disagree. The count was first published from commit `37dd805` and corrected in `5b895d8`. It has grown since: a static parse counts 585 `test_*` functions across 43 modules at HEAD, against 300 across 25 modules at `37dd805` — the tests added with the sync-cursor, recoverable-removal, company-matching, stage-vocabulary, application-identity, RLS and migration-chain work, four of which brought their own module (`test_status_vocabulary.py`, `test_application_identity.py`, `test_rls_postgres.py`, `test_migrations_postgres.py`). The bold 696 is the artifact's and moves only on `--record`, while the static parse is recomputed on every `--check`, so between recordings the two drift apart — and parametrization lifts collected above the parse besides. CI reruns the suite with `--cov` on every push, so the current number lands in a public run log rather than resting on this sentence.
 
 The 11 that used to skip are the Postgres row-level-security module — the only thing in the repo that can demonstrate the isolation the product claims. They waited on a database URL no workflow set, and a skip is green, so as of 2026-08-02 they had **never executed anywhere**. Two fixes: `test_rls_postgres.py` now starts its own `postgres:16` via testcontainers when `JOBTRACKER_TEST_PG_ADMIN_URL` is absent and Docker is available, and the `rls-postgres` CI job supplies its own service container. That job then parses the JUnit XML and **fails the build if the suite reports zero tests or any skip**, because a skipped security test and a passing one produce the same green tick.
 
@@ -383,7 +383,7 @@ Those tests drive the production machinery, not a fixture: `jobtracker.database.
 
 `test_migrations_postgres.py` rides in the same job, for a defect the rest of the suite is structurally blind to: on SQLite, `sa.Enum` renders as `VARCHAR`, so a migration can add an enum label in the wrong case and every other test stays green while production 500s on the first write. It applies the whole Alembic chain to a bare database through the real CLI, then asserts the `applicationstatus` labels are the Python enum's member names in declaration order, that a row round-trips, and that the lowercase spelling is genuinely rejected. It is guarded by the same "did it actually run" JUnit check as the RLS suite.
 
-**Coverage**, from the same run: **59.49%** overall — 9,486 statements, 3,843 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **88.7%**; `auth` 80.5%; `database` 77.5%. What pulls the average down is `jobtracker/scripts` at 2,357 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
+**Coverage**, from the same run: **59.53%** overall — 9,495 statements, 3,843 missed. The distribution matters more than the total. `jobtracker/cloud`, the code that actually deploys, is at **88.7%**; `auth` 80.5%; `database` 77.5%. What pulls the average down is `jobtracker/scripts` at 2,357 statements and 33.6%, of which eight modules no test imports account for 1,010 statements at 0%.
 
 This paragraph read "54% overall, 61% excluding one-off scripts … 2,163 statements of dataset importers" until 2026-08-03, and three of those four numbers were wrong. The corrections, in full, are in commit `5b895d8`: 54% came from a Python 3.14 run, where PEP 649 stops emitting line events for annotation-only class attributes, so the same tree measures 8,018 statements instead of 8,210 — a 192-statement gap across 13 Pydantic models. 61% is dropped rather than restated, because it reaches 60.5% only by excluding 1,234 statements that CI invokes directly as gates. And 2,163 never described dataset importers; those are 662 statements at 0%. The portfolio was citing this README instead of a run, which is how they persisted.
 
@@ -538,7 +538,7 @@ applied/
 │   │   └── scripts/         # evaluator, latency benchmark, ML-ops tooling
 │   ├── alembic/versions/    # 12 revisions incl. the RLS + InitPlan-hoist migrations
 │   ├── data/evaluation/     # eval sets, committed baselines, benchmark + monitoring history
-│   └── tests/               # 42 modules
+│   └── tests/               # 43 modules
 │
 ├── ml/                      # the classifier as a deployable service
 │   ├── browser/             # ONNX export + the in-browser site (Transformers.js)

--- a/apps/web/lib/api/schema.d.ts
+++ b/apps/web/lib/api/schema.d.ts
@@ -982,8 +982,11 @@ export interface components {
             version: string;
             /** Deployment */
             deployment: string;
-            /** Environment */
-            environment: string;
+            /**
+             * Environment
+             * @description The configured environment, or null when the deployment does not declare one. Null is not 'development' -- it means nobody said. This endpoint used to print the field's default, which read as an assertion that production was a development deployment.
+             */
+            environment?: string | null;
         };
         /** InboxResponse */
         InboxResponse: {

--- a/backend/jobtracker/config.py
+++ b/backend/jobtracker/config.py
@@ -55,7 +55,38 @@ class Settings(BaseSettings):
     # - development: normal local runs (uses on-disk SQLite DB)
     # - production: same as development for now, but reserved for future tuning
     # - test: in-memory SQLite DB for pytest (never touches real data)
+    #
+    # THIS VALUE IS A DEFAULT, NOT A MEASUREMENT. Nothing sets
+    # JOBTRACKER_ENVIRONMENT on Vercel, so the deployed production API has
+    # reported "development" since the day it shipped -- not because anyone
+    # decided that, but because nobody decided anything. Use
+    # ``environment_is_configured`` to tell the two apart, and never build a
+    # security decision on this field alone: a condition of the form
+    # ``if settings.environment == "production"`` is false in production and
+    # is therefore a check that cannot fail.
     environment: Literal["development", "production", "test"] = "development"
+
+    # Interactive API documentation: /docs (Swagger UI), /redoc, and the
+    # /openapi.json document that feeds them.
+    #
+    # OFF BY DEFAULT, AND DELIBERATELY NOT DERIVED FROM ``environment``.
+    # The obvious gate -- "serve docs unless environment == production" --
+    # cannot work here for the reason spelled out above: the deployed API
+    # *is* "development" as far as this config can tell, so that gate would
+    # keep publishing the full interactive API surface to anyone who asked.
+    # An independent switch whose default is the safe value inverts the
+    # failure mode: a deployment configured with nothing at all serves no
+    # docs, and a docs endpoint can only exist because somebody explicitly
+    # asked for one.
+    enable_docs: bool = Field(
+        default=False,
+        description=(
+            "Serve the interactive API docs (/docs, /redoc, /openapi.json). "
+            "Off unless explicitly enabled -- set JOBTRACKER_ENABLE_DOCS=true "
+            "for local development. A deployment that configures nothing "
+            "serves no docs."
+        ),
+    )
 
     # Deployment target. "desktop" keeps every existing assumption (SQLite,
     # Keychain, WebSocket router, localhost CORS). "cloud" selects the
@@ -64,6 +95,24 @@ class Settings(BaseSettings):
     # cloud paths in one at a time; this flag only gates which app builder
     # is imported.
     deployment: Literal["desktop", "cloud"] = "desktop"
+
+    @property
+    def environment_is_configured(self) -> bool:
+        """True only when ``environment`` was actually supplied by the operator.
+
+        Pydantic records the field names a model was *constructed* with in
+        ``model_fields_set``, and pydantic-settings feeds env vars and ``.env``
+        entries in as constructor values. A field left at its default is
+        therefore absent from that set. This is the only way to distinguish a
+        deployment that said ``JOBTRACKER_ENVIRONMENT=development`` from one
+        that said nothing and inherited the identical string -- which is
+        exactly the situation the deployed cloud API is in.
+
+        Not a ``computed_field``: this is a fact about how the settings were
+        loaded, not a setting, and it has no business in a serialised dump.
+        """
+
+        return "environment" in self.model_fields_set
 
     # -------------------------------------------------------------------------
     # API Server

--- a/backend/jobtracker/main_cloud.py
+++ b/backend/jobtracker/main_cloud.py
@@ -34,7 +34,7 @@ from typing import Any
 
 from fastapi import Depends, FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from jobtracker.config import settings
 from jobtracker.logging import setup_logging
@@ -97,13 +97,35 @@ def _build_cors_origin_regex() -> str:
     return rf"^https?://({'|'.join(parts)})$"
 
 
+# Interactive docs are OPT-IN. Until 2026-08-12 the three URLs below were
+# passed unconditionally, so the production API published its complete
+# interactive surface -- every path, every schema, a live "Try it out" -- to
+# anyone who loaded https://<api-host>/docs.
+#
+# WHY THE GATE IS `enable_docs` AND NOT `environment`
+# ---------------------------------------------------
+# The reflexive fix is ``if settings.environment != "production"``. It would
+# have changed nothing. Nothing sets JOBTRACKER_ENVIRONMENT on Vercel, so the
+# deployed API reports ``"development"`` -- the field's default -- and that
+# condition is false in production. A gate whose condition is never true where
+# it matters is not a gate.
+#
+# ``enable_docs`` defaults to False instead, which puts the safe state in the
+# default rather than in the configuration. The property that holds: a
+# deployment carrying no environment configuration at all serves no docs.
+# Passing None (rather than a path) is what makes that a 404 -- FastAPI does
+# not register the route at all, so there is nothing to probe. ``app.openapi()``
+# still works in-process, which is what scripts/generate_api_schema.sh uses to
+# build the web client's typed bindings.
+_docs_enabled = settings.enable_docs
+
 app = FastAPI(
     title=f"{settings.app_name} (cloud)",
     description="Cloud (Vercel + Supabase) deployment of the Applied backend.",
     version=settings.app_version,
-    docs_url="/docs",
-    redoc_url="/redoc",
-    openapi_url="/openapi.json",
+    docs_url="/docs" if _docs_enabled else None,
+    redoc_url="/redoc" if _docs_enabled else None,
+    openapi_url="/openapi.json" if _docs_enabled else None,
 )
 
 app.add_middleware(
@@ -158,7 +180,15 @@ class HealthResponse(BaseModel):
     status: str
     version: str
     deployment: str
-    environment: str
+    environment: str | None = Field(
+        default=None,
+        description=(
+            "The configured environment, or null when the deployment does not "
+            "declare one. Null is not 'development' -- it means nobody said. "
+            "This endpoint used to print the field's default, which read as an "
+            "assertion that production was a development deployment."
+        ),
+    )
 
 
 @app.get(
@@ -180,7 +210,15 @@ async def health_check() -> HealthResponse:
         status="ok",
         version=settings.app_version,
         deployment=settings.deployment,
-        environment=settings.environment,
+        # Report the environment only when one was actually configured.
+        # ``settings.environment`` always holds a string; until now this
+        # endpoint printed it unconditionally, so production told every caller
+        # it was a "development" deployment on the strength of a default
+        # nobody had set. Null is the honest answer to "which environment?"
+        # when the deployment has never been told.
+        environment=(
+            settings.environment if settings.environment_is_configured else None
+        ),
     )
 
 
@@ -192,13 +230,22 @@ async def health_check() -> HealthResponse:
 async def root() -> dict[str, Any]:
     """Root endpoint with API information for the cloud deployment."""
 
-    return {
+    payload: dict[str, Any] = {
         "name": settings.app_name,
         "version": settings.app_version,
         "deployment": "cloud",
-        "docs": "/docs",
-        "health": "/health",
     }
+    # Advertise the docs only when they are actually mounted -- and read that
+    # off the app object rather than re-reading ``settings.enable_docs``, so
+    # "advertised if and only if served" is structural instead of two
+    # independent reads that happen to agree. Before this, the root of the
+    # production API handed out "/docs" as a directions sign to a page that
+    # should never have existed; the failure mode to avoid now is the mirror
+    # image, a sign pointing at a 404.
+    if app.docs_url:
+        payload["docs"] = app.docs_url
+    payload["health"] = "/health"
+    return payload
 
 
 # =============================================================================

--- a/backend/tests/test_api_docs_are_opt_in.py
+++ b/backend/tests/test_api_docs_are_opt_in.py
@@ -1,0 +1,304 @@
+"""The cloud API must not publish its interactive docs by accident.
+
+WHAT SHIPPED, AND WHAT THESE TESTS PIN
+
+``jobtracker.main_cloud`` built its ``FastAPI`` with ``docs_url="/docs"``,
+``redoc_url="/redoc"`` and ``openapi_url="/openapi.json"`` unconditionally, so
+the production deployment served its complete interactive API surface to
+anybody who asked. Measured against the live service on 2026-08-12::
+
+    $ curl -s https://jobtracker-api-seven.vercel.app/
+    {"name":"Applied", ... ,"docs":"/docs", ...}
+
+THE FIX THAT WOULD NOT HAVE WORKED
+
+Gating on ``settings.environment`` -- ``if settings.environment !=
+"production"`` -- looks like the answer and is worthless here. Nothing sets
+``JOBTRACKER_ENVIRONMENT`` on Vercel, so the deployed API reports
+``"development"``, the field's default. That condition is *false* in
+production; the docs would still have been served, and the repository would
+have gained another check that cannot fail. The same trap swallows
+``environment == "development"`` as an allow-condition: production satisfies it.
+
+So the property under test is not "docs are off in production" (which depends
+on configuration that is not there). It is stronger and does not depend on any
+configuration at all:
+
+    A DEPLOYMENT THAT CONFIGURES NOTHING SERVES NO DOCS.
+
+WHY THE FIRST TEST IS A SUBPROCESS
+
+Two reasons, one of them a hazard. ``tests/conftest.py`` sets
+``JOBTRACKER_ENVIRONMENT=test`` for the whole session, and *that* is what
+routes ``Settings.database_url`` to in-memory SQLite (``config.py``). Deleting
+it in-process and reloading the config module would silently recompute the URL
+to the real on-disk database under ``~/Library/Application Support``. Nothing
+in these routes touches the DB today, but it is one import away.
+
+Second, a subprocess with every ``JOBTRACKER_*`` variable stripped is the only
+way to exercise the real env -> Settings -> FastAPI chain in the shape
+production actually runs in. Reaching in and patching the settings object would
+prove the gate reads a boolean, not that the boolean is False when a serverless
+function boots with an empty environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+DOC_PATHS = ("/docs", "/redoc", "/openapi.json")
+
+
+def _run_in_clean_env(script: str) -> dict:
+    """Execute ``script`` with every JOBTRACKER_* variable removed.
+
+    Returns the JSON object the script prints on its last stdout line. The
+    child's ``cwd`` is the backend package root (this file's grandparent) so
+    ``jobtracker`` imports the tree under test; ``PYTHONPATH`` carries it too
+    in case the child is started from somewhere else.
+    """
+
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("JOBTRACKER_")}
+    env["PYTHONPATH"] = backend_dir
+    # Desktop keyring is not on the cloud import path, but a stray macOS
+    # Keychain prompt in CI would hang the child; the null backend is what
+    # backend-ci.yml uses for the same reason.
+    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=backend_dir,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"probe subprocess failed ({result.returncode}).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+_PROBE = """
+import asyncio, json, os, sys
+
+# Deployment mode is what api/index.py forces on Vercel; it is not
+# "environment configuration" in the sense under test and says nothing
+# about docs.
+os.environ["JOBTRACKER_DEPLOYMENT"] = "cloud"
+{extra_env}
+
+from jobtracker.config import settings
+from jobtracker.main_cloud import app
+from httpx import ASGITransport, AsyncClient
+
+async def probe():
+    codes = {{}}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://cloud-probe") as client:
+        for path in {paths!r}:
+            codes[path] = (await client.get(path)).status_code
+        root = (await client.get("/")).json()
+        health = (await client.get("/health")).json()
+    # getattr with a sentinel, deliberately: if the gate is ever deleted these
+    # settings vanish, and a probe that raised AttributeError would turn every
+    # test below into a setup error whose message is about a missing attribute
+    # rather than about docs being served. A test must fail on the property it
+    # names.
+    print(json.dumps({{
+        "codes": codes,
+        "root": root,
+        "health": health,
+        "enable_docs": getattr(settings, "enable_docs", "<absent>"),
+        "environment_is_configured": getattr(
+            settings, "environment_is_configured", "<absent>"
+        ),
+        "jobtracker_env_vars": sorted(
+            k for k in os.environ if k.startswith("JOBTRACKER_")
+        ),
+    }}))
+
+asyncio.run(probe())
+"""
+
+
+@pytest.fixture(scope="module")
+def unconfigured_probe() -> dict:
+    """Boot the cloud app with an empty JOBTRACKER_* environment."""
+
+    return _run_in_clean_env(
+        _PROBE.format(paths=DOC_PATHS, extra_env="")
+    )
+
+
+def test_unconfigured_deployment_serves_no_docs(unconfigured_probe: dict) -> None:
+    """/docs, /redoc and /openapi.json are 404 when nothing is configured.
+
+    This is the regression that was live in production. It fails if the gate is
+    removed, and it also fails if the gate is rewritten in terms of
+    ``environment`` -- because in this probe, as on Vercel, ``environment`` is
+    the unset default.
+    """
+
+    # Guard the guard: if the child inherited configuration, the 404s below
+    # would prove nothing about a bare deployment. JOBTRACKER_DEPLOYMENT is the
+    # one exception -- api/index.py sets it unconditionally on Vercel and it
+    # carries no information about docs.
+    assert unconfigured_probe["jobtracker_env_vars"] == ["JOBTRACKER_DEPLOYMENT"], (
+        "the probe subprocess was not actually unconfigured: "
+        f"{unconfigured_probe['jobtracker_env_vars']}"
+    )
+
+    assert unconfigured_probe["codes"] == dict.fromkeys(DOC_PATHS, 404), (
+        "the cloud API published interactive docs on a deployment that "
+        f"configured nothing: {unconfigured_probe['codes']}. Docs must be "
+        "opt-in via JOBTRACKER_ENABLE_DOCS; a gate on `environment` does not "
+        "work because production's environment IS the default."
+    )
+    # Supporting detail, asserted after the property so a regression reports
+    # the 200s rather than a bookkeeping mismatch.
+    assert unconfigured_probe["enable_docs"] is False
+    assert unconfigured_probe["environment_is_configured"] is False
+
+
+def test_unconfigured_root_does_not_advertise_docs(unconfigured_probe: dict) -> None:
+    """The root route must not hand out a link to a page it does not serve."""
+
+    root = unconfigured_probe["root"]
+    assert "docs" not in root, (
+        f"GET / advertised docs at {root.get('docs')!r} while /docs returns "
+        f"{unconfigured_probe['codes']['/docs']}."
+    )
+    # The rest of the root contract is unchanged.
+    assert root["deployment"] == "cloud"
+    assert root["health"] == "/health"
+
+
+def test_unconfigured_health_does_not_claim_an_environment(
+    unconfigured_probe: dict,
+) -> None:
+    """/health reports null, not "development", when nobody configured one.
+
+    The deployed API answered ``"environment":"development"`` for months. That
+    was not a report; it was the default leaking out through a field typed as
+    if it were a measurement.
+    """
+
+    health = unconfigured_probe["health"]
+    assert health["status"] == "ok"
+    assert health["environment"] is None, (
+        f"/health asserted environment={health['environment']!r} on a "
+        "deployment that never configured one."
+    )
+
+
+@pytest.fixture(scope="module")
+def docs_enabled_probe() -> dict:
+    """Boot the cloud app with the docs opt-in explicitly turned on."""
+
+    return _run_in_clean_env(
+        _PROBE.format(
+            paths=DOC_PATHS,
+            extra_env=(
+                'os.environ["JOBTRACKER_ENABLE_DOCS"] = "true"\n'
+                'os.environ["JOBTRACKER_ENVIRONMENT"] = "development"\n'
+            ),
+        )
+    )
+
+
+def test_opt_in_serves_docs_redoc_and_openapi(docs_enabled_probe: dict) -> None:
+    """JOBTRACKER_ENABLE_DOCS=true brings all three endpoints back.
+
+    Without this the "fix" could be a hard-coded ``None`` and every other test
+    here would still pass, leaving no way to read the API locally.
+    """
+
+    assert docs_enabled_probe["codes"] == dict.fromkeys(DOC_PATHS, 200), (
+        "JOBTRACKER_ENABLE_DOCS=true did not restore the interactive docs: "
+        f"{docs_enabled_probe['codes']}"
+    )
+    assert docs_enabled_probe["enable_docs"] is True
+
+
+def test_opt_in_root_advertises_the_docs_it_serves(docs_enabled_probe: dict) -> None:
+    """When docs are mounted the root advertises them, and at the served path."""
+
+    root = docs_enabled_probe["root"]
+    assert root["docs"] == "/docs"
+    assert docs_enabled_probe["codes"][root["docs"]] == 200
+
+
+def test_configured_health_reports_the_configured_environment(
+    docs_enabled_probe: dict,
+) -> None:
+    """An environment that WAS configured is reported, not suppressed.
+
+    The honesty fix must not degrade into "never say anything".
+    """
+
+    assert docs_enabled_probe["health"]["environment"] == "development"
+    assert docs_enabled_probe["environment_is_configured"] is True
+
+
+def test_openapi_document_is_still_buildable_without_the_route() -> None:
+    """``app.openapi()`` works even with the HTTP route switched off.
+
+    ``scripts/generate_api_schema.sh`` imports the app and calls
+    ``app.openapi()`` to regenerate ``apps/web/lib/api/schema.d.ts``; the
+    e2e workflow fails the build if the committed bindings drift. Passing
+    ``openapi_url=None`` must remove the *route*, not the document -- otherwise
+    disabling docs quietly breaks the web client's typed contract.
+    """
+
+    probe = _run_in_clean_env(
+        'import json, os\n'
+        'os.environ["JOBTRACKER_DEPLOYMENT"] = "cloud"\n'
+        'from jobtracker.main_cloud import app\n'
+        'doc = app.openapi()\n'
+        'print(json.dumps({\n'
+        '    "openapi_url": app.openapi_url,\n'
+        '    "paths": len(doc["paths"]),\n'
+        '    "has_health": "/health" in doc["paths"],\n'
+        '}))\n'
+    )
+
+    assert probe["openapi_url"] is None, "the /openapi.json route should be off"
+    assert probe["has_health"] is True
+    assert probe["paths"] > 1, probe
+
+
+# -----------------------------------------------------------------------------
+# WHY THERE IS NO IN-PROCESS `importlib.reload` VARIANT HERE
+#
+# The obvious way to add an in-process case is the fixture idiom in
+# test_main_cloud.py: monkeypatch the env, ``importlib.reload`` jobtracker.config
+# and jobtracker.main_cloud, yield the app, reload again on teardown. It was
+# written that way first, and it turned 14 unrelated tests red -- every test in
+# test_auth_supabase_jwt.py and test_application_delete_children.py. Reloading
+# jobtracker.config rebinds the module-level ``settings`` singleton, and every
+# module that had already done ``from jobtracker.config import settings`` keeps
+# the old object while anything importing afterwards gets the new one; reloading
+# main_cloud then rebuilds the app and its routers around the second copy.
+#
+# test_main_cloud.py gets away with it only because "main_cloud" sorts after
+# almost everything else, so its wreckage lands at the end of the session. This
+# file sorts near the top. Measured:
+#
+#   pytest tests/test_auth_supabase_jwt.py tests/test_application_delete_children.py
+#       -> 23 passed
+#   pytest tests/test_api_docs_are_opt_in.py <same two>
+#       -> 14 failed, 17 passed
+#   pytest tests/test_api_docs_are_opt_in.py <same two> -k "not survives_a_module_reload"
+#       -> 30 passed
+#
+# The subprocess probes above cover the same property with a stronger guarantee
+# and no shared state, so the reload variant bought nothing. Do not add one.
+# -----------------------------------------------------------------------------

--- a/backend/tests/test_main_cloud.py
+++ b/backend/tests/test_main_cloud.py
@@ -69,8 +69,13 @@ async def test_cloud_app_root_returns_deployment_info(cloud_app):
     assert response.status_code == 200
     payload = response.json()
     assert payload["deployment"] == "cloud"
-    assert payload["docs"] == "/docs"
     assert payload["health"] == "/health"
+    # This fixture does not set JOBTRACKER_ENABLE_DOCS, so the docs are off and
+    # the root must not advertise them. It used to assert ``payload["docs"] ==
+    # "/docs"``, which was true of the deployment that published its full
+    # interactive API surface to the internet. The docs contract, both halves
+    # of it, now lives in tests/test_api_docs_are_opt_in.py.
+    assert "docs" not in payload
 
 
 def test_cloud_app_does_not_import_keyring_or_aiosqlite(tmp_path):

--- a/backend/tests/test_status_vocabulary.py
+++ b/backend/tests/test_status_vocabulary.py
@@ -406,9 +406,19 @@ async def test_a_category_that_is_not_a_stage_is_still_not_settable(
     assert "interviewing" in resp.text
 
 
-async def test_the_openapi_enum_is_the_same_list(client: AsyncClient) -> None:
-    """A client generating types from the schema gets the canonical list too."""
+async def test_the_openapi_enum_is_the_same_list(cloud_app: Any) -> None:
+    """A client generating types from the schema gets the canonical list too.
 
-    schema = (await client.get("/openapi.json")).json()
+    Reads the document from ``app.openapi()`` rather than over HTTP from
+    ``/openapi.json``. The route is opt-in as of 2026-08-12 (see
+    tests/test_api_docs_are_opt_in.py) and is absent unless
+    JOBTRACKER_ENABLE_DOCS is set, so fetching it here would test the docs
+    switch instead of the enum. The document itself is unaffected, and
+    ``app.openapi()`` is exactly what scripts/generate_api_schema.sh calls to
+    build apps/web/lib/api/schema.d.ts -- so this now checks the same object
+    the real type generator consumes.
+    """
+
+    schema = cloud_app.openapi()
     enum = schema["components"]["schemas"]["ApplicationStatus"]["enum"]
     assert enum == list(EXPECTED_STATUSES)

--- a/docs/readme-facts.json
+++ b/docs/readme-facts.json
@@ -4,7 +4,7 @@
   "machine": "Darwin-arm64, 3.11.14",
   "facts": {
     "testsCollected": {
-      "value": 689,
+      "value": 696,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "testsSkipped": {
@@ -12,11 +12,11 @@
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coveragePercent": {
-      "value": 59.49,
+      "value": 59.53,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageStatements": {
-      "value": 9486,
+      "value": 9495,
       "command": "cd backend && pytest tests -q --cov=jobtracker --cov-report=json:.readme-facts-coverage.json --cov-report=term"
     },
     "coverageMissed": {
@@ -53,7 +53,7 @@
     }
   },
   "suiteOutcome": {
-    "passed": 689,
+    "passed": 696,
     "failed": 0,
     "skipped": 0,
     "errors": 0,


### PR DESCRIPTION
Task #85 on the working list. Deliberately **not** written as `Closes #85` — GitHub #85 in this repo is an unrelated merged PR (`fix(pipeline): stop prose leaking into an extracted role title`), and no open issue tracks this defect.

## What was live

```
$ curl -s https://jobtracker-api-seven.vercel.app/
{"name":"Applied","version":"0.1.0","deployment":"cloud","docs":"/docs","health":"/health"}

$ curl -s https://jobtracker-api-seven.vercel.app/health
{"status":"ok","version":"0.1.0","deployment":"cloud","environment":"development"}
```

`main_cloud.py` passed `docs_url` / `redoc_url` / `openapi_url` unconditionally, so the production API published its complete interactive surface — every path, every schema, a live "Try it out" — and the root route advertised the way there.

## Why this is **not** gated on `environment`

The obvious fix, `if settings.environment != "production"`, would have changed **nothing**. Nothing sets `JOBTRACKER_ENVIRONMENT` on Vercel, so the deployed service reports `"development"` — the field's default, not a decision anybody made. That condition is *false* in production; the docs would still be served and the repository would have gained one more check that cannot fail. The mirror-image gate (`== "development"` as an allow-condition) is worse: production satisfies it.

So the safe state moves into the **default** rather than into the configuration. `Settings.enable_docs` defaults to `False`, and the property that now holds needs no configuration to exist:

> **A deployment that configures nothing serves no docs.**

`JOBTRACKER_ENABLE_DOCS=true` brings `/docs`, `/redoc` and `/openapi.json` back for local work. Passing `None` rather than a path is what makes the un-opted case a real 404 — FastAPI never registers the route. `app.openapi()` still builds the document in-process, which is what `scripts/generate_api_schema.sh` calls, so the web client's typed bindings keep working.

## Health honesty

`/health` printed `settings.environment` unconditionally, so production has been asserting it is a development deployment on the strength of a default. It now reports the configured environment **or `null`**. `Settings.environment_is_configured` reads pydantic's `model_fields_set`, which contains a field only when a value was actually supplied by the environment or a `.env` file. `null` means *nobody said*; it does not mean development.

The root route now sources the docs URL from `app.docs_url` instead of re-reading the setting, so "advertised if and only if served" is structural rather than two independent reads that happen to agree.

## Tests, and the mutation results

7 new cases in `backend/tests/test_api_docs_are_opt_in.py`. The unconfigured cases run in a **subprocess with every `JOBTRACKER_*` variable stripped**, which exercises the real env → `Settings` → FastAPI chain in production shape; patching a settings object would only prove the gate reads a boolean.

Every test was mutation-tested — reverted, seen RED, restored, seen GREEN:

| mutation | result |
|---|---|
| full revert (docs unconditional + health prints the default) | **5 RED** |
| health honesty removed | **1 RED** |
| gate hard-wired OFF | **2 RED** |
| root advertises `/docs` unconditionally | **2 RED** |
| `enable_docs` default flipped to `True` | **4 RED** |
| gate rewritten as `environment != "production"` — *the trap* | **4 RED** |
| health always `null` | **1 RED** |
| fixed sources | **12 GREEN** |

The trap row is the one that matters: an `environment`-based gate leaves the unconfigured-deployment tests red.

That subprocess design is also why the new file carries **no `importlib.reload` fixture**. Written that way first, it turned 14 unrelated tests red across `test_auth_supabase_jwt.py` and `test_application_delete_children.py` — reloading `jobtracker.config` rebinds the `settings` singleton under every module that already imported it. `test_main_cloud.py` survives the same idiom only because it sorts late alphabetically; this file sorts early. Measured three ways and recorded in a comment so nobody re-adds it.

## Collateral, all mechanically required

- `test_status_vocabulary.py` read the enum from `/openapi.json` over HTTP; it now reads `app.openapi()` — the same object the type generator consumes.
- `apps/web/lib/api/schema.d.ts` regenerated (`HealthResponse.environment` is now optional/nullable). The e2e schema-drift gate fails the build otherwise. Regenerating the **pre-change** spec locally reproduced the committed file byte-for-byte first, so this diff contains only the intended change.
- `README.md` + `docs/readme-facts.json` re-recorded. `machine` still `Darwin-arm64, 3.11.14`; `dockerAvailable: true`; `allGreen: true`.

## Verification

- `backend/.venv311/bin/python -m pytest` → **696 passed, 0 failed, 0 skipped** (689 before).
- `readme_facts.py --record` → `--write` → `--check`: *49 facts, asserted at 113 sites across 3 files, all agree (13 invariants hold)*.
- `ruff` on the changed files: clean. `mypy` on `config.py` + `main_cloud.py`: identical to baseline (same 4 pre-existing `unused-ignore` errors, 0 new).

Not run here, for `labrat`: the Playwright e2e suite and `pnpm -C apps/web tsc --noEmit`. Nothing in `apps/web` reads `HealthResponse.environment` (grepped), so the nullable field should be inert, but the web typecheck has not been executed.

## Notes

- Desktop `jobtracker/main.py` is deliberately untouched: it binds `127.0.0.1`, it is not the deployed surface, and widening this diff into it was out of scope. It carries the same environment dishonesty at `main.py:263`.
- `vercel.json`'s CSP carve-out for `/docs` and `/redoc` is left in place on purpose — it is inert while the routes 404, and removing it would break the opt-in for anyone who deliberately enables docs on a deployment.
- **Deploy checks are expected to come back rate-limited** (the 24h Vercel cap is exhausted). That is not a CI failure; every other check must be green.
- Merging this is what finally ships the API — production is 8 commits stale at `47fc104`, and the ignore filter only rebuilds when a commit touches `backend/jobtracker` (this one does): the sync P0 (#139), cross-user embeddings scoping (#134), the FK cascade (#137), the classifier fix (#138) and assessment-as-a-status (#131).
