### PR TITLE
fix(dashboard): restore the pulse band, collapse chrome to one command row

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -33,24 +33,28 @@ import { getCurrentUser } from "@/lib/supabase/auth";
  *
  * The geometry is viewport-locked at desktop: the shell is one screen tall,
  * this page fills its pane exactly (`lg:min-h-0 lg:flex-1`), and the ONLY
- * thing that scrolls is the worklist inside `PipelineBoard`. Header, notice
- * lines and the spine hold still — the dashboard reads as an instrument, not
- * a document. Below `lg` the lock releases and the page flows normally.
+ * thing that scrolls is the worklist inside `PipelineBoard`. Below `lg` the
+ * lock releases and the page flows normally.
  *
- * The notice zone under the SyncBar is deliberately one line box per notice
- * (`truncate`, no wrapping): the "what changed since you last looked" summary
- * (PR #113, `SinceLastLook`) lands in this zone as a single line, so nothing
- * that appears after hydration can ever shift the board. The in-app weekly
- * digest is no longer a second line here — it restated the subtitle's own
- * numbers plus one (task #59), so its one new number (+N this wk) folds into
- * the subtitle itself when the pref asks for it.
+ * The page spends ONE line of chrome above the board's pulse band: the shell's
+ * top bar carries the route title now, and everything this page used to stack
+ * — the header row, the notice line, the board's own in-column search row —
+ * shares the board's command row instead. The SyncBar (subtitle · the
+ * change-ledger chip · recency · Sync · ⋯ · +) rides that row through the
+ * board's `toolbar` slot, so the /demo twin inherits the identical
+ * composition by construction and the worklist gets every reclaimed line.
+ * The in-app weekly digest is not a line anywhere — it restated the
+ * subtitle's own numbers plus one (task #59), so its one new number
+ * (+N this wk) folds into the subtitle itself when the pref asks for it.
  *
  * The pulse's four derived signals — filed-per-week momentum, the age
- * distribution of open rows, deadlines, and how much of the board the
- * classifier built / is holding — render inside the board's stage spine,
- * under the stage buttons (`PipelineBoard`'s `pulse` prop), filling the
- * column's blank run instead of spending a band of the pane. They derive
- * from the same rows the board renders, so the board is where they live.
+ * distribution of open rows, deadlines, and how much of the board arrived
+ * from mail / is held for review — render as a full-width band across the
+ * top of the board's body (`PipelineBoard`'s `pulse` prop). That is the
+ * pre-#136 home the owner asked back, at band density instead of the old
+ * ~200px strip; the shell rail and the stage spine are both measured,
+ * rejected homes for it. They derive from the same rows the board renders,
+ * so the board is where they live.
  *
  * Data path unchanged: the counts come from the O(1) `GET
  * /applications/summary`, the board from one bounded page of
@@ -162,7 +166,9 @@ async function loadDashboard(): Promise<LoadState> {
  *  restating everything else this line already says. */
 function buildSubtitle(summary: PipelineSummary, weekly: boolean): string {
   const thisWeek = weekly && summary.thisWeek > 0 ? ` · +${summary.thisWeek} this wk` : "";
-  return `${summary.total} filed${thisWeek} · ${summary.inMotion} in motion · ${summary.offers} offer${
+  // "open", not "in motion": the pulse already calls these same rows open,
+  // and an applied-and-waiting row is precisely the one NOT moving.
+  return `${summary.total} filed${thisWeek} · ${summary.inMotion} open · ${summary.offers} offer${
     summary.offers === 1 ? "" : "s"
   }`;
 }
@@ -173,9 +179,7 @@ export default async function DashboardPage() {
     getGmailStatus(),
     getCurrentUser(),
   ]);
-  const notifPrefs = readNotificationPrefs(
-    (user?.user_metadata ?? {}) as Record<string, unknown>,
-  );
+  const notifPrefs = readNotificationPrefs((user?.user_metadata ?? {}) as Record<string, unknown>);
 
   // A failed status probe is UNKNOWN, not disconnected — the SyncBar renders
   // no gmail cluster at all rather than a guessed state.
@@ -217,7 +221,7 @@ export default async function DashboardPage() {
     const headline =
       state.kind === "offline"
         ? "We couldn't reach the server."
-        : "We couldn't load your pipeline.";
+        : "We couldn't load your applications.";
     // Only an auth rejection is a session problem. A 500 told through the same
     // words sent people to sign in again — a loop that could not help them.
     const detail =
@@ -242,8 +246,8 @@ export default async function DashboardPage() {
           </h2>
           <p className="mt-2 max-w-xl text-sm text-muted">{detail}</p>
           <p className="mt-2 max-w-xl text-xs text-dim">
-            This is a loading failure, not an empty pipeline — nothing below is your data, because
-            we have none to show yet.
+            This is a loading failure, not an empty board — nothing below is your data, because we
+            have none to show yet.
           </p>
           <div className="mt-5 flex flex-wrap items-center gap-3">
             <RetryLoadButton />
@@ -319,7 +323,7 @@ export default async function DashboardPage() {
     // Genuinely fresh user (not connected, nothing imported) → scaffold + sample.
     return (
       <section className="space-y-6">
-        <SyncBar subtitle="0 filed · start your pipeline" gmail={gmail}>
+        <SyncBar subtitle="0 filed · nothing tracked yet" gmail={gmail}>
           <AddApplicationForm compact />
         </SyncBar>
         <DashboardEmptyState />
@@ -341,18 +345,16 @@ export default async function DashboardPage() {
 
   return (
     <section className={LOCKED_PAGE_CLASS}>
-      <SyncBar subtitle={subtitle} gmail={gmail}>
-        <AddApplicationForm compact />
-      </SyncBar>
+      {/* The board owns the whole pane; the sync surface rides its command
+          row (`toolbar`), so header, search and controls cost one line
+          between them and the /demo twin inherits this composition by
+          construction — there is no second place to mount any of it.
 
-      {/* The notice zone: single-line notices only, so nothing here can shift
-          the board. Its two tenants are `SinceLastLook` and the in-app weekly
-          digest, both exactly one line tall.
-
-          SinceLastLook is client-only (the marker is this browser's), per
-          user, and silent until it has a previous visit to compare against.
-          The rows are projected here so the flight payload carries six fields
-          per row rather than the whole record twice.
+          SinceLastLook is the chip on that row: client-only (the marker is
+          this browser's), per user, and silent until it has a previous visit
+          to compare against. The rows are projected here so the flight
+          payload carries six fields per row rather than the whole record
+          twice.
 
           No id, no ledger — never a shared "anon" scope. One marker key holds
           one board, so a record written under a fallback scope would OVERWRITE
@@ -362,31 +364,19 @@ export default async function DashboardPage() {
           the branch should be unreachable; borrowing that guarantee from
           another file is what makes it worth stating here. Same discipline as
           the SyncBar's gmail cluster: an unknown state renders nothing rather
-          than a guessed one. */}
-      {user?.id ? (
-        <SinceLastLook
-          rows={state.applications.map(toChangeRow)}
-          total={state.total}
-          scope={user.id}
-          storageKey={LAST_LOOK_KEY}
-        />
-      ) : null}
-
-      {/* The worklist owns the rest of the pane. `total` is the account's true
-          count, not the page's: past BOARD_PAGE_SIZE the board says which slice
-          it is showing, so the subtitle's "250 filed" and a list summing to 200
-          stop contradicting each other.
+          than a guessed one.
 
           "Needs review alerts" decides whether held mail interrupts the list
           (above the rows) or waits under it — the quiet-board promise the
           Settings toggle describes, kept real. Both placements live INSIDE the
           list's scroll context, so an eight-item queue can never starve the
-          worklist of its viewport. */}
-      {/* `total` and `stageTotals` both come from the summary endpoint, and the
-          board's prop type makes them inseparable: the spine states the
+          worklist of its viewport.
+
+          `total` and `stageTotals` both come from the summary endpoint, and
+          the board's prop type makes them inseparable: the spine states the
           ACCOUNT's per-stage counts (a `GROUP BY status` in the database), not
           the shape of the page that happened to load. Past BOARD_PAGE_SIZE the
-          two differ, and a spine summing to the page while this subtitle says
+          two differ, and a spine summing to the page while the subtitle says
           the account is exactly the contradiction the scope note exists for. */}
       <PipelineBoard
         variant="locked"
@@ -394,6 +384,24 @@ export default async function DashboardPage() {
         total={state.total}
         stageTotals={stageCountsOf(state.summary)}
         pulse={{ needsReview: state.needsReview }}
+        toolbar={
+          <SyncBar
+            subtitle={subtitle}
+            gmail={gmail}
+            since={
+              user?.id ? (
+                <SinceLastLook
+                  rows={state.applications.map(toChangeRow)}
+                  total={state.total}
+                  scope={user.id}
+                  storageKey={LAST_LOOK_KEY}
+                />
+              ) : null
+            }
+          >
+            <AddApplicationForm compact />
+          </SyncBar>
+        }
         beforeList={notifPrefs.reviewAlerts ? queue : null}
         afterList={!notifPrefs.reviewAlerts ? queue : null}
       />

--- a/apps/web/app/demo/shell/page.tsx
+++ b/apps/web/app/demo/shell/page.tsx
@@ -36,7 +36,7 @@ export const dynamic = "force-dynamic";
  *
  * What is fixture here and what is real:
  *   - real: every layout component, the board's full interactivity (drag,
- *     detail sheet, stage filter), the pulse in the board's stage spine, the
+ *     detail sheet, stage filter), the pulse band across the board, the
  *     theme.
  *   - fixture: the rows, the rail's Gmail state, and the identity block.
  *   - the pulse's `needsReview` is 0, same reasoning as /demo: the classifier

--- a/apps/web/components/dashboard/PipelineBoard.tsx
+++ b/apps/web/components/dashboard/PipelineBoard.tsx
@@ -37,9 +37,16 @@ import { liveBoardTransport, type BoardTransport } from "@/lib/dashboard/transpo
  *     zero and an empty meter, which costs a line, not a quarter of the
  *     screen. At 29-0-0-0 it reads as a young pipeline; at a healthy spread
  *     it reads as a funnel. Below `lg` it compresses into a chip strip.
- *     When the caller passes `pulse`, the pulse's four derived signals
- *     (`PipelinePulse`) stack under the stage buttons and fill the column's
- *     blank run — stage lens above, derived lenses below, one instrument.
+ *   - the **pulse band** (`pulse` prop): the four derived signals
+ *     (`PipelinePulse`) as one full-width band above the spine + worklist
+ *     row — dashboard content, in the dashboard's content area. This is the
+ *     pre-#136 home restored at band-density (~56px, not the old ~200px
+ *     strip); the spine and the shell rail are both measured, rejected homes
+ *     for it (see PipelinePulse's header).
+ *   - the **command row** (top): search, the caller's sync surface
+ *     (`toolbar`), and the board's own scope lines share ONE full-width row,
+ *     so the dashboard spends a single line of chrome above the band where
+ *     it used to spend three (page header, notice line, in-column toolbar).
  *   - the **worklist** (right) renders every application as one full-width
  *     row with a fixed skeleton, grouped by stage in flow order. Rows are
  *     even by construction: company and the role slot share one line, and a
@@ -159,7 +166,9 @@ function StaticApplicationRow({
     // `sm` (stamp on the company line, meta left-anchored), one line above it.
     <div
       className="flex flex-col gap-y-1.5 rounded-lg border border-line-soft bg-surface-2 py-2 pl-3 pr-2 transition-colors hover:border-line-strong sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3"
-      style={{ borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)` }}
+      style={{
+        borderLeft: `2px solid color-mix(in oklab, ${stage.color} 55%, transparent)`,
+      }}
     >
       <div className="flex min-w-0 flex-col gap-y-0.5 sm:flex-1 sm:basis-56 sm:flex-row sm:items-baseline sm:gap-x-2.5">
         {inSet ? (
@@ -275,9 +284,7 @@ function BoardCell({
       layoutId={layoutKey}
       initial={entering && !reduceMotion ? { opacity: 0, y: 6 } : false}
       animate={{ opacity: 1, y: 0 }}
-      transition={
-        reduceMotion ? { duration: 0 } : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }
-      }
+      transition={reduceMotion ? { duration: 0 } : { duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
     >
       {children}
     </motion.li>
@@ -312,6 +319,7 @@ export function PipelineBoard({
   variant = "flow",
   transport = liveBoardTransport,
   pulse,
+  toolbar,
   beforeList,
   afterList,
 }: {
@@ -322,11 +330,17 @@ export function PipelineBoard({
   variant?: "locked" | "flow";
   /** How mutations reach data — the live proxy by default, fixtures on /demo. */
   transport?: BoardTransport;
-  /** Mount the pulse's derived signals under the stage buttons (see the spine
-   *  note above). Omitted by the inert empty-state preview on purpose: four
-   *  derived signals over sample rows would be onboarding noise. `needsReview`
-   *  is the account's held-verdict count — the classifier signal's deep link. */
+  /** Mount the pulse's derived signals as a full-width band above the spine +
+   *  worklist row (`lg`-up, one instance — see the band note above). Omitted
+   *  by the inert empty-state preview on purpose: four derived signals over
+   *  sample rows would be onboarding noise. `needsReview` is the account's
+   *  held-verdict count — the auto-filed signal's deep link. */
   pulse?: { needsReview: number };
+  /** The caller's sync surface (SyncBar), rendered INTO the board's command
+   *  row beside search. Both twins pass it, so the one-row header is shared
+   *  composition, not a copy — and the board never has to know what a sync
+   *  is. Error/empty pages render the same SyncBar standalone instead. */
+  toolbar?: ReactNode;
   /** Rendered inside the list pane, above the rows (e.g. the review queue
    *  when alerts interrupt) — it scrolls with the list, so an interrupt can
    *  never starve the worklist of its viewport. */
@@ -413,8 +427,7 @@ export function PipelineBoard({
    *  — a set the user opened stays open across filters and refreshes of this
    *  mount, and there is nothing worth persisting beyond it. */
   const [openSets, setOpenSets] = useState<Record<string, boolean>>({});
-  const toggleSet = (key: string) =>
-    setOpenSets((s) => ({ ...s, [key]: !s[key] }));
+  const toggleSet = (key: string) => setOpenSets((s) => ({ ...s, [key]: !s[key] }));
 
   /**
    * The chip is suppressed for the company the board is already filtered to —
@@ -432,7 +445,13 @@ export function PipelineBoard({
   for (const app of applications) {
     let counts = companyStages.get(app.company);
     if (!counts) {
-      counts = { applied: 0, assessment: 0, interviewing: 0, offered: 0, rejected: 0 };
+      counts = {
+        applied: 0,
+        assessment: 0,
+        interviewing: 0,
+        offered: 0,
+        rejected: 0,
+      };
       companyStages.set(app.company, counts);
     }
     counts[stageOf(shownStatus(app))] += 1;
@@ -686,7 +705,10 @@ export function PipelineBoard({
           >
             <span
               className="block h-full rounded-full"
-              style={{ width: `${(count / spineMax) * 100}%`, background: column.color }}
+              style={{
+                width: `${(count / spineMax) * 100}%`,
+                background: column.color,
+              }}
             />
           </span>
         ) : null}
@@ -695,16 +717,23 @@ export function PipelineBoard({
   };
 
   /**
-   * Search + view state. Lives INSIDE the worklist column (not spanning the
-   * spine): it filters the list, so it sits over the list — and the spine
-   * gets the column's full height for the stage lens + pulse, which is where
-   * that height was being wasted as a full-width input row.
+   * The command row: search, the board's own scope lines, and the caller's
+   * sync surface on ONE full-width line. Search used to live inside the
+   * worklist column while the page spent a separate header row on the title
+   * and controls — with the title in the shell's top bar and the sync
+   * cluster here, that whole row comes back to the worklist. Search keeps
+   * the left edge (it filters the list below); the sync surface owns the
+   * right, and its transient lines (status, alert, receipt) wrap to their
+   * own full-width lines only while they have something to say.
    */
-  const toolbar =
-    showSearch || filterActive || scopeNote ? (
+  const commandRow =
+    toolbar || showSearch || filterActive || scopeNote ? (
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        {/* Search is full-width below `sm` — beside a stacked sync surface, a
+            shared line vertically centres the input against the whole stack
+            and squeezes the subtitle off-screen (measured at 375). */}
         {showSearch ? (
-          <div className="relative min-w-0 flex-1 basis-56 sm:max-w-sm">
+          <div className="relative w-full sm:w-auto sm:min-w-0 sm:flex-1 sm:basis-40 sm:max-w-56">
             <Search
               className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-dim"
               aria-hidden
@@ -720,7 +749,7 @@ export function PipelineBoard({
           </div>
         ) : null}
         {filterActive ? (
-          <span className="tabular text-xs text-dim" role="status">
+          <span className="tabular shrink-0 text-xs text-dim" role="status">
             {filtered.length} of {applications.length} shown
           </span>
         ) : null}
@@ -732,6 +761,7 @@ export function PipelineBoard({
             board shows the {scopeNote} · older rows aren&apos;t loaded
           </span>
         ) : null}
+        {toolbar}
       </div>
     ) : null;
 
@@ -740,6 +770,21 @@ export function PipelineBoard({
       data-testid="pipeline-board"
       className={cn("flex flex-col gap-3", locked && "lg:min-h-0 lg:flex-1")}
     >
+      {commandRow}
+
+      {/* --- The pulse band (lg-up) ------------------------------------------
+          Full width, above the spine + worklist row — the dashboard's own
+          content area, which is the one home the owner has accepted for it.
+          One instance: below `lg` the cards carry the same ground truth
+          (age tags, deadline tags, the review queue), so nothing renders. */}
+      {pulse ? (
+        <PipelinePulse
+          applications={applications}
+          total={total ?? applications.length}
+          needsReview={pulse.needsReview}
+        />
+      ) : null}
+
       {/* --- The stage lens, compressed (below lg) --------------------------
           `flex-wrap`, not a scroller: at 375px the horizontal scroller cut
           "offered" to "offer" at the viewport edge and hid "closed" entirely,
@@ -766,11 +811,16 @@ export function PipelineBoard({
       </div>
 
       {/* --- Body: spine + worklist ----------------------------------------- */}
-      <div className={cn("flex flex-col gap-4 lg:flex-row lg:gap-5", locked && "lg:min-h-0 lg:flex-1")}>
+      <div
+        className={cn("flex flex-col gap-4 lg:flex-row lg:gap-5", locked && "lg:min-h-0 lg:flex-1")}
+      >
+        {/* w-44, not the w-52 the pulse-in-spine era needed: the longest
+            stage word + count fits comfortably, and every horizontal pixel
+            the emptier column gives back goes to the rows. */}
         <aside
           aria-label="Stages"
           className={cn(
-            "hidden w-52 shrink-0 flex-col gap-0.5 lg:flex",
+            "hidden w-44 shrink-0 flex-col gap-0.5 lg:flex",
             locked ? "lg:min-h-0 lg:overflow-y-auto" : "lg:sticky lg:top-5 lg:self-start",
           )}
         >
@@ -802,25 +852,9 @@ export function PipelineBoard({
             </span>
           </button>
           {columns.map((column) => stageButton(column, "spine"))}
-          {/* The pulse fills the run under the stage buttons — the blank
-              space this column used to spend on nothing. `px-2.5` puts its
-              text on the stage labels' own left edge; its first section's
-              hairline is the divider. The spine's counts above state the
-              ACCOUNT; the pulse derives from the loaded rows and its own
-              scope line says so when the two differ. */}
-          {pulse ? (
-            <div className="mt-0.5 px-2.5">
-              <PipelinePulse
-                applications={applications}
-                total={total ?? applications.length}
-                needsReview={pulse.needsReview}
-              />
-            </div>
-          ) : null}
         </aside>
 
         <div className={cn("flex min-w-0 flex-1 flex-col gap-3", locked && "lg:min-h-0")}>
-          {toolbar}
           {/* --- The filter state, stated once ------------------------------ */}
           {companyFilter !== null ? (
             <CompanyBand
@@ -847,7 +881,10 @@ export function PipelineBoard({
                 lock nothing pushes against would pass vacuously. */}
             <div
               data-testid="worklist-pane"
-              className={cn("space-y-4", locked && "lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1")}
+              className={cn(
+                "space-y-4",
+                locked && "lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1",
+              )}
             >
               {beforeList}
               {groups.map(({ column, items }) => (
@@ -928,7 +965,11 @@ export function PipelineBoard({
       </div>
 
       {interactive ? (
-        <ApplicationDetail app={detailApp} onClose={() => setDetailApp(null)} transport={transport} />
+        <ApplicationDetail
+          app={detailApp}
+          onClose={() => setDetailApp(null)}
+          transport={transport}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/components/dashboard/PipelinePulse.tsx
+++ b/apps/web/components/dashboard/PipelinePulse.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import type { ReactNode } from "react";
 
 import { bucketAges, daysBetween, momentumDelta, weeklyCounts } from "@/lib/dashboard/age";
 import { useLocalToday } from "@/lib/dashboard/useLocalToday";
@@ -25,32 +26,29 @@ import { stageOf, type PulseRow } from "@/lib/dashboard/summary";
  *     that inks the card tags (`lib/dashboard/deadline.ts`), plus the single
  *     most urgent row BY NAME — the one thing on this surface a user should
  *     act on today. When nothing carries a deadline the cell says so and says
- *     where deadlines come from, instead of inventing urgency: most boards,
+ *     where a deadline comes from, instead of inventing urgency: most boards,
  *     most of the time, honestly have nothing due;
- *   - **classifier** — how much of this pipeline the classifier built
- *     (source = "gmail" rows) and what it is holding under the 0.85 gate,
- *     deep-linked to the review queue.
+ *   - **auto-filed** — how much of this board arrived from the user's own
+ *     mail (source = "gmail" rows) and what is being held for their review,
+ *     deep-linked to the review queue. The mechanism's real names (the
+ *     classifier, the 0.85 gate) live in Settings, which is the page that
+ *     controls them — here the user has a mailbox, not a classifier.
  *
- * ONE home, one layout: the column under the stage buttons in the board's own
- * spine (`PipelineBoard` mounts it inside the "Stages" aside). It lived as a
- * full-width strip above the worklist, then as the shell rail's instrument
- * column (PR #122) — both were the wrong shelf, measured: the strip spent a
- * ~200px band of every viewport restating what this column says in the
- * spine's own blank space, and the rail version made the sidebar itself
- * scroll (744px of column in a 537–717px pane at 1280×720…1440×900), which
- * read as "the dashboard still scrolls". The spine has the empty vertical
- * run under "closed", it is stage-lens territory (these signals ARE lenses on
- * the same rows), and it collapses below `lg` exactly like the pulse should:
- * a phone dashboard leads with the worklist, and every signal's ground truth
- * already inks the cards themselves (age tags, deadline tags, the review
- * queue in the list). No display-none twin renders anywhere.
+ * ONE home, one layout: a full-width band across the top of the board's body
+ * (`PipelineBoard` mounts it above the spine + worklist row). This is the
+ * pre-#136 home restored at a fraction of the cost: the original strip spent
+ * ~200px of every viewport (p-4 cells, h-9 bars, a week-axis line, a
+ * two-line urgent block); this band says the same four things in ~56px —
+ * label, drawn element and one figure line per cell, the urgent row riding
+ * the deadline cell's own label line. The two rejected homes stay rejected:
+ * the shell rail (PR #122) made the sidebar itself scroll, and the stage
+ * spine (#136) took the pulse out of the dashboard's content area, which is
+ * where the owner keeps putting it back. Left columns are closed territory
+ * for this feature.
  *
- * The grammar is the spine's own: a caps label, a drawn element, one figure
- * line — dense on purpose. No week axis (the delta line states recency; the
- * aria-label states "oldest first"), no ladders (three rungs of dot–label–
- * figure cost 3× the height of one condensed line and said the same thing),
- * and exactly two bars (momentum's and ageing's): deadline counts are units,
- * not proportions, and the classifier fraction is already a number.
+ * `lg`-up only, one instance, no display-none twins: below `lg` the dashboard
+ * leads with the worklist and every signal's ground truth already inks the
+ * cards themselves (age tags, deadline tags, the review queue in the list).
  *
  * Rows arrive as {@link PulseRow} — the projection of a board row this
  * component actually reads; callers holding full rows pass them as-is
@@ -68,7 +66,7 @@ import { stageOf, type PulseRow } from "@/lib/dashboard/summary";
  * Honesty rules: the board fetch is one bounded page, so when the loaded rows
  * are fewer than the account's total the row-derived signals say they describe
  * the newest N rather than pretending to describe everything — once, as the
- * column's last line, since every signal derives from the same slice.
+ * band's trailing line, since every signal derives from the same slice.
  * Ages/weeks are calendar-day math on a day string — UTC for the server pass
  * and the hydrating pass, the reader's own day thereafter — so the pulse
  * hydrates cleanly and then tells the truth about time left. The micro-bars
@@ -92,7 +90,7 @@ function SegmentBar({
     <div
       role="img"
       aria-label={ariaLabel}
-      className="mt-1.5 flex h-1.5 overflow-hidden rounded-full bg-surface-2"
+      className="flex h-1.5 w-16 shrink-0 overflow-hidden rounded-full bg-surface-2"
     >
       {segments
         .filter(([count]) => count > 0)
@@ -107,6 +105,35 @@ function SegmentBar({
             }}
           />
         ))}
+    </div>
+  );
+}
+
+/**
+ * One cell of the band: caps label (with an optional right-aligned aside on
+ * the same line — the deadline cell's "act on this today" slot), then one
+ * content line. Two lines, `py-2` — the whole band's height budget lives
+ * here, because every pixel it grows comes out of the worklist below it.
+ */
+function PulseCell({
+  label,
+  aside,
+  children,
+}: {
+  label: string;
+  aside?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-w-0 border-line-soft px-3 py-2 first:pl-0 last:pr-0 [&+&]:border-l">
+      <div className="flex items-baseline justify-between gap-2">
+        {/* A cell WITH an aside keeps its (short) label whole and lets the
+            aside truncate; a cell without one lets the label give way at the
+            narrowest lg widths instead of bleeding into its neighbour. */}
+        <h2 className={aside ? "label-caps shrink-0" : "label-caps min-w-0 truncate"}>{label}</h2>
+        {aside}
+      </div>
+      <div className="mt-1 flex min-w-0 items-center gap-2">{children}</div>
     </div>
   );
 }
@@ -155,20 +182,23 @@ export function PipelinePulse({
   // --- deadlines (rows carrying a due_at; no due date, no claim) -------------
   const due = deadlinePulse(applications, today);
 
-  // --- classifier -----------------------------------------------------------
+  // --- auto-filed -----------------------------------------------------------
   const autoFiled = applications.filter((app) => app.source === "gmail").length;
 
   const scopeNote = complete ? null : `newest ${applications.length} of ${total}`;
 
   return (
-    <section aria-label="Pipeline pulse" data-testid="pipeline-pulse" className="flex flex-col">
+    <section
+      aria-label="Pipeline pulse"
+      data-testid="pipeline-pulse"
+      className="hidden border-y border-line-soft lg:grid lg:grid-cols-4"
+    >
       {/* momentum */}
-      <div className="border-t border-line-soft py-2">
-        <h2 className="label-caps">momentum · filed per wk</h2>
+      <PulseCell label="momentum · filed per wk">
         <div
           role="img"
           aria-label={`Applications filed per week, oldest first: ${weeks.join(", ")}`}
-          className="mt-1.5 flex h-5 items-end gap-1"
+          className="flex h-4 w-16 shrink-0 items-end gap-0.5"
         >
           {weeks.map((count, i) => (
             <span
@@ -184,17 +214,16 @@ export function PipelinePulse({
             />
           ))}
         </div>
-        <p className="tabular mt-1.5 text-xs text-muted">
+        <p className="tabular min-w-0 truncate text-xs text-muted">
           <span className="tabular text-strong">{recent}</span> last 4 wk{" "}
           <span aria-hidden="true">{arrow}</span> vs {prior} prior
         </p>
-      </div>
+      </PulseCell>
 
       {/* ageing */}
-      <div className="border-t border-line-soft py-2">
-        <h2 className="label-caps">open · age since filed</h2>
+      <PulseCell label="open · age since filed">
         {openTotal === 0 ? (
-          <p className="mt-2 text-xs text-dim">no open applications</p>
+          <p className="text-xs text-dim">no open applications</p>
         ) : (
           <>
             <SegmentBar
@@ -206,10 +235,10 @@ export function PipelinePulse({
                 [ages.quiet, "var(--amber)"],
               ]}
             />
-            <p className="tabular mt-1.5 text-xs text-muted">
+            <p className="tabular min-w-0 truncate text-xs text-muted">
               <span className="tabular text-strong">{ages.fresh}</span> &lt;1 wk ·{" "}
               <span className="tabular">{ages.waiting}</span> 1–2 wk ·{" "}
-              {/* "quiet" is the column's one amber word when it is non-zero —
+              {/* "quiet" is the band's one amber word when it is non-zero —
                   the same threshold that tags the individual cards. */}
               <span className={ages.quiet > 0 ? "text-review" : ""}>
                 <span className="tabular">{ages.quiet}</span> quiet
@@ -217,78 +246,79 @@ export function PipelinePulse({
             </p>
           </>
         )}
-      </div>
+      </PulseCell>
 
-      {/* deadlines */}
-      <div className="border-t border-line-soft py-2">
-        <h2 className="label-caps">deadlines · time left</h2>
+      {/* deadlines — the label tail is cut here (unlike its siblings) to make
+          room for the one thing on this surface to act on today, named on the
+          label's own line: the row with the smallest days-left, so an overdue
+          row outranks everything until it is dealt with. */}
+      <PulseCell
+        label="deadlines"
+        aside={
+          due.urgent ? (
+            // The phrase is the urgent part, so it never truncates; a long
+            // company name gives way instead.
+            <p className="flex min-w-0 items-baseline gap-1 text-xs leading-snug text-muted">
+              <span className="shrink-0">next ·</span>
+              <span className="min-w-0 truncate">{due.urgent.company}</span>
+              <span
+                className={`tabular shrink-0 font-mono text-[10px] ${
+                  due.urgent.daysLeft < 0 ? "text-reject-ink" : "text-review"
+                }`}
+              >
+                {duePhrase(due.urgent.daysLeft)}
+              </span>
+            </p>
+          ) : undefined
+        }
+      >
         {due.total === 0 ? (
-          <>
-            {/* The state most users see most of the time, so it earns real
-                copy: never a nag, never counts drawn at zero. */}
-            <p className="mt-2 text-xs text-dim">nothing due</p>
-            <p className="mt-1 text-[11px] leading-snug text-dim">
-              filed from mail when one is stated · or set one in a card&apos;s detail
-            </p>
-          </>
+          // The state most users see most of the time — never a nag, never
+          // counts drawn at zero, and it says where a deadline comes from.
+          <p className="min-w-0 truncate text-xs text-dim">
+            nothing due · set one in a card&apos;s detail
+          </p>
         ) : (
-          <>
-            {/* Counts, no bar: deadline counts are units, not proportions —
-                two overdue beside ten "later" is not a 1:5 wash of red.
-                "N overdue" turns red as a unit — a red word beside a white
-                digit would put the emphasis on the wrong half. */}
-            <p className="tabular mt-1.5 text-xs text-muted">
-              <span className={due.overdue > 0 ? "font-medium text-reject-ink" : ""}>
-                <span className={due.overdue > 0 ? "tabular" : "tabular text-strong"}>
-                  {due.overdue}
-                </span>{" "}
-                overdue
+          // Counts, no bar: deadline counts are units, not proportions — two
+          // overdue beside ten "later" is not a 1:5 wash of red. "N overdue"
+          // turns red as a unit — a red word beside a white digit would put
+          // the emphasis on the wrong half.
+          <p className="tabular min-w-0 truncate text-xs text-muted">
+            <span className={due.overdue > 0 ? "font-medium text-reject-ink" : ""}>
+              <span className={due.overdue > 0 ? "tabular" : "tabular text-strong"}>
+                {due.overdue}
               </span>{" "}
-              · <span className="tabular">{due.soon}</span> ≤{DUE_SOON_DAYS}d ·{" "}
-              <span className="tabular">{due.later}</span> later
-            </p>
-            {/* The one to act on today, by name — smallest days-left wins, so
-                an overdue row outranks everything until it is dealt with. */}
-            {due.urgent ? (
-              <p className="mt-1 text-xs leading-snug text-muted">
-                next · {due.urgent.company}{" "}
-                <span
-                  className={`tabular font-mono text-[10px] ${
-                    due.urgent.daysLeft < 0 ? "text-reject-ink" : "text-review"
-                  }`}
-                >
-                  {duePhrase(due.urgent.daysLeft)}
-                </span>
-              </p>
-            ) : null}
-          </>
+              overdue
+            </span>{" "}
+            · <span className="tabular">{due.soon}</span> ≤{DUE_SOON_DAYS}d ·{" "}
+            <span className="tabular">{due.later}</span> later
+          </p>
         )}
-      </div>
+      </PulseCell>
 
-      {/* classifier */}
-      <div className="border-t border-line-soft py-2">
-        <h2 className="label-caps">classifier</h2>
-        <p className="tabular mt-1.5 text-xs text-muted">
-          <span className="tabular text-strong">{autoFiled}</span> of {applications.length}{" "}
-          auto-filed from mail
+      {/* auto-filed */}
+      <PulseCell label="auto-filed · from your mail">
+        <p className="tabular min-w-0 truncate text-xs text-muted">
+          <span className="tabular text-strong">{autoFiled}</span> of {applications.length}
+          {" · "}
+          {needsReview > 0 ? (
+            <Link
+              href="/dashboard#needs-classification"
+              className="font-medium text-review underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
+            >
+              <span className="tabular">{needsReview}</span> held for your review →
+            </Link>
+          ) : (
+            <span className="text-dim">nothing waiting on you</span>
+          )}
         </p>
-        {needsReview > 0 ? (
-          <Link
-            href="/dashboard#needs-classification"
-            className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-review underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong"
-          >
-            <span className="tabular">{needsReview}</span> held under the 0.85 gate →
-          </Link>
-        ) : (
-          <p className="mt-1 text-xs text-dim">queue clear · gate 0.85</p>
-        )}
-      </div>
+      </PulseCell>
 
-      {/* The bounded-page caveat, once for the whole column — every signal
+      {/* The bounded-page caveat, once for the whole band — every signal
           above derives from the same loaded slice, so per-cell repetition
-          bought nothing but noise at this width. */}
+          bought nothing but noise. */}
       {scopeNote ? (
-        <p className="border-t border-line-soft py-2 text-[11px] leading-snug text-dim">
+        <p className="tabular col-span-full border-t border-line-soft py-1 text-[11px] leading-snug text-dim">
           signals derive from the {scopeNote} rows
         </p>
       ) : null}

--- a/apps/web/components/dashboard/SinceLastLook.tsx
+++ b/apps/web/components/dashboard/SinceLastLook.tsx
@@ -48,25 +48,32 @@ import { useLocalToday } from "@/lib/dashboard/useLocalToday";
  * individuals (which the counts cannot), the same two-level shape the pulse
  * strip's deadline cell already uses.
  *
- * ONE LINE ON ARRIVAL — the shape, and why it is this shape
- * ---------------------------------------------------------
- * The two levels are now literally two levels: the arrival LINE carries the
- * counts, and opening it names the rows. Every state of this band — the server
- * pass, first run, quiet, and a loud return — occupies exactly one line box at
- * every width, so the band can never move the board it sits above.
+ * A CHIP ON THE COMMAND ROW — the shape, and why it is this shape
+ * ----------------------------------------------------------------
+ * The two levels are literally two levels: the arrival CHIP carries the
+ * counts, and opening it names the rows. The chip lives on the dashboard's
+ * one command row (SyncBar's `since` slot, between the subtitle and the sync
+ * controls), inside a wrapper whose flex-basis is FIXED — so hydration can
+ * never re-wrap the row, and every state of this chip occupies the same line
+ * box. The dedicated notice line it used to hold is a line the worklist got
+ * back.
  *
- * That is not only a layout fix. The band sits between the sync header and the
- * board on a work surface, and the old block grew with the news: three groups
- * of four named rows plus "+N more" is ~300px on a laptop and half a phone
- * screen, so the busiest morning — the one this feature exists for — was the
- * morning the board itself got pushed out of view. A digest that costs the
- * work surface more space the more there is to say has its incentives
- * backwards. One line always; the reader spends the space, by opening it, only
- * when they want the names.
+ * Space inside the chip varies with the viewport and its row-mates, so the
+ * loud state is container-adaptive rather than truncated: per-kind counts
+ * ("2 filed · 1 moved") when the chip is wide enough to say them, the total
+ * ("3 changes") when it is not — and the opened panel names the rows either
+ * way, so nothing is ever clipped mid-claim.
+ *
+ * The NAMES are an overlay, not a reflow: opening the chip floats the panel
+ * over the board (absolutely positioned under the row) instead of pushing the
+ * board down. The old block grew with the news — three groups of four named
+ * rows plus "+N more" is ~300px on a laptop — so the busiest morning was the
+ * morning the board itself got pushed out of view. Now not even the asked-for
+ * expansion moves the work surface.
  *
  * The expansion is never remembered. Restoring it on the next load would
  * re-create exactly the defect this shape removes — the server cannot know it
- * was open, so the board would move again after hydration.
+ * was open, so the panel would pop over the board unasked after hydration.
  *
  * Three states, all of them real:
  *
@@ -140,7 +147,9 @@ function DueNote({ dueAt, today }: { dueAt: string; today: string }) {
   const ink =
     due.state === "overdue" ? "text-reject" : due.state === "soon" ? "text-review" : "text-dim";
   return (
-    <span className={`tabular shrink-0 font-mono text-[10px] ${ink}`}>{duePhrase(due.daysLeft)}</span>
+    <span className={`tabular shrink-0 font-mono text-[10px] ${ink}`}>
+      {duePhrase(due.daysLeft)}
+    </span>
   );
 }
 
@@ -243,10 +252,21 @@ export function SinceLastLook({
    *  impure and a render must not depend on when it happens to run. */
   const [now] = useState(() => Date.now());
   /** Whether the names are showing. Deliberately not persisted — see the
-   *  header: a remembered expansion would move the board on the next load,
-   *  because the server pass cannot know about it. */
+   *  header: a remembered panel would pop over the board unasked on the next
+   *  load, because the server pass cannot know about it. */
   const [named, setNamed] = useState(false);
   const panelId = useId();
+
+  // The panel is an overlay, so it gets an overlay's exit: Escape closes it.
+  // (The toggle and "Mark as seen" are the other two ways out.)
+  useEffect(() => {
+    if (!named) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setNamed(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [named]);
 
   const partial = total !== undefined && rows.length < total;
   const entries = useMemo(
@@ -266,7 +286,10 @@ export function SinceLastLook({
     // digest it exists to protect.
     const stored = parseLastLook(readLastLookRaw(storageKey), scope);
     if (stored === null) {
-      writeLastLook(storageKey, { ...snapshotOf(rows, scope, Date.now(), partial), seed: true });
+      writeLastLook(storageKey, {
+        ...snapshotOf(rows, scope, Date.now(), partial),
+        seed: true,
+      });
       return;
     }
     // Rule 3: nothing to report → fold the board in, leave the moment alone.
@@ -305,15 +328,20 @@ export function SinceLastLook({
 
   if (seeded) {
     return (
-      <section data-testid="since-last-look" aria-label="Changes since your last visit">
+      <section
+        data-testid="since-last-look"
+        aria-label="Changes since your last visit"
+        className="w-full @container"
+      >
         <ArrivalLine>
           {/* The clause that carries the fact is the whole sentence on a
-              phone; the tail explaining what happens next is what a wider
-              line has room for. One sentence, two lengths — never two lines. */}
+              tight chip; the tail explaining what happens next is what a
+              roomier one has space for. One sentence, two lengths — never
+              two lines. */}
           <p className="min-w-0 truncate text-dim">
             No earlier visit recorded in this browser
-            <span className="sm:hidden">.</span>
-            <span className="hidden sm:inline">
+            <span className="@[34rem]:hidden">.</span>
+            <span className="hidden @[34rem]:inline">
               {" "}
               — from your next one, this line names what changed.
             </span>
@@ -327,14 +355,20 @@ export function SinceLastLook({
 
   if (groups.length === 0) {
     return (
-      <section data-testid="since-last-look" aria-label="Changes since your last visit">
+      <section
+        data-testid="since-last-look"
+        aria-label="Changes since your last visit"
+        className="w-full @container"
+      >
         <ArrivalLine>
           <p className="min-w-0 truncate text-muted">
             Nothing new since <span className="font-mono text-[11px] text-dim">{moment}</span>
-            {/* The slice this reading covers, where a phone has room for it —
-                the board and the pulse carry the same disclosure, in the
+            {/* The slice this reading covers, where the chip has room for it
+                — the board and the pulse carry the same disclosure, in the
                 same words, at every width. */}
-            {scopeNote ? <span className="hidden text-dim sm:inline"> · {scopeNote}</span> : null}
+            {scopeNote ? (
+              <span className="hidden text-dim @[34rem]:inline"> · {scopeNote}</span>
+            ) : null}
           </p>
         </ArrivalLine>
       </section>
@@ -342,28 +376,22 @@ export function SinceLastLook({
   }
 
   const Chevron = named ? ChevronUp : ChevronDown;
-  /** The phone's one number, summed from the same groups the wider line prints
-   *  one by one — two renderings of one reading, never two readings. */
+  /** The narrow chip's one number, summed from the same groups the wider chip
+   *  prints one by one — two renderings of one reading, never two readings. */
   const counted = groups.reduce((sum, group) => sum + group.count, 0);
 
   return (
     <section
       data-testid="since-last-look"
       aria-label="Changes since your last visit"
-      /* Capped to a reading measure rather than the page's width: the stage
-         annotations form a right-hand column, and across 1100px the eye loses
-         which name they belong to. */
-      className="max-w-3xl border-l-2 border-stage-applied pl-3"
+      /* `@container` because the chip's room depends on its row-mates, not
+         the viewport: the /demo row carries a wider cluster than the signed-in
+         one at the same width, and a viewport breakpoint cannot know that.
+         The blue rule is the loud state's across-the-room signal — the caps
+         heading it used to carry belongs to the section's aria-label now. */
+      className="relative w-full border-l-2 border-stage-applied pl-2 @container"
     >
       <ArrivalLine>
-        {/* Below `sm` the counts lead and the heading gives way — the news
-            first, then the window it covers; the section's own label carries
-            the name of the band for a reader who cannot see the rule. */}
-        <h2 className="label-caps order-1 hidden shrink-0 sm:block">since you last looked</h2>
-        <span className="order-3 shrink-0 font-mono text-[11px] text-dim sm:order-2">
-          · {moment}
-        </span>
-
         {/* The counts ARE the control: pressing them is what names the rows
             they count, so the affordance and the summary are one thing rather
             than a label with a "show" beside it. */}
@@ -372,16 +400,17 @@ export function SinceLastLook({
           aria-expanded={named}
           aria-controls={panelId}
           onClick={() => setNamed((showing) => !showing)}
-          className={`${LINE_CONTROL} order-2 flex min-w-0 items-baseline gap-1.5 text-muted sm:order-3`}
+          className={`${LINE_CONTROL} flex min-w-0 items-baseline gap-1.5 text-muted`}
         >
           <span className="tabular truncate">
-            {/* One rendering at a time, never both: a phone gets the total, a
-                wider line gets the kinds. The count is the group's heading in
-                both — no summary restates it. */}
-            <span className="sm:hidden">
+            {/* One rendering at a time, never both: a tight chip gets the
+                total, a roomy one gets the kinds. Opening it names the rows
+                under their kind either way, so a reader on the total form is
+                one press from everything the wide form says. */}
+            <span className="@[26rem]:hidden">
               {counted} change{counted === 1 ? "" : "s"}
             </span>
-            <span className="hidden sm:inline">
+            <span className="hidden @[26rem]:inline">
               {groups.map((group, i) => (
                 <Fragment key={group.kind}>
                   {i > 0 ? <span className="text-dim"> · </span> : null}
@@ -396,20 +425,29 @@ export function SinceLastLook({
           <span className="sr-only">{named ? "Hide the rows" : "Name the rows"}</span>
         </button>
 
+        <span className="hidden shrink-0 font-mono text-[11px] text-dim @[34rem]:inline">
+          · {moment}
+        </span>
+
         <button
           type="button"
           onClick={() => writeLastLook(storageKey, snapshotOf(rows, scope, Date.now(), partial))}
-          className={`${LINE_CONTROL} order-4 ml-auto shrink-0 text-muted`}
+          className={`${LINE_CONTROL} ml-auto shrink-0 text-muted`}
         >
           Mark as seen
         </button>
       </ArrivalLine>
 
-      {/* Opened by the reader, so the space it takes is spent on purpose —
-          this is the only thing on the band that moves the board, and only
-          ever after a press. */}
+      {/* Opened by the reader — and even then the board holds still: the
+          panel FLOATS under the row (anchored to the chip's right edge, so it
+          opens inward over the board rather than past the pane's edge). The
+          one movement this feature used to make on request is now no
+          movement at all. */}
       {named ? (
-        <div id={panelId} className="pb-1 pt-2.5">
+        <div
+          id={panelId}
+          className="absolute right-0 top-full z-30 mt-2 w-[min(38rem,85vw)] rounded-xl border border-line bg-surface p-4 shadow-[0_18px_50px_-20px_rgba(0,0,0,0.8)]"
+        >
           {/* Baseline alignment across the two columns, not a nudge: the kind
               label is 11px caps and the entries 13px, so the grid lines their
               first baselines up rather than their boxes. */}
@@ -419,17 +457,16 @@ export function SinceLastLook({
               const hidden = group.count - shown.length;
               return (
                 <Fragment key={group.kind}>
-                  {/* The kind, not the count: the line above is already the
-                      counts, and the same number twice is the thing this
+                  {/* The kind, not the count: the chip is already the counts
+                      (and on its total form, the entries under each kind ARE
+                      the count) — the same number twice is the thing this
                       dashboard removed everywhere else. */}
                   <dt className="label-caps">{group.label}</dt>
                   <dd className="space-y-1.5">
                     {shown.map((entry) => (
                       <EntryLine key={entry.id} entry={entry} today={today} />
                     ))}
-                    {hidden > 0 ? (
-                      <p className="tabular text-xs text-dim">+{hidden} more</p>
-                    ) : null}
+                    {hidden > 0 ? <p className="tabular text-xs text-dim">+{hidden} more</p> : null}
                   </dd>
                 </Fragment>
               );
@@ -438,7 +475,7 @@ export function SinceLastLook({
 
           {/* The ledger reads one bounded page, so it says which page — the
               same disclosure, in the same words, as the board and the pulse
-              strip. */}
+              band. */}
           {scopeNote ? (
             <p className="tabular mt-2.5 text-xs text-dim">
               reads the {scopeNote} · older rows aren&apos;t loaded

--- a/apps/web/components/dashboard/SyncBar.tsx
+++ b/apps/web/components/dashboard/SyncBar.tsx
@@ -42,9 +42,19 @@ import { filedSummary, isStale, type SyncCounts } from "@/lib/gmail/sync-state";
 
 /**
  * The one sync surface. Everything the dashboard says about Gmail flows
- * through this component: the header (title, subtitle, recency, the `Sync`
- * button, the `⋯` overflow), the persistent status/alert line, the rebuild
- * dialog, and the rebuild receipt.
+ * through this component: the header cluster (subtitle, the change-ledger
+ * chip, recency, the `Sync` button, the `⋯` overflow), the persistent
+ * status/alert line, the rebuild dialog, and the rebuild receipt.
+ *
+ * It renders as ROW CONTENT, not a block: the root is a flex-wrap line whose
+ * resting members (subtitle · ledger chip · recency · Sync · ⋯ · +) share one
+ * ~40px row — on the dashboard it is passed into `PipelineBoard`'s command
+ * row beside search, and on the error/empty pages it stands alone as the same
+ * one line. The page TITLE is gone from here on purpose: the shell's top bar
+ * carries the route name now, and every line this header used to spend is a
+ * line the worklist gets back. The transient members (the status line, the
+ * alert, the receipt) are `basis-full`, so they only take a wrap-line of
+ * their own while they actually have something to say.
  *
  * It replaces three things that used to speak over each other:
  *   - `ReSyncButton` — a prominent button labelled "Re-sync" that silently ran
@@ -159,12 +169,18 @@ export function RebuildWindowButton() {
 export function SyncBar({
   subtitle,
   gmail,
+  since,
   children,
   transport = liveSyncTransport,
 }: {
-  /** The page's one honest line of state — `214 filed · 32 in motion · 1 offer`. */
+  /** The page's one honest line of state — `214 filed · 32 open · 1 offer`. */
   subtitle: string;
   gmail: SyncGmailState | null;
+  /** The change-ledger chip (`SinceLastLook`) — one line by that component's
+   *  own contract, mounted right after the subtitle so state and news read as
+   *  one sentence. A slot rather than an import: the ledger's rows/scope are
+   *  the caller's business, and the error/empty pages pass nothing. */
+  since?: ReactNode;
   /** The compact `+` (AddApplicationForm) — stays rightmost in the cluster. */
   children?: ReactNode;
   /** How sync requests reach data — Gmail via the proxy by default; the demo
@@ -180,7 +196,10 @@ export function SyncBar({
   /** Ticks while a sync/rebuild runs so the elapsed clock stays honest. */
   const [nowMs, setNowMs] = useState(() => Date.now());
   const autoRan = useRef(false);
-  const lastRebuild = useRef<{ depth: RebuildDepth; range: RebuildRange } | null>(null);
+  const lastRebuild = useRef<{
+    depth: RebuildDepth;
+    range: RebuildRange;
+  } | null>(null);
 
   const connected = gmail?.connected === true;
   const hasCursor = gmail?.hasCursor === true;
@@ -198,7 +217,11 @@ export function SyncBar({
     // rescan this surface exists to remove.
     const res = await transport.sync({ mode: "additive" });
     if (!res.ok) {
-      setPhase({ kind: "failed", op: "sync", notConnected: res.status === 409 });
+      setPhase({
+        kind: "failed",
+        op: "sync",
+        notConnected: res.status === 409,
+      });
       return;
     }
     const data = res.body as Partial<SyncCounts>;
@@ -237,10 +260,18 @@ export function SyncBar({
     async (d: RebuildDepth, r: RebuildRange) => {
       lastRebuild.current = { depth: d, range: r };
       const startedAt = Date.now();
-      setPhase({ kind: "rebuilding", startedAt, scopeLine: rebuildScopeLine(d, r) });
+      setPhase({
+        kind: "rebuilding",
+        startedAt,
+        scopeLine: rebuildScopeLine(d, r),
+      });
       const res = await transport.sync(rebuildRequestBody(d, r));
       if (!res.ok) {
-        setPhase({ kind: "failed", op: "rebuild", notConnected: res.status === 409 });
+        setPhase({
+          kind: "failed",
+          op: "rebuild",
+          notConnected: res.status === 409,
+        });
         return;
       }
       const outcome = readRebuildOutcome(res.body);
@@ -301,7 +332,9 @@ export function SyncBar({
         ...p,
         outcome: {
           ...p.outcome,
-          removed: p.outcome.removed.map((row) => (row.id === id ? { ...row, restored: true } : row)),
+          removed: p.outcome.removed.map((row) =>
+            row.id === id ? { ...row, restored: true } : row,
+          ),
         },
       };
     });
@@ -405,7 +438,10 @@ export function SyncBar({
     alertContent = phase.notConnected ? (
       <>
         Gmail is not connected · nothing was changed{" "}
-        <Link href="/settings" className="text-muted underline-offset-2 hover:text-strong hover:underline">
+        <Link
+          href="/settings"
+          className="text-muted underline-offset-2 hover:text-strong hover:underline"
+        >
           connect in settings →
         </Link>
       </>
@@ -442,93 +478,101 @@ export function SyncBar({
   return (
     // `data-sync-surface` scopes assertions (e.g. "no percentage anywhere in
     // the sync UI") to this surface without leaning on copy or classes.
-    <div className="space-y-2" data-sync-surface="">
+    //
+    // `flex-1 min-w-0` matter only inside the board's command row, where this
+    // whole surface is one flex item sharing the line with search; standalone
+    // (error/empty pages) the root is an ordinary block and they are inert.
+    <div
+      className="flex w-full flex-wrap items-center gap-x-3 gap-y-2 sm:w-auto sm:min-w-0 sm:flex-1"
+      data-sync-surface=""
+    >
+      <p className="tabular shrink-0 text-[13px] text-muted">{subtitle}</p>
+      {/* The ledger chip takes the slack between state and controls — its own
+          fixed flex-basis, so hydration can never re-wrap the row (the board
+          below must not move when the ledger finds its words). */}
+      {since ? <div className="min-w-0 flex-1 basis-40">{since}</div> : null}
       {/* Below `sm` the action cluster takes its own full-width line under the
-          title, anchored LEFT — flex-wrap + justify-end orphaned "File an
+          state, anchored LEFT — flex-wrap + justify-end orphaned "File an
           application" on its own right-aligned line with a dead gap beside it.
-          The recency sentence drops to a quiet line of its own down there
+          The recency phrase drops to a quiet line of its own down there
           (`order-last`), so the controls read as one bar. */}
-      <header className="flex flex-wrap items-end justify-between gap-3">
-        {/* Title and subtitle share one baseline: stacked they cost a second
-            line of the pane for numbers that read fine beside the name. On a
-            narrow viewport the row wraps and the stack comes back for free. */}
-        <div className="flex min-w-0 flex-wrap items-baseline gap-x-3">
-          <h1 className="text-2xl font-semibold tracking-tight text-strong">Pipeline</h1>
-          <p className="tabular text-[13px] text-muted">{subtitle}</p>
-        </div>
-        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
-          {connected ? (
-            <>
-              {showRecency ? (
-                simulated ? (
-                  <span className="order-last w-full text-xs text-dim sm:order-none sm:w-auto">
-                    simulated account · nothing is read
-                  </span>
-                ) : (
-                  // A sentence, so the product voice — the machine-readable
-                  // instant already rides in the <time> element's dateTime and
-                  // title. Mono here was the "last synced …" defect the
-                  // type-system note in globals.css names.
-                  <LastSynced
-                    at={gmail?.lastSyncAt ?? null}
-                    className="order-last w-full text-xs text-dim sm:order-none sm:w-auto"
-                  />
-                )
-              ) : null}
-              <button
-                type="button"
-                onClick={() => void runSync()}
-                disabled={busy}
-                aria-label="Sync new mail from Gmail"
-                title="Checks Gmail for new mail and adds what it finds. Never removes anything."
-                className="inline-flex items-center gap-1.5 rounded-lg border border-line px-3 py-2 text-sm text-foreground transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <RefreshCw className="h-4 w-4" aria-hidden />
-                Sync
-              </button>
-              <RowActionsMenu
-                label="Sync options"
-                disabled={busy}
-                triggerClassName="grid h-9 w-9 place-items-center rounded-lg border border-line text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50"
-                triggerContent={<MoreHorizontal className="h-4 w-4" aria-hidden />}
-                items={[
-                  {
-                    key: "rebuild",
-                    label: "Rebuild from Gmail…",
-                    hint: "replaces Gmail-filed rows · lists every removal",
-                    onSelect: openDialog,
-                  },
-                  {
-                    key: "inbox",
-                    label: "Open inbox workbench",
-                    hint: "mine, inspect and file mail by hand",
-                    onSelect: () => router.push("/inbox"),
-                  },
-                ]}
-              />
-            </>
-          ) : gmail !== null ? (
-            // S0 — known not-connected. An unknown status (failed probe)
-            // renders nothing rather than a guessed state.
-            <Link
-              href="/settings"
-              className="text-xs text-dim underline-offset-2 hover:text-strong hover:underline"
+      <div className="flex w-full flex-wrap items-center gap-2 sm:ml-auto sm:w-auto sm:justify-end">
+        {connected ? (
+          <>
+            {showRecency ? (
+              simulated ? (
+                <span className="order-last w-full text-xs text-dim sm:order-none sm:w-auto">
+                  simulated account · nothing is read
+                </span>
+              ) : (
+                // A phrase, so the product voice — the machine-readable
+                // instant already rides in the <time> element's dateTime and
+                // title. Compact ("synced 3 minutes ago"): the Sync button
+                // beside it carries the noun, and on the shared command row
+                // every word here is width the ledger's news needs.
+                <LastSynced
+                  at={gmail?.lastSyncAt ?? null}
+                  compact
+                  className="order-last w-full text-xs text-dim sm:order-none sm:w-auto"
+                />
+              )
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void runSync()}
+              disabled={busy}
+              aria-label="Sync new mail from Gmail"
+              title="Checks Gmail for new mail and adds what it finds. Never removes anything."
+              className="inline-flex items-center gap-1.5 rounded-lg border border-line px-3 py-2 text-sm text-foreground transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50"
             >
-              gmail not connected · connect in settings →
-            </Link>
-          ) : null}
-          {children}
-        </div>
-      </header>
+              <RefreshCw className="h-4 w-4" aria-hidden />
+              Sync
+            </button>
+            <RowActionsMenu
+              label="Sync options"
+              disabled={busy}
+              triggerClassName="grid h-9 w-9 place-items-center rounded-lg border border-line text-muted transition-colors hover:border-line-strong hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50"
+              triggerContent={<MoreHorizontal className="h-4 w-4" aria-hidden />}
+              items={[
+                {
+                  key: "rebuild",
+                  label: "Rebuild from Gmail…",
+                  hint: "replaces Gmail-filed rows · lists every removal",
+                  onSelect: openDialog,
+                },
+                {
+                  key: "inbox",
+                  label: "Open inbox workbench",
+                  hint: "mine, inspect and file mail by hand",
+                  onSelect: () => router.push("/inbox"),
+                },
+              ]}
+            />
+          </>
+        ) : gmail !== null ? (
+          // S0 — known not-connected. An unknown status (failed probe)
+          // renders nothing rather than a guessed state.
+          <Link
+            href="/settings"
+            className="text-xs text-dim underline-offset-2 hover:text-strong hover:underline"
+          >
+            gmail not connected · connect in settings →
+          </Link>
+        ) : null}
+        {children}
+      </div>
 
-      {/* Persistent live regions — visually empty when idle. The inner span is
-          keyed by the machine's state so each transition (idle → syncing →
-          synced…) slides its sentence in — the state CHANGE is visible, not
-          just the state. Reduced motion renders each state statically. */}
+      {/* Persistent live regions — visually empty when idle (sr-only takes
+          them out of flow, so the resting row is exactly one line). When one
+          speaks, `basis-full` gives it a wrap-line of its own under the row.
+          The inner span is keyed by the machine's state so each transition
+          (idle → syncing → synced…) slides its sentence in — the state CHANGE
+          is visible, not just the state. Reduced motion renders each state
+          statically. */}
       <p
         role="status"
         aria-live="polite"
-        className={`text-xs text-muted ${statusContent === null ? "sr-only" : ""}`}
+        className={`text-xs text-muted ${statusContent === null ? "sr-only" : "basis-full"}`}
       >
         <motion.span
           key={phase.kind}
@@ -542,26 +586,28 @@ export function SyncBar({
       </p>
       <p
         role="alert"
-        className={`text-xs text-reject-ink ${alertContent === null ? "sr-only" : ""}`}
+        className={`text-xs text-reject-ink ${alertContent === null ? "sr-only" : "basis-full"}`}
       >
         {alertContent}
       </p>
 
       {phase.kind === "receipt" ? (
-        <RebuildReceipt
-          op={phase.op}
-          outcome={phase.outcome}
-          transport={transport}
-          onDismiss={() => setPhase({ kind: "idle" })}
-          onRestored={restoreSucceeded}
-          onContinue={() => {
-            if (phase.op === "sync") {
-              void runSync();
-            } else if (lastRebuild.current) {
-              void runRebuild(lastRebuild.current.depth, lastRebuild.current.range);
-            }
-          }}
-        />
+        <div className="basis-full">
+          <RebuildReceipt
+            op={phase.op}
+            outcome={phase.outcome}
+            transport={transport}
+            onDismiss={() => setPhase({ kind: "idle" })}
+            onRestored={restoreSucceeded}
+            onContinue={() => {
+              if (phase.op === "sync") {
+                void runSync();
+              } else if (lastRebuild.current) {
+                void runRebuild(lastRebuild.current.depth, lastRebuild.current.range);
+              }
+            }}
+          />
+        </div>
       ) : null}
 
       <Dialog

--- a/apps/web/components/demo/DemoDashboard.tsx
+++ b/apps/web/components/demo/DemoDashboard.tsx
@@ -106,8 +106,8 @@ export function DemoDashboard({
    *  `locked` — the /demo/shell twin: the signed-in dashboard's exact
    *  geometry (`LOCKED_PAGE_CLASS` root, `variant="locked"` board), which is
    *  what makes the viewport-lock e2e assertions executable without a
-   *  session. Both mount the pulse where the real page does: in the board's
-   *  stage spine. */
+   *  session. Both mount the pulse where the real page does: the board's
+   *  full-width band. */
   variant?: "flow" | "locked";
 }) {
   const locked = variant === "locked";
@@ -165,7 +165,11 @@ export function DemoDashboard({
       const s = store.current;
       original.current = [...pristine.apps, ...pristine.pool];
       setDatedFor(today);
-      commit({ ...s, apps: redate(s.apps, dated), pool: redate(s.pool, dated) });
+      commit({
+        ...s,
+        apps: redate(s.apps, dated),
+        pool: redate(s.pool, dated),
+      });
     }, 0);
     return () => window.clearTimeout(id);
   }, [today, datedFor, pipeline, commit]);
@@ -181,7 +185,10 @@ export function DemoDashboard({
         // only ever offer canonical statuses, so this never fires from the
         // UI; it fires if one of them ever drifts, which is the point.
         if (!isApplicationStatus(status)) {
-          return { ok: false, detail: `“${status}” is not a status the API accepts` };
+          return {
+            ok: false,
+            detail: `“${status}” is not a status the API accepts`,
+          };
         }
         const s = store.current;
         // The visitor moved this card themselves — fold it into the change
@@ -205,7 +212,11 @@ export function DemoDashboard({
               ? // The live backend's exact semantics: any write through the
                 // deadline endpoint is the user's word (`due_source: "user"`),
                 // and null clears both fields together.
-                { ...app, due_at: dueAt, due_source: dueAt === null ? null : ("user" as const) }
+                {
+                  ...app,
+                  due_at: dueAt,
+                  due_source: dueAt === null ? null : ("user" as const),
+                }
               : app,
           ),
           // A hand-set deadline is a correction — a rebuild keeps the row.
@@ -253,10 +264,7 @@ export function DemoDashboard({
             (app) => app.company === STALE_COMPANY && !s.touched.includes(app.id),
           );
           const removed = stale ? [{ id: stale.id, company: stale.company }] : [];
-          const nextApps = [
-            ...filed,
-            ...s.apps.filter((app) => app.id !== stale?.id),
-          ];
+          const nextApps = [...filed, ...s.apps.filter((app) => app.id !== stale?.id)];
           commit({ ...s, apps: nextApps, pool: [] });
           const changed = filed.length > 0 || removed.length > 0;
           // A shallow scan that still had work to do stops at its message
@@ -331,39 +339,50 @@ export function DemoDashboard({
    *  passed below: on this twin the store IS the whole account, so there is no
    *  slice to disclose. */
   const ledgerRows = useMemo(() => snapshot.apps.map(toChangeRow), [snapshot.apps]);
-  const subtitle = `${summary.total} filed · ${summary.inMotion} in motion · ${summary.offers} offer${
+  const subtitle = `${summary.total} filed · ${summary.inMotion} open · ${summary.offers} offer${
     summary.offers === 1 ? "" : "s"
   }`;
 
   return (
     <section className={locked ? LOCKED_PAGE_CLASS : "flex flex-col gap-6"}>
-      <SyncBar subtitle={subtitle} gmail={DEMO_GMAIL} transport={syncTransport}>
-        <AddApplicationForm mode="demo" />
-      </SyncBar>
-      {/* The real change ledger, over the fixture store and under its own
-          marker key — a signed-in owner who visits /demo never has these rows
-          folded into their own board's record. */}
-      <SinceLastLook
-        rows={ledgerRows}
-        scope={LAST_LOOK_DEMO_SCOPE}
-        storageKey={LAST_LOOK_DEMO_KEY}
-      />
-      {/* The pulse rides the board's stage spine here exactly as it does on
-          the signed-in dashboard — one home, both variants, so the twin stays
-          honest evidence for the real page's geometry. `needsReview` is 0
-          deliberately, not a stub: /demo mounts no review queue for a held
-          verdict to point at, and the signal's non-zero branch deep-links to
+      {/* Exactly the signed-in composition: the sync surface — with the real
+          change ledger as its chip, over the fixture store and under its own
+          marker key, so a signed-in owner who visits /demo never has these
+          rows folded into their own board's record — rides the board's
+          command row. One shared shape, which is what keeps this twin honest
+          evidence for the real page.
+
+          The pulse is the board's full-width band here exactly as it is on
+          the signed-in dashboard. `needsReview` is 0 deliberately, not a
+          stub: /demo mounts no review queue for a held verdict to point at,
+          and the signal's non-zero branch deep-links to
           /dashboard#needs-classification — an auth-gated route that would
           dead-end an anonymous visitor. The fixture queue (DEMO_REVIEW_QUEUE)
           does hold one sub-gate message; the DecisionTrace lower down /demo
-          is where it is shown and explained. Below `lg` the spine collapses
-          and the pulse goes with it — the phone answer the old full-width
-          strip needed a `max-sm:order-last` workaround to approximate. */}
+          is where it is shown and explained. Below `lg` the band yields to
+          the cards' own tags — the phone answer the old full-width strip
+          needed a `max-sm:order-last` workaround to approximate. */}
       <PipelineBoard
         variant={locked ? "locked" : "flow"}
         applications={snapshot.apps}
         pulse={{ needsReview: 0 }}
         transport={boardTransport}
+        toolbar={
+          <SyncBar
+            subtitle={subtitle}
+            gmail={DEMO_GMAIL}
+            transport={syncTransport}
+            since={
+              <SinceLastLook
+                rows={ledgerRows}
+                scope={LAST_LOOK_DEMO_SCOPE}
+                storageKey={LAST_LOOK_DEMO_KEY}
+              />
+            }
+          >
+            <AddApplicationForm mode="demo" compact />
+          </SyncBar>
+        }
       />
     </section>
   );

--- a/apps/web/components/gmail/LastSynced.tsx
+++ b/apps/web/components/gmail/LastSynced.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import {
   NOT_SYNCED_YET,
   absoluteInstant,
+  compactSyncLabel,
   relativeSyncLabel,
 } from "@/lib/gmail/sync-state";
 
@@ -26,16 +27,26 @@ import {
  * shell, and a long-open tab that still reads "just now" an hour later is the
  * same lie the product told before it had any sync memory at all.
  */
-export function LastSynced({ at, className }: { at: string | null; className?: string }) {
+export function LastSynced({
+  at,
+  className,
+  compact = false,
+}: {
+  at: string | null;
+  className?: string;
+  /** "synced 3 minutes ago" instead of the full sentence — for rows where a
+   *  Sync control sits beside it and already names the operation. */
+  compact?: boolean;
+}) {
   /** `null` until mounted — the server has no honest `now` to compute from. */
   const [label, setLabel] = useState<string | null>(null);
 
   useEffect(() => {
-    const tick = () => setLabel(relativeSyncLabel(at, Date.now()));
+    const tick = () => setLabel((compact ? compactSyncLabel : relativeSyncLabel)(at, Date.now()));
     tick();
     const id = window.setInterval(tick, 60_000);
     return () => window.clearInterval(id);
-  }, [at]);
+  }, [at, compact]);
 
   if (!at) {
     return <span className={className}>{NOT_SYNCED_YET}</span>;

--- a/apps/web/components/shell/Sidebar.tsx
+++ b/apps/web/components/shell/Sidebar.tsx
@@ -31,8 +31,8 @@ import { RailFooter } from "./RailFooter";
  * "the dashboard still scrolls". And even the slim snapshot that survived a
  * first fix stated a total the same screen already stated twice (the page
  * subtitle, the spine's "all" row — the task #59 restatement family). The
- * pulse is dashboard content, so it lives with the board — under the stage
- * buttons in the spine's blank run (`PipelineBoard`'s `pulse` prop) — and
+ * pulse is dashboard content, so it lives with the board — its full-width
+ * band above the spine + worklist row (`PipelineBoard`'s `pulse` prop) — and
  * the chrome stays constant on every tab and can never scroll again: four
  * nav items cannot outgrow any viewport this app supports.
  *
@@ -58,7 +58,7 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
       <div className="px-4 py-4">
         <Link
           href="/dashboard"
-          aria-label="Applied — go to dashboard"
+          aria-label="Applied — go to your applications"
           className="brand-logo-link rounded-md text-strong focus-accent"
         >
           <Logo className="h-7 w-auto" />
@@ -103,7 +103,6 @@ export function Sidebar({ rail, userEmail }: SidebarProps) {
             })}
           </ul>
         </nav>
-
       </div>
 
       <div className="shrink-0 border-t border-line-soft px-3 py-3">

--- a/apps/web/components/shell/TopBar.tsx
+++ b/apps/web/components/shell/TopBar.tsx
@@ -28,6 +28,16 @@ export function TopBar({ userEmail, demo = false }: TopBarProps) {
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
+  // The route's own name, from the nav vocabulary — never hardcoded, because
+  // this one bar serves every authed route (and /demo/shell, whose path
+  // matches no nav item but which IS the board twin). The board route gets an
+  // <h1>: its page surrendered the in-page header row to the worklist, so the
+  // page heading lives here now. Every other route keeps its own <h1> below
+  // and this reads as the location label beside it.
+  const current =
+    navItems.find((item) => isNavItemActive(pathname, item.href)) ?? (demo ? navItems[0] : null);
+  const isBoardTitle = current?.href === "/dashboard";
+
   // The desktop sidebar is hidden below `md`, so this menu is the only way to
   // move between sections on a phone — never leave the user stranded. It closes
   // on Escape, on the backdrop, and whenever a destination link is tapped (each
@@ -75,15 +85,24 @@ export function TopBar({ userEmail, demo = false }: TopBarProps) {
         <span className="shrink-0 md:hidden">
           <Link
             href="/dashboard"
-            aria-label="Applied — go to dashboard"
+            aria-label="Applied — go to your applications"
             className="brand-logo-link text-strong"
           >
             <Logo variant="mark" className="h-7 w-7" />
           </Link>
         </span>
-        {/* Identity moved to the sidebar rail's bottom user chip on desktop —
-            keep the email here only below `md`, where the rail is hidden. */}
-        <div className="truncate text-sm text-muted md:hidden">{userEmail ?? ""}</div>
+        {/* The route title — this bar's one piece of content besides sign-out,
+            in a bar that measured 92% empty. Identity lives in the rail
+            footer (desktop) and the mobile menu (below `md`). */}
+        {current ? (
+          isBoardTitle ? (
+            <h1 className="truncate text-sm font-semibold tracking-tight text-strong">
+              {current.label}
+            </h1>
+          ) : (
+            <span className="truncate text-sm font-medium text-muted">{current.label}</span>
+          )
+        ) : null}
       </div>
 
       {demo ? (
@@ -95,12 +114,7 @@ export function TopBar({ userEmail, demo = false }: TopBarProps) {
           demo · fixture data
         </Link>
       ) : (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={handleSignOut}
-          disabled={isSigningOut}
-        >
+        <Button type="button" variant="ghost" onClick={handleSignOut} disabled={isSigningOut}>
           {isSigningOut ? "Signing out…" : "Sign out"}
         </Button>
       )}
@@ -121,6 +135,14 @@ export function TopBar({ userEmail, demo = false }: TopBarProps) {
             aria-label="Primary"
             className="absolute inset-x-0 top-12 z-50 border-b border-line-soft bg-surface px-2 py-2 shadow-[0_18px_50px_-20px_rgba(0,0,0,0.8)] md:hidden"
           >
+            {/* Identity lives here below `md` (the rail footer's job on
+                desktop) — it used to sit in the bar itself, where the route
+                title now goes. */}
+            {userEmail ? (
+              <p className="mb-2 truncate border-b border-line-soft px-3 pb-2 text-xs text-dim">
+                {userEmail}
+              </p>
+            ) : null}
             <ul className="space-y-1">
               {navItems.map((item) => {
                 const Icon = item.icon;

--- a/apps/web/components/shell/nav.ts
+++ b/apps/web/components/shell/nav.ts
@@ -8,7 +8,10 @@ import { LayoutDashboard, Inbox, Upload, Settings, type LucideIcon } from "lucid
 export type NavItem = { href: string; label: string; icon: LucideIcon };
 
 export const navItems: NavItem[] = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  // "Applications", because that is what the rows are and what a person says
+  // — "Dashboard" named the furniture, and "Pipeline" was a sales-CRM borrow.
+  // The ROUTE stays /dashboard: renames stop at presentation labels.
+  { href: "/dashboard", label: "Applications", icon: LayoutDashboard },
   { href: "/inbox", label: "Inbox", icon: Inbox },
   { href: "/import", label: "Import mail", icon: Upload },
   { href: "/settings", label: "Settings", icon: Settings },

--- a/apps/web/lib/gmail/sync-state.ts
+++ b/apps/web/lib/gmail/sync-state.ts
@@ -179,6 +179,16 @@ export function relativeSyncLabel(value: string | null | undefined, nowMs: numbe
   return relative === null ? NOT_SYNCED_YET : `last synced ${relative}`;
 }
 
+/**
+ * The same fact for tight rows — "synced 3 minutes ago". Used where the Sync
+ * button sits right beside it and already carries the noun; the full sentence
+ * stays the default everywhere else.
+ */
+export function compactSyncLabel(value: string | null | undefined, nowMs: number): string {
+  const relative = relativeSince(value, nowMs);
+  return relative === null ? NOT_SYNCED_YET : `synced ${relative}`;
+}
+
 function count(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
 }

--- a/apps/web/tests/e2e/dashboard.spec.ts
+++ b/apps/web/tests/e2e/dashboard.spec.ts
@@ -39,10 +39,10 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     const watch = startConsoleWatch(page);
     await page.goto("/demo");
 
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
-    // The one prose data line — 17 fixtures, 14 in motion (10 applied + 4
-    // interviewing), 0 offers. The page's only rendering of the totals.
-    await expect(page.getByText("17 filed · 14 in motion · 0 offers")).toBeVisible();
+    // The one prose data line — 17 fixtures, 14 open (10 applied + 4
+    // interviewing), 0 offers. The page's only rendering of the totals, and
+    // the twin's anchor now that the route title lives in the shell's bar.
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toBeVisible();
 
     // Populated stages render as list groups, carrying their counts…
     await expect(page.getByRole("region", { name: /applied — 10/i })).toBeVisible();
@@ -75,7 +75,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     page,
   }) => {
     await page.goto("/demo");
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toBeVisible();
 
     // Classifier internals belong to the landing/system card, never a board.
     await expect(page.getByText("auto-file gate", { exact: true })).toHaveCount(0);
@@ -158,7 +158,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     // worklist redesign exists for.
     await page.goto("/demo?pipeline=early");
 
-    await expect(page.getByText("17 filed · 17 in motion · 0 offers")).toBeVisible();
+    await expect(page.getByText("17 filed · 17 open · 0 offers")).toBeVisible();
     // One populated group — 17 APPLICATIONS, however few cards the employer
     // grouping draws (Northstar's four and Cedar's two fold into one card
     // each; the count must reflect the applications, not the cards)…
@@ -185,7 +185,7 @@ test.describe("dashboard content (via the public /demo twin)", () => {
     const watch = startConsoleWatch(page);
     await page.setViewportSize(MOBILE_375);
     await page.goto("/demo");
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toBeVisible();
     await expectNoHorizontalOverflow(page);
     expect(watch.errors, watch.errors.join("\n")).toEqual([]);
   });
@@ -197,7 +197,10 @@ test.describe("dashboard (signed in — needs a session)", () => {
     // Either populated (the worklist) or empty (the empty-state hero) — both
     // must offer the file-application entry point and never be a blank page.
     await expect(page.getByRole("button", { name: /file an application/i }).first()).toBeVisible();
-    await expect(page.getByRole("heading", { name: /pipeline/i })).toBeVisible();
+    // The route title in the shell's top bar is the page heading now.
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Applications", exact: true }),
+    ).toBeVisible();
   });
 
   test("the dashboard is viewport-locked at desktop: the page itself does not scroll", async ({

--- a/apps/web/tests/e2e/demo.spec.ts
+++ b/apps/web/tests/e2e/demo.spec.ts
@@ -115,7 +115,9 @@ test.describe("live demo (/demo)", () => {
     const watch = startConsoleWatch(page);
     await page.goto("/demo");
 
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
+    // The board twin has no in-page h1 anymore (the signed-in shell's top bar
+    // carries the route title); its one line of state is the anchor.
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toBeVisible();
     await expect(page.getByRole("heading", { name: /decision trace/i })).toBeVisible();
     // Pipeline columns render the fixture applications. (`exact` everywhere a
     // company is asserted visible: each interactive card also carries an
@@ -161,8 +163,9 @@ test.describe("live demo (/demo)", () => {
       .toBe(true);
 
     await expect(page.locator("body")).toHaveCSS("font-family", /atkinson/i);
-    // The page h1 and the board's structural column labels speak the product voice…
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toHaveCSS(
+    // The board's state line and its structural column labels speak the
+    // product voice…
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toHaveCSS(
       "font-family",
       /atkinson/i,
     );
@@ -189,7 +192,7 @@ test.describe("live demo (/demo)", () => {
     // …and the board actually gained the two filed fixture rows.
     await expect(page.getByRole("region", { name: /applied — 12/i })).toBeVisible();
     await expect(page.getByText("Twitch", { exact: true })).toBeVisible();
-    await expect(page.getByText("19 filed · 16 in motion · 0 offers")).toBeVisible();
+    await expect(page.getByText("19 filed · 16 open · 0 offers")).toBeVisible();
 
     // A second sync has nothing new, and the cursored zero case says exactly
     // that — never a claim about a window it did not check.
@@ -450,16 +453,19 @@ test.describe("live demo (/demo)", () => {
     await expect(fileOpener).toBeFocused();
   });
 
-  test("the pulse renders all four derived signals in the stage spine", async ({ page }) => {
+  test("the pulse renders all four derived signals in the board's band", async ({ page }) => {
     await page.goto("/demo");
-    // ONE copy, and it lives inside the board's "Stages" aside — the home the
-    // strip (a full-width band) and the shell rail (which it made scroll)
-    // both ceded to.
+    // ONE copy, and it is the board's full-width band — back in the
+    // dashboard's content area, where the owner keeps putting it. The stage
+    // spine (#136) and the shell rail (PR #122) are the closed homes.
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse).toHaveCount(1);
     await expect(
-      page.locator('aside[aria-label="Stages"]').getByTestId("pipeline-pulse"),
+      page.getByTestId("pipeline-board").getByTestId("pipeline-pulse"),
     ).toBeVisible();
+    await expect(
+      page.locator('aside[aria-label="Stages"]').getByTestId("pipeline-pulse"),
+    ).toHaveCount(0);
 
     // Momentum: exactly 8 week-bars plus the delta sentence derived from them.
     await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
@@ -471,14 +477,20 @@ test.describe("live demo (/demo)", () => {
     await expect(pulse.getByText(/[1-9]\d* quiet/)).toBeVisible();
 
     // Deadlines: the three fixture states, counted, and the most urgent row
-    // named. The counts derive from the same `dueInfo` that inks the cards.
+    // named on the cell's label line. The counts derive from the same
+    // `dueInfo` that inks the cards. (Name and phrase are separate spans —
+    // the name truncates before the phrase ever does — so they are asserted
+    // separately rather than as one string.)
     await expect(pulse.getByText(/1 overdue · 1 ≤2d · 1 later/)).toBeVisible();
-    await expect(pulse.getByText(/next · Tidewater Labs/)).toBeVisible();
+    await expect(pulse.getByText("next ·")).toBeVisible();
+    await expect(pulse.getByText("Tidewater Labs")).toBeVisible();
     await expect(pulse.getByText("overdue 2d", { exact: true })).toBeVisible();
 
-    // Classifier: every fixture row is source="gmail", and nothing is held.
-    await expect(pulse.getByText("17 of 17 auto-filed from mail")).toBeVisible();
-    await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
+    // Auto-filed: every fixture row is source="gmail", and nothing is held.
+    // (A user has a mailbox, not a classifier — the mechanism's real names,
+    // the gate included, live in Settings, which controls them.)
+    await expect(pulse.getByText(/17 of 17/)).toBeVisible();
+    await expect(pulse.getByText("nothing waiting on you")).toBeVisible();
 
     // The card-level ageing tag agrees with the pulse's threshold. `.last()`,
     // not `.first()`: the filed stamp renders a phone-width twin earlier in
@@ -488,12 +500,13 @@ test.describe("live demo (/demo)", () => {
 
   test("the pulse moves when Sync files fresh mail", async ({ page }) => {
     await page.goto("/demo");
-    await expect(page.getByText("17 of 17 auto-filed from mail")).toBeVisible();
+    const pulse = page.getByTestId("pipeline-pulse");
+    await expect(pulse.getByText(/17 of 17/)).toBeVisible();
     await page.getByRole("button", { name: "Sync new mail from Gmail" }).click();
-    // Two fixture rows arrive → the classifier fraction re-derives from the
+    // Two fixture rows arrive → the auto-filed fraction re-derives from the
     // new board. (No assertion on the ageing buckets here: the fixture dates
     // are static while real time passes, so any exact bucket count would rot.)
-    await expect(page.getByText("19 of 19 auto-filed from mail")).toBeVisible();
+    await expect(pulse.getByText(/19 of 19/)).toBeVisible();
   });
 
   test("the change ledger claims nothing on a first visit", async ({ page }) => {
@@ -589,8 +602,9 @@ test.describe("live demo (/demo)", () => {
     await page.goto("/demo");
     const band = ledger(page);
     // Wait for the LOUD state specifically — a quiet band would pass the
-    // geometry below while proving nothing about this case.
-    await expect(band.getByText("2 filed")).toBeVisible();
+    // geometry below while proving nothing about this case. "Mark as seen"
+    // exists only on the loud chip, at every chip width.
+    await expect(band.getByRole("button", { name: "Mark as seen" })).toBeVisible();
     const loudBox = await card(page).boundingBox();
     const bandBox = await band.boundingBox();
 
@@ -607,16 +621,17 @@ test.describe("live demo (/demo)", () => {
       `the loud band is ${bandBox?.height}px against a reserved ${reserveBox?.height}px`,
     ).toBeLessThanOrEqual(1);
 
-    // Positive control, measured the same way: naming the rows DOES move the
-    // board, so the assertions above can fail. A reader presses for that —
-    // it is the one movement on this band that is asked for.
+    // Naming the rows is an OVERLAY now, not a reflow: the panel floats over
+    // the board, so even the one movement this feature used to make on
+    // request is no movement at all. The names still appear — over the
+    // board, not instead of it.
     await band.getByRole("button", { name: /Name the rows/ }).click();
     await expect(band.getByText("Copperline", { exact: true })).toBeVisible();
     const openedBox = await card(page).boundingBox();
     expect(
-      (openedBox?.y ?? 0) - (loudBox?.y ?? 0),
-      "naming the rows must take space — without a real delta here the check above proves nothing",
-    ).toBeGreaterThan(40);
+      Math.abs((openedBox?.y ?? 0) - (loudBox?.y ?? 0)),
+      "the board moved when the names panel opened — the panel must float, not push",
+    ).toBeLessThanOrEqual(1);
     await page.close();
   });
 
@@ -626,18 +641,24 @@ test.describe("live demo (/demo)", () => {
     await seedPriorVisit(page);
     await page.goto("/demo");
     const band = ledger(page);
-    await expect(band.getByRole("heading", { name: "since you last looked" })).toBeVisible();
 
-    // The counts are the arrival line — one line, whatever the news is.
-    await expect(band.getByText("2 filed")).toBeVisible();
-    await expect(band.getByText("1 moved")).toBeVisible();
-    await expect(band.getByText("1 new deadline")).toBeVisible();
+    // The chip is the arrival line — the counts by kind when its share of the
+    // command row can say them, the total when it cannot (container-adaptive;
+    // this depends on the row-mates, not just the viewport, so accept either
+    // rendering here — the opened panel below is the width-independent claim).
+    await expect(band.getByRole("button", { name: "Mark as seen" })).toBeVisible();
+    await expect(band.getByText(/2 filed|4 changes/)).toBeVisible();
 
-    // Nobody is named until the reader asks: the band above the board holds
-    // one line, and the space the names need is spent on a press.
+    // Nobody is named until the reader asks: the chip holds its line, and
+    // the names appear on a press.
     await expect(band).not.toContainText("Copperline");
     await expect(band).not.toContainText("Northstar Systems");
     await band.getByRole("button", { name: /Name the rows/ }).click();
+
+    // The panel groups by kind — the two-level shape, one press deep.
+    await expect(band.getByText("filed", { exact: true })).toBeVisible();
+    await expect(band.getByText("moved", { exact: true })).toBeVisible();
+    await expect(band.getByText("new deadline", { exact: true })).toBeVisible();
 
     // …and then every claim names the row it is about, with the column to
     // look in.
@@ -931,8 +952,8 @@ test.describe("live demo (/demo)", () => {
     // component rendering nothing is the shape this estate keeps producing.
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
-    await expect(pulse.getByText("17 of 17 auto-filed from mail")).toBeVisible();
-    await expect(pulse.getByText("queue clear · gate 0.85")).toBeVisible();
+    await expect(pulse.getByText(/17 of 17/)).toBeVisible();
+    await expect(pulse.getByText("nothing waiting on you")).toBeVisible();
     // The change ledger carries no animation at all, so there is nothing for
     // this mode to collapse — its sentence is simply present.
     await expect(ledger(page)).toContainText("No earlier visit recorded in this browser");
@@ -1017,7 +1038,7 @@ test.describe("live demo (/demo)", () => {
     const watch = startConsoleWatch(page);
     await page.setViewportSize(MOBILE_375);
     await page.goto("/demo");
-    await expect(page.getByRole("heading", { name: "Pipeline" })).toBeVisible();
+    await expect(page.getByText("17 filed · 14 open · 0 offers")).toBeVisible();
     await expectNoHorizontalOverflow(page);
     expect(watch.errors, watch.errors.join("\n")).toEqual([]);
   });

--- a/apps/web/tests/e2e/shell.spec.ts
+++ b/apps/web/tests/e2e/shell.spec.ts
@@ -53,17 +53,19 @@ test.describe("app shell — viewport lock (via /demo/shell, executes without a 
     }));
 
   /**
-   * The dashboard's own H1 — `exact` and `level` on purpose. This shell tree
-   * once held a SECOND heading whose name contained "pipeline" (the retired
-   * rail snapshot's h2), and Playwright's default role-name matching is
-   * case-insensitive substring, so the loose form resolved to both — a
-   * strict-mode violation that poisoned every geometry test in this describe
-   * on its first CI run. The strict form stays: if a duplicate H1 ever
-   * appears, it should fail the one assertion that counts things, not every
-   * wait-for-load line.
+   * The dashboard's own H1 — "Applications", rendered by the shell's TOP BAR
+   * (the board page surrendered its in-page header row to the worklist, so
+   * the route title in the bar is the page heading now). `exact` and `level`
+   * on purpose: this shell tree once held a SECOND heading whose name
+   * contained the page word (the retired rail snapshot's h2), and
+   * Playwright's default role-name matching is case-insensitive substring, so
+   * the loose form resolved to both — a strict-mode violation that poisoned
+   * every geometry test in this describe on its first CI run. The strict form
+   * stays: if a duplicate H1 ever appears, it should fail the one assertion
+   * that counts things, not every wait-for-load line.
    */
   const pageHeading = (page: Page) =>
-    page.getByRole("heading", { level: 1, name: "Pipeline", exact: true });
+    page.getByRole("heading", { level: 1, name: "Applications", exact: true });
 
   for (const viewport of [
     { width: 1280, height: 800 },
@@ -149,35 +151,77 @@ test.describe("app shell — viewport lock (via /demo/shell, executes without a 
     });
   }
 
-  test("the pulse lives in the board's stage spine — exactly one copy in the tree", async ({
+  test("the pulse is the board's full-width band — exactly one copy in the tree", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/demo/shell");
     await expect(pageHeading(page)).toBeVisible();
 
-    // One rendered pulse, inside the "Stages" aside — under the stage list,
-    // where the owner pointed — and provably NOT in the shell rail (the
-    // PR #122 slot, which the measured sidebar overflow retired) nor as a
-    // display-none twin under the list (the pre-#122 duplicate).
+    // One rendered pulse, as a full-width band in the BOARD's own tree —
+    // the dashboard's content area, where the owner keeps putting it back.
+    // Both left-column homes are closed and provably empty of it: the stage
+    // spine (#136, rejected) and the shell rail (PR #122, retired for
+    // measured sidebar overflow). No display-none twin anywhere.
     const pulse = page.getByTestId("pipeline-pulse");
     await expect(pulse).toHaveCount(1);
     await expect(
-      page.locator('aside[aria-label="Stages"]').getByTestId("pipeline-pulse"),
+      page.getByTestId("pipeline-board").getByTestId("pipeline-pulse"),
     ).toBeVisible();
+    await expect(
+      page.locator('aside[aria-label="Stages"]').getByTestId("pipeline-pulse"),
+    ).toHaveCount(0);
     await expect(
       page.locator('aside:has(nav[aria-label="Primary"])').getByTestId("pipeline-pulse"),
     ).toHaveCount(0);
     await expect(pulse.getByTestId("pulse-week")).toHaveCount(8);
 
-    // Below lg the spine collapses into the chip strip and the pulse goes
-    // with it — a deliberate choice (the phone dashboard leads with the
-    // worklist; age/deadline tags on the cards carry the same ground truth),
-    // not a hidden duplicate.
+    // A BAND, not a column: it spans the board. A pulse that fits in a spine
+    // again would pass every locator above and still be the rejected layout.
+    const bandBox = await pulse.boundingBox();
+    const boardBox = await page.getByTestId("pipeline-board").boundingBox();
+    expect(bandBox?.width ?? 0).toBeGreaterThan((boardBox?.width ?? 1) * 0.9);
+
+    // Below lg the band yields — a deliberate choice (the phone dashboard
+    // leads with the worklist; age/deadline tags on the cards carry the same
+    // ground truth), not a hidden duplicate.
     await page.setViewportSize(MOBILE_375);
     await expect(pulse).toBeHidden();
     await expect(page.getByTestId("pipeline-pulse")).toHaveCount(1);
   });
+
+  /**
+   * The floor the band's return must never eat through: the worklist's own
+   * viewport share. The document-lock gate CANNOT catch this failure —
+   * `h-dvh overflow-hidden` plus the min-h-0 chain is structural, so chrome
+   * that overspends its budget doesn't scroll the page; it silently shrinks
+   * the one region the dashboard exists to show, with every geometry test
+   * green. The floors are measured on /demo/shell (recorded 2026-08-12,
+   * `next start`, headless Chrome): worklist-pane clientHeight 604 at
+   * 1280×800 and 524 at 1280×720. A small tolerance absorbs sub-pixel/font
+   * drift; a real regression (a fatter band, a second header row, a
+   * reinstated notice line) costs tens of pixels and lands far below it.
+   */
+  for (const { viewport, floor } of [
+    { viewport: { width: 1280, height: 800 }, floor: 600 },
+    { viewport: { width: 1280, height: 720 }, floor: 520 },
+  ]) {
+    test(`the worklist keeps its viewport share at ${viewport.width}×${viewport.height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto("/demo/shell");
+      await expect(pageHeading(page)).toBeVisible();
+
+      const client = await page
+        .getByTestId("worklist-pane")
+        .evaluate((el) => el.clientHeight);
+      expect(
+        client,
+        `the worklist pane shrank to ${client}px (floor ${floor}px) — some chrome above it is spending the list's pixels`,
+      ).toBeGreaterThanOrEqual(floor);
+    });
+  }
 
   test("light theme: still locked, still no horizontal overflow at 375", async ({ page }) => {
     // `jt-theme` is THEME_STORAGE_KEY (lib/theme.ts) — hardcoded here because
@@ -230,7 +274,7 @@ test.describe("app shell — signed out (public)", () => {
 
 test.describe("app shell — signed in (needs a session)", () => {
   for (const { path, label } of [
-    { path: "/dashboard", label: "Dashboard" },
+    { path: "/dashboard", label: "Applications" },
     { path: "/inbox", label: "Inbox" },
     { path: "/settings", label: "Settings" },
   ]) {
@@ -259,8 +303,10 @@ test.describe("app shell — signed in (needs a session)", () => {
 
     // The import tool itself is here...
     await expect(page.getByRole("heading", { name: "Import your mail" })).toBeVisible();
-    // ...and there is a way back into the rest of the app.
-    await page.getByRole("link", { name: "Dashboard" }).click();
+    // ...and there is a way back into the rest of the app. `exact`: the brand
+    // logo's own aria-label ("…go to your applications") substring-matches
+    // the loose form now that the nav item is named "Applications".
+    await page.getByRole("link", { name: "Applications", exact: true }).click();
     await expect(page).toHaveURL(/\/dashboard$/);
   });
 


### PR DESCRIPTION
## What this is

Fifth pass on the signed-in dashboard. The pulse returns to the dashboard's content area as a **full-width band** (the pre-#136 home, at band density instead of the old ~200px strip), and the chrome above the worklist collapses from three rows (page header, notice line, in-column search row) to **one command row**. The route title moves to the shell's top bar, which was measured 92% empty.

Both left-column homes for the pulse stay closed: the shell rail (#122, measured sidebar overflow) and the stage spine (#136, rejected).

## The gate that matters

`docScrollH == docClientH` can no longer fail — the `h-dvh` + `min-h-0` chain is structural, so overspent chrome silently shrinks the worklist instead of scrolling the page. The real gate is the worklist's own height, measured before/after on the same viewports:

| viewport | worklist clientHeight before (signed-in baseline) | after (/demo/shell, `next start`) |
|---|---|---|
| 1374×812 | 598 | **616** (+18) |
| 1309×693 | 480 | **497** (+17) |
| 1280×800 | — | 604 (new e2e floor 600) |
| 1280×720 | — | 524 (new e2e floor 520) |

Band renders at **55px**; command row at **38px**, one line at every measured desktop width. Document and `<main>` locked at all four viewports, zero rogue scrollers, no horizontal overflow at 375.

## Layout

- **PipelinePulse** — horizontal four-cell band: caps label + drawn element + one figure line per cell. Urgent deadline rides its cell's label line by name (name truncates, phrase never). Week axis stays cut; per-cell scope notes stay consolidated into one trailing line. `lg`-up only, one instance.
- **PipelineBoard** — band above the spine + worklist row; new full-width command row with a `toolbar` slot both twins fill with `SyncBar`, so `/demo` inherits the composition by construction and cannot drift. Spine narrowed w-52 → w-44.
- **SyncBar** — no h1; renders as row content (subtitle · ledger chip · compact recency · Sync · ⋯ · +); status/alert/receipt are `basis-full` and only cost a line while speaking. Phase machine, dialog, receipt and live regions untouched.
- **SinceLastLook** — the notice line becomes a chip on the command row (fixed flex-basis: hydration can never re-wrap the row) with container-adaptive counts; the names panel now **floats over the board** instead of pushing it — even the asked-for expansion no longer moves the work surface.
- **TopBar** — route title from `nav.ts` (h1 on the board route, location label elsewhere); identity moves into the mobile menu; sign-out stays in the bar.

## Vocabulary (presentation labels only)

Dashboard → **Applications** (nav, aria), Pipeline → **Applications** (page title), "in motion" → **"open"**, classifier cell → "auto-filed · from your mail" / "N held for your review →" / "nothing waiting on you"; error/empty copy follows ("your applications", "not an empty board", "nothing tracked yet"). Routes, identifiers, enum values, API strings untouched. Settings keeps the mechanism's real names.

## Known tradeoff, stated

Pulling the pulse out of the spine reopens the spine's blank run (~380px of empty column under "closed" at 1374×812 on the one-stage production shape). Narrowing to w-44 shrinks it; it is otherwise the same void the approved pre-#136 layout had. Filling it would mean either reinstating a rejected home or inventing restatement content — both worse than the void.

## Verification still needed (CI / labrat)

- `pnpm e2e` (Playwright): `shell.spec.ts` (rewritten pulse-home test + new worklist floors), `demo.spec.ts` (ledger chip/panel rewrites, pulse strings, subtitle strings), `dashboard.spec.ts` (anchors, "Applications" h1).
- `pnpm test:unit` (`node --test`) — expected untouched, `sync-state` gained one additive export.
- The signed-in browser pass on real data (email+password on localhost), especially the loud-ledger chip at 1309×693 and the error/empty states, which render `SyncBar` standalone and are unreachable without a session.
